### PR TITLE
feat: add geo-restriction middleware for sanctions compliance

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,3 +69,7 @@ AGENT_ESCROW_CONTRACT_ID=your_deployed_contract_id_here
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # Platform fee in basis points (250 = 2.5%)
 ESCROW_FEE_BPS=250
+
+# Geo-restriction — comma-separated ISO 3166-1 alpha-2 country codes
+# Requests from these countries receive HTTP 451 (Unavailable For Legal Reasons)
+BLOCKED_COUNTRIES=KP,IR,CU,RU,SY

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
         "express-validator": "^7.0.1",
+        "geoip-lite": "^2.0.1",
         "helmet": "^8.0.0",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.2",
@@ -32,7 +33,77 @@
       "devDependencies": {
         "jest": "^30.3.0",
         "nodemon": "^3.0.2",
-        "supertest": "^7.2.2"
+        "supertest": "^7.2.2",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -66,7 +137,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1077,6 +1147,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1136,6 +1213,14 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -1294,6 +1379,13 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -2043,7 +2135,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2090,6 +2181,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2161,6 +2261,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2205,7 +2312,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2458,6 +2564,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/component-emitter": {
@@ -2746,6 +2862,19 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -2930,6 +3059,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3012,7 +3151,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3306,6 +3444,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geoip-lite": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-2.0.1.tgz",
+      "integrity": "sha512-cR9E28nu1a6dsvzB1tANhdmCyXWV1L4AiSCT9alHLIUl06599EGu33mqY99ieU0twQob0kfcDQ/sAUBvHb7swA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "yauzl": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3433,7 +3587,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3669,6 +3822,26 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4540,6 +4713,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4640,6 +4819,15 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
     },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4681,6 +4869,14 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4697,6 +4893,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -4721,6 +4925,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -5338,6 +5549,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5482,12 +5701,17 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6687,13 +6911,118 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {
@@ -7296,6 +7625,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -7364,6 +7703,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7375,6 +7727,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
     "express-validator": "^7.0.1",
+    "geoip-lite": "^2.0.1",
     "helmet": "^8.0.0",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",

--- a/backend/src/__tests__/geoRestriction.test.js
+++ b/backend/src/__tests__/geoRestriction.test.js
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for the geoRestriction middleware.
+ *
+ * geoip-lite is mocked so that tests are deterministic and don't rely on
+ * real MaxMind data.  We verify:
+ *   - Allowed countries pass through to next().
+ *   - Blocked countries receive HTTP 451 with the correct error body.
+ *   - Unknown / unresolvable IPs pass through (fail-open).
+ *   - Blocked attempts are logged via Winston.
+ */
+
+// Set env BEFORE any module loads so the middleware caches the correct list.
+process.env.BLOCKED_COUNTRIES = 'KP,IR,CU,RU,SY';
+
+jest.mock('geoip-lite', () => ({
+  lookup: jest.fn(),
+}));
+
+jest.mock('../utils/logger', () => ({
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const geoip = require('geoip-lite');
+const logger = require('../utils/logger');
+
+// Now require the middleware — it will read the env var we set above.
+let geoRestriction;
+beforeAll(() => {
+  // Clear any previous cached version and re-require.
+  delete require.cache[require.resolve('../middleware/geoRestriction')];
+  geoRestriction = require('../middleware/geoRestriction');
+});
+
+// ---------- helpers ----------
+function makeReq(overrides = {}) {
+  return {
+    ip: '1.2.3.4',
+    headers: {},
+    requestId: 'test-request-id',
+    method: 'POST',
+    originalUrl: '/api/auth/register',
+    ...overrides,
+  };
+}
+
+function makeRes() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+      return this;
+    },
+  };
+  return res;
+}
+
+// ---------- tests ----------
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('geoRestriction middleware', () => {
+  test('allows request from a non-blocked country', () => {
+    geoip.lookup.mockReturnValue({ country: 'US' });
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('blocks request from a sanctioned country (IR) with 451', () => {
+    geoip.lookup.mockReturnValue({ country: 'IR' });
+
+    const req = makeReq({ ip: '5.6.7.8' });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+    expect(res.body).toEqual({
+      error: 'Service unavailable in your jurisdiction',
+    });
+  });
+
+  test('blocks request from North Korea (KP)', () => {
+    geoip.lookup.mockReturnValue({ country: 'KP' });
+
+    const req = makeReq({ ip: '175.45.176.1' });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+  });
+
+  test('logs blocked attempts with audit-relevant details', () => {
+    geoip.lookup.mockReturnValue({ country: 'SY' });
+
+    const req = makeReq({
+      ip: '10.0.0.1',
+      requestId: 'audit-req-123',
+      method: 'POST',
+      originalUrl: '/api/auth/login',
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Blocked request from sanctioned country',
+      expect.objectContaining({
+        requestId: 'audit-req-123',
+        ip: '10.0.0.1',
+        country: 'SY',
+        method: 'POST',
+        path: '/api/auth/login',
+      })
+    );
+  });
+
+  test('allows request when geoip lookup returns null (unknown IP)', () => {
+    geoip.lookup.mockReturnValue(null);
+
+    const req = makeReq({ ip: '127.0.0.1' });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('allows request when IP cannot be determined', () => {
+    geoip.lookup.mockReturnValue(null);
+
+    const req = makeReq({ ip: undefined, headers: {} });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('reads IP from x-forwarded-for when req.ip is missing', () => {
+    geoip.lookup.mockReturnValue({ country: 'CU' });
+
+    const req = makeReq({
+      ip: undefined,
+      headers: { 'x-forwarded-for': '9.8.7.6, 10.0.0.1' },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    // The middleware should use the first IP in x-forwarded-for
+    expect(geoip.lookup).toHaveBeenCalledWith('9.8.7.6');
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+  });
+
+  test('country code comparison is case-insensitive', () => {
+    geoip.lookup.mockReturnValue({ country: 'ru' }); // lowercase from geoip
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+  });
+
+  test('allows request from an African country (NG)', () => {
+    geoip.lookup.mockReturnValue({ country: 'NG' });
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/backend/src/middleware/geoRestriction.js
+++ b/backend/src/middleware/geoRestriction.js
@@ -1,0 +1,54 @@
+const geoip = require('geoip-lite');
+const logger = require('../utils/logger');
+
+/**
+ * Geo-restriction middleware for OFAC / UN sanctions compliance.
+ *
+ * Reads the comma-separated BLOCKED_COUNTRIES env var (ISO 3166-1 alpha-2),
+ * resolves the caller's IP via geoip-lite, and returns HTTP 451 when the
+ * request originates from a sanctioned jurisdiction.
+ *
+ * Every blocked attempt is logged at WARN level for compliance audit.
+ */
+
+// Parse blocked countries once at startup for O(1) lookups.
+const blockedCountries = new Set(
+  (process.env.BLOCKED_COUNTRIES || '')
+    .split(',')
+    .map((c) => c.trim().toUpperCase())
+    .filter(Boolean)
+);
+
+module.exports = function geoRestriction(req, res, next) {
+  // Determine the client IP.
+  // When behind a reverse proxy with trust-proxy enabled, req.ip already
+  // contains the real client address. Fall back to x-forwarded-for header.
+  const forwarded = req.headers['x-forwarded-for'];
+  const ip =
+    req.ip ||
+    (typeof forwarded === 'string' ? forwarded.split(',')[0].trim() : undefined);
+
+  if (!ip) {
+    // Cannot determine IP – let the request through (fail-open).
+    return next();
+  }
+
+  const geo = geoip.lookup(ip);
+  const country = geo && geo.country ? geo.country.toUpperCase() : null;
+
+  if (country && blockedCountries.has(country)) {
+    logger.warn('Blocked request from sanctioned country', {
+      requestId: req.requestId,
+      ip,
+      country,
+      method: req.method,
+      path: req.originalUrl,
+    });
+
+    return res.status(451).json({
+      error: 'Service unavailable in your jurisdiction',
+    });
+  }
+
+  next();
+};

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -18,6 +18,7 @@ const {
   resetPassword,
 } = require('../controllers/authController');
 const authMiddleware = require('../middleware/auth');
+const geoRestriction = require('../middleware/geoRestriction');
 
 const validate = (req, res, next) => {
   const errors = validationResult(req);
@@ -27,6 +28,7 @@ const validate = (req, res, next) => {
 
 router.post(
   '/register',
+  geoRestriction,
   [
     body('full_name').trim().notEmpty().withMessage('Full name is required'),
     body('email').isEmail().normalizeEmail(),
@@ -38,6 +40,7 @@ router.post(
 
 router.post(
   '/login',
+  geoRestriction,
   [body('email').isEmail().normalizeEmail(), body('password').notEmpty()],
   validate,
   login


### PR DESCRIPTION
PR #108 Add Geo-Restriction Middleware for Sanctioned Countries

## Summary

This PR implements IP-based geo-restriction middleware to block requests from OFAC/UN-sanctioned countries on the AfriPay cross-border payment platform. Registration and login from blocked jurisdictions are rejected with **HTTP 451 (Unavailable For Legal Reasons)**, and every blocked attempt is persisted in the audit log via Winston.

---

## Motivation

Cross-border payment platforms are legally required to comply with OFAC and UN sanctions programmes. Without this guard, AfriPay accepts traffic from sanctioned jurisdictions, exposing the platform to significant regulatory and legal risk.

---

## Changes

### New Files
| File | Purpose |
|------|---------|
| `backend/src/middleware/geoRestriction.js` | Core geo-restriction middleware |
| `backend/src/__tests__/geoRestriction.test.js` | 9 unit tests for the middleware |

### Modified Files
| File | Change |
|------|--------|
| `backend/src/routes/auth.js` | Apply `geoRestriction` to `POST /register` and `POST /login` |
| `backend/.env.example` | Add `BLOCKED_COUNTRIES` env var with example list |
| `backend/package.json` | Add `geoip-lite` dependency |
| `backend/package-lock.json` | Updated lockfile |

---

## How It Works

```
Incoming Request
      │
      ▼
 geoRestriction middleware
      │
      ├─ Extract IP from req.ip (or x-forwarded-for fallback)
      │
      ├─ Lookup country via geoip-lite
      │
      ├─ Country in BLOCKED_COUNTRIES?
      │       ├─ YES → log warn (requestId, ip, country, method, path)
      │       │         → return 451 { error: "Service unavailable in your jurisdiction" }
      │       │
      │       └─ NO / IP unknown → next()
```

### Configuration
Set blocked country codes (ISO 3166-1 alpha-2) in the environment:

```env
# Comma-separated list — edit to match your compliance requirements
BLOCKED_COUNTRIES=KP,IR,CU,RU,SY
```

The `Set` is built once at startup for O(1) per-request lookups. Updating the list requires a server restart.

### Audit Log Format (Winston `warn`)
```json
{
  "level": "warn",
  "message": "Blocked request from sanctioned country",
  "requestId": "3e4a1c2d-...",
  "ip": "5.6.7.8",
  "country": "IR",
  "method": "POST",
  "path": "/api/auth/register",
  "timestamp": "2026-04-23T09:15:00.000Z"
}
```

---

## Test Coverage

```
PASS src/__tests__/geoRestriction.test.js
  geoRestriction middleware
    ✓ allows request from a non-blocked country
    ✓ blocks request from a sanctioned country (IR) with 451
    ✓ blocks request from North Korea (KP)
    ✓ logs blocked attempts with audit-relevant details
    ✓ allows request when geoip lookup returns null (unknown IP)
    ✓ allows request when IP cannot be determined
    ✓ reads IP from x-forwarded-for when req.ip is missing
    ✓ country code comparison is case-insensitive
    ✓ allows request from an African country (NG)

Tests: 9 passed, 9 total
```

All pre-existing test failures in the suite are unrelated to this PR (duplicate import statements in `payments.js`, decimal formatting in `path-payment.test.js`).

---

## Requirements Checklist

- [x] Configurable blocked country codes via `BLOCKED_COUNTRIES` env var
- [x] GeoIP lookup using `geoip-lite` (IP-based, VPN detection out of scope)
- [x] HTTP 451 response on `/register` and `/login` for blocked jurisdictions
- [x] Compliance audit log on every blocked attempt
- [x] Fail-open when IP cannot be determined (does not break legitimate traffic)
- [x] `x-forwarded-for` support for reverse-proxy deployments
- [x] Unit tests covering block, allow, logging, and edge cases

---

## Notes for Reviewers

- **Proxy trust:** If the server runs behind a reverse proxy (e.g., nginx, AWS ALB), ensure `app.set('trust proxy', true)` is set in `app.js` so `req.ip` reflects the actual client address.
- **Blocked list:** The default list (`KP,IR,CU,RU,SY`) is a starting point based on common OFAC/UN targets. Legal/compliance should review and finalise the list before going to production.
- **VPN bypass:** Per issue scope, VPN detection is intentionally out of scope — IP-based check satisfies the baseline compliance requirement.

---

Closes #108 
