### PR TITLE
feat: Prometheus metrics endpoint for backend observability

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,3 +69,9 @@ AGENT_ESCROW_CONTRACT_ID=your_deployed_contract_id_here
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # Platform fee in basis points (250 = 2.5%)
 ESCROW_FEE_BPS=250
+
+# Prometheus metrics endpoint bearer token (leave unset to disable auth in dev)
+METRICS_TOKEN=change_me_to_a_strong_random_secret
+
+# Referral program: fee discount credit per successful referral in basis points (50 = 0.5%)
+REFERRAL_CREDIT_BPS=50

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "node-pg-migrate": "^7.0.0",
         "nodemailer": "^8.0.3",
         "pg": "^8.11.3",
+        "prom-client": "15.1.3",
         "qrcode": "^1.5.4",
         "speakeasy": "^2.0.0",
         "uuid": "^9.0.0",
@@ -32,7 +33,77 @@
       "devDependencies": {
         "jest": "^30.3.0",
         "nodemon": "^3.0.2",
-        "supertest": "^7.2.2"
+        "supertest": "^7.2.2",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -66,7 +137,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1077,6 +1147,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1101,6 +1178,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -1136,6 +1222,14 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -1294,6 +1388,13 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -1976,6 +2077,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -2043,7 +2150,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2160,6 +2266,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2460,6 +2573,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -2746,6 +2869,19 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -2930,6 +3066,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3012,7 +3158,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4681,6 +4826,14 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4697,6 +4850,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -4721,6 +4882,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -5338,6 +5506,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5487,7 +5663,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -5698,6 +5873,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/proxy-addr": {
@@ -6696,6 +6884,112 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -6710,6 +7004,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {
@@ -7296,6 +7599,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -7375,6 +7688,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "node-pg-migrate": "^7.0.0",
     "nodemailer": "^8.0.3",
     "pg": "^8.11.3",
+    "prom-client": "15.1.3",
     "qrcode": "^1.5.4",
     "speakeasy": "^2.0.0",
     "uuid": "^9.0.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,8 @@ const rateLimit = require('express-rate-limit');
 const cookieParser = require('cookie-parser');
 
 const requestId = require('./middleware/requestId');
+const metricsMiddleware = require('./middleware/metricsMiddleware');
+const { registry } = require('./utils/metrics');
 
 const authRoutes = require('./routes/auth');
 const walletRoutes = require('./routes/wallet');
@@ -35,6 +37,7 @@ const { runHealthChecks } = require('./services/health');
 const app = express();
 
 app.use(requestId);
+app.use(metricsMiddleware);
 app.use(cookieParser());
 app.use(helmet({
   contentSecurityPolicy: {
@@ -155,6 +158,18 @@ app.get('/health', async (req, res) => {
       network: process.env.STELLAR_NETWORK || 'testnet',
     });
   }
+});
+
+app.get('/metrics', async (req, res) => {
+  const token = process.env.METRICS_TOKEN;
+  if (token) {
+    const auth = req.headers.authorization || '';
+    if (auth !== `Bearer ${token}`) {
+      return res.status(401).end();
+    }
+  }
+  res.set('Content-Type', registry.contentType);
+  res.end(await registry.metrics());
 });
 
 app.use((err, req, res, next) => {

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,4 +1,5 @@
 const { Pool } = require('pg');
+const { dbQueryDuration } = require('./utils/metrics');
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
@@ -6,7 +7,16 @@ pool.on('error', (err) => {
   console.error('Unexpected DB error', err);
 });
 
-module.exports = {
-  query: (text, params) => pool.query(text, params),
-  pool
-};
+async function query(text, params) {
+  const end = dbQueryDuration.startTimer();
+  try {
+    const result = await pool.query(text, params);
+    end({ success: 'true' });
+    return result;
+  } catch (err) {
+    end({ success: 'false' });
+    throw err;
+  }
+}
+
+module.exports = { query, pool };

--- a/backend/src/middleware/metricsMiddleware.js
+++ b/backend/src/middleware/metricsMiddleware.js
@@ -1,0 +1,15 @@
+const { httpRequestDuration } = require('../utils/metrics');
+
+/**
+ * Records HTTP request duration.
+ * Uses req.route.path when available (e.g. /api/payments/send) to avoid
+ * high-cardinality labels from dynamic path segments like user IDs.
+ */
+module.exports = function metricsMiddleware(req, res, next) {
+  const end = httpRequestDuration.startTimer();
+  res.on('finish', () => {
+    const route = req.route?.path || req.path || 'unknown';
+    end({ method: req.method, route, status_code: res.statusCode });
+  });
+  next();
+};

--- a/backend/src/services/horizonWorker.js
+++ b/backend/src/services/horizonWorker.js
@@ -7,6 +7,7 @@ const StellarSdk = require('@stellar/stellar-sdk');
 const db = require('../db');
 const { sendPushToUser } = require('../controllers/notificationController');
 const logger = require('../utils/logger');
+const { wsConnections } = require('../utils/metrics');
 
 const server = new StellarSdk.Horizon.Server(
   process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org'
@@ -54,6 +55,7 @@ async function startStreamForUser(userId, publicKey) {
     });
 
   activeStreams.set(publicKey, close);
+  wsConnections.set(activeStreams.size);
 }
 
 function stopStreamForUser(publicKey) {
@@ -61,6 +63,7 @@ function stopStreamForUser(publicKey) {
   if (close) {
     close();
     activeStreams.delete(publicKey);
+    wsConnections.set(activeStreams.size);
   }
 }
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -4,6 +4,7 @@ const logger = require('../utils/logger');
 const { withRetry } = require('../utils/retry');
 const { withTimeout } = require('../utils/withTimeout');
 const { enqueue } = require('../utils/txQueue');
+const { horizonRequestDuration } = require('../utils/metrics');
 
 const isTestnet = process.env.STELLAR_NETWORK !== 'mainnet';
 const networkPassphrase = isTestnet
@@ -34,14 +35,18 @@ function isNetworkError(err) {
 
 /**
  * Execute fn(server) with automatic failover to the fallback node on network errors only.
+ * Records Horizon call duration via Prometheus.
  */
-async function withFallback(fn) {
+async function withFallback(fn, operation = 'unknown') {
+  const end = horizonRequestDuration.startTimer({ operation });
   try {
     const result = await fn(server);
+    end({ success: 'true' });
     logger.debug('Horizon request succeeded', { node: 'primary', url: primaryUrl });
     return result;
   } catch (primaryErr) {
     if (!isNetworkError(primaryErr) || !fallbackServer) {
+      end({ success: 'false' });
       throw primaryErr;
     }
     logger.warn('Primary Horizon node unreachable, trying fallback', {
@@ -51,9 +56,11 @@ async function withFallback(fn) {
     });
     try {
       const result = await fn(fallbackServer);
+      end({ success: 'true' });
       logger.info('Horizon request succeeded on fallback node', { url: fallbackUrl });
       return result;
     } catch (fallbackErr) {
+      end({ success: 'false' });
       const err = new Error(
         `Both Horizon nodes are unavailable. Primary: ${primaryErr.message}. Fallback: ${fallbackErr.message}`
       );
@@ -111,7 +118,7 @@ async function createWallet() {
 
 async function getBalance(publicKey) {
   try {
-    const account = await withRetry(() => withFallback(s => s.loadAccount(publicKey)), { label: 'loadAccount' });
+    const account = await withRetry(() => withFallback(s => s.loadAccount(publicKey), 'loadAccount'), { label: 'loadAccount' });
     return account.balances.map(b => ({
       asset: b.asset_type === 'native' ? 'XLM' : b.asset_code,
       balance: b.balance
@@ -140,7 +147,7 @@ function resolveAsset(asset) {
 async function checkTrustline(recipientPublicKey, assetObj) {
   let recipientAccount;
   try {
-    recipientAccount = await withRetry(() => withFallback(s => s.loadAccount(recipientPublicKey)), { label: 'loadAccount(recipient)' });
+    recipientAccount = await withRetry(() => withFallback(s => s.loadAccount(recipientPublicKey), 'loadAccount'), { label: 'loadAccount(recipient)' });
   } catch (e) {
     if (e.response?.status === 404) {
       const err = new Error('Recipient account does not exist on the Stellar network.');
@@ -242,10 +249,10 @@ async function createClaimableBalance({
   const assetObj = resolveAsset(asset);
   const secretKey = decryptPrivateKey(encryptedSecretKey);
   const senderKeypair = StellarSdk.Keypair.fromSecret(secretKey);
-  const senderAccount = await withRetry(() => withFallback(s => s.loadAccount(senderPublicKey)), { label: 'loadAccount(sender)' });
+  const senderAccount = await withRetry(() => withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount'), { label: 'loadAccount(sender)' });
 
   const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-    fee: await withRetry(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee' }),
+    fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' }),
     networkPassphrase
   })
     .addOperation(StellarSdk.Operation.createClaimableBalance({
@@ -263,7 +270,7 @@ async function createClaimableBalance({
   const transaction = txBuilder.build();
   transaction.sign(senderKeypair);
 
-  const result = await withRetry(() => withFallback(s => s.submitTransaction(transaction)), { label: 'submitTransaction' });
+  const result = await withRetry(() => withFallback(s => s.submitTransaction(transaction), 'submitTransaction'), { label: 'submitTransaction' });
   return { transactionHash: result.hash, ledger: result.ledger };
 }
 
@@ -303,10 +310,10 @@ async function _sendPaymentOnce({
   for (let attempt = 0; attempt < MAX_SEQ_RETRIES; attempt++) {
     try {
       // Fetch a fresh sequence number on every attempt
-      const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey));
+      const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount');
 
       const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-        fee: await withFallback(s => s.fetchBaseFee()),
+        fee: await withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'),
         networkPassphrase
       })
         .addOperation(StellarSdk.Operation.payment({
@@ -322,7 +329,7 @@ async function _sendPaymentOnce({
       const transaction = txBuilder.build();
       transaction.sign(senderKeypair);
 
-      const result = await withFallback(s => s.submitTransaction(transaction));
+      const result = await withFallback(s => s.submitTransaction(transaction), 'submitTransaction');
       return { transactionHash: result.hash, ledger: result.ledger, type: 'payment' };
     } catch (err) {
       if (isBadSeq(err) && attempt < MAX_SEQ_RETRIES - 1) {
@@ -376,7 +383,7 @@ async function getTransactions(publicKey, limit = 20) {
 // ---------------------------------------------------------------------------
 
 async function fetchFee() {
-  return withRetry(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee' });
+  return withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' });
 }
 
 // ---------------------------------------------------------------------------
@@ -433,7 +440,7 @@ async function sendPathPayment({
 
   const secretKey = decryptPrivateKey(encryptedSecretKey);
   const senderKeypair = StellarSdk.Keypair.fromSecret(secretKey);
-  const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey));
+  const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount');
 
   const sdkPath = path.map(p =>
     p.asset_type === 'native'
@@ -442,7 +449,7 @@ async function sendPathPayment({
   );
 
   const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-    fee: await withFallback(s => s.fetchBaseFee()),
+    fee: await withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'),
     networkPassphrase
   })
     .addOperation(StellarSdk.Operation.pathPaymentStrictSend({
@@ -460,7 +467,7 @@ async function sendPathPayment({
   const transaction = txBuilder.build();
   transaction.sign(senderKeypair);
 
-  const result = await withFallback(s => s.submitTransaction(transaction));
+  const result = await withFallback(s => s.submitTransaction(transaction), 'submitTransaction');
   return { transactionHash: result.hash, ledger: result.ledger };
 }
 
@@ -591,12 +598,12 @@ async function mergeAccount({ sourcePublicKey, encryptedSecretKey, destinationPu
   const secretKey = decryptPrivateKey(encryptedSecretKey);
   const sourceKeypair = StellarSdk.Keypair.fromSecret(secretKey);
   const sourceAccount = await withRetry(
-    () => withFallback(s => s.loadAccount(sourcePublicKey)),
+    () => withFallback(s => s.loadAccount(sourcePublicKey), 'loadAccount'),
     { label: 'loadAccount(merge)' }
   );
 
   const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
-    fee: await withRetry(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee' }),
+    fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' }),
     networkPassphrase,
   })
     .addOperation(StellarSdk.Operation.accountMerge({ destination: destinationPublicKey }))
@@ -605,7 +612,7 @@ async function mergeAccount({ sourcePublicKey, encryptedSecretKey, destinationPu
 
   tx.sign(sourceKeypair);
   const result = await withRetry(
-    () => withFallback(s => s.submitTransaction(tx)),
+    () => withFallback(s => s.submitTransaction(tx), 'submitTransaction'),
     { label: 'submitTransaction(merge)' }
   );
   return { transactionHash: result.hash, ledger: result.ledger };
@@ -622,12 +629,12 @@ async function clawbackAsset({ issuerPublicKey, encryptedIssuerSecretKey, fromPu
   const secretKey = decryptPrivateKey(encryptedIssuerSecretKey);
   const issuerKeypair = StellarSdk.Keypair.fromSecret(secretKey);
   const issuerAccount = await withRetry(
-    () => withFallback(s => s.loadAccount(issuerPublicKey)),
+    () => withFallback(s => s.loadAccount(issuerPublicKey), 'loadAccount'),
     { label: 'loadAccount(clawback)' }
   );
 
   const tx = new StellarSdk.TransactionBuilder(issuerAccount, {
-    fee: await withRetry(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee' }),
+    fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' }),
     networkPassphrase,
   })
     .addOperation(StellarSdk.Operation.clawback({
@@ -640,7 +647,7 @@ async function clawbackAsset({ issuerPublicKey, encryptedIssuerSecretKey, fromPu
 
   tx.sign(issuerKeypair);
   const result = await withRetry(
-    () => withFallback(s => s.submitTransaction(tx)),
+    () => withFallback(s => s.submitTransaction(tx), 'submitTransaction'),
     { label: 'submitTransaction(clawback)' }
   );
   return { transactionHash: result.hash, ledger: result.ledger };

--- a/backend/src/utils/metrics.js
+++ b/backend/src/utils/metrics.js
@@ -1,0 +1,44 @@
+const client = require('prom-client');
+
+const registry = new client.Registry();
+
+// Default Node.js process metrics (memory, CPU, event loop lag, etc.)
+client.collectDefaultMetrics({ register: registry });
+
+const httpRequestDuration = new client.Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.01, 0.05, 0.1, 0.3, 0.5, 1, 2, 5],
+  registers: [registry],
+});
+
+const horizonRequestDuration = new client.Histogram({
+  name: 'horizon_request_duration_seconds',
+  help: 'Stellar Horizon API call duration in seconds',
+  labelNames: ['operation', 'success'],
+  buckets: [0.05, 0.1, 0.3, 0.5, 1, 2, 5, 10],
+  registers: [registry],
+});
+
+const dbQueryDuration = new client.Histogram({
+  name: 'db_query_duration_seconds',
+  help: 'PostgreSQL query duration in seconds',
+  labelNames: ['success'],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
+  registers: [registry],
+});
+
+const wsConnections = new client.Gauge({
+  name: 'websocket_active_connections',
+  help: 'Number of active Horizon WebSocket stream connections',
+  registers: [registry],
+});
+
+module.exports = {
+  registry,
+  httpRequestDuration,
+  horizonRequestDuration,
+  dbQueryDuration,
+  wsConnections,
+};

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,0 +1,121 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "title": "AfriPay Backend",
+  "uid": "afripay-backend",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_duration_seconds_count[1m])) by (method, route)",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "HTTP Error Rate (5xx/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_duration_seconds_count{status_code=~\"5..\"}[1m]))",
+          "legendFormat": "5xx errors/s"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP P95 Latency (s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p95 {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Horizon API P95 Latency (s)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(horizon_request_duration_seconds_bucket[5m])) by (le, operation))",
+          "legendFormat": "p95 {{operation}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Horizon Error Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(horizon_request_duration_seconds_count{success=\"false\"}[1m])) by (operation)",
+          "legendFormat": "errors {{operation}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "DB Query P95 Latency (s)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(db_query_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95 DB latency"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Active Horizon WebSocket Streams",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 24, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "websocket_active_connections",
+          "legendFormat": "streams"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Node.js Heap Used (MB)",
+      "type": "timeseries",
+      "gridPos": { "x": 6, "y": 24, "w": 18, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "nodejs_heap_size_used_bytes / 1024 / 1024",
+          "legendFormat": "heap used MB"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `/metrics` endpoint exposing Prometheus-compatible metrics for HTTP requests, Horizon API calls, DB queries, and WebSocket connections. Closes #126 

## Changes

**New files**
- `backend/src/utils/metrics.js` — metric definitions (4 metrics + default Node.js process metrics)
- `backend/src/middleware/metricsMiddleware.js` — records HTTP request duration per method/route/status_code
- `monitoring/grafana-dashboard.json` — importable Grafana dashboard (8 panels)

**Modified files**
- `backend/src/db.js` — wraps `pool.query` to record `db_query_duration_seconds{success}`
- `backend/src/services/stellar.js` — `withFallback` accepts an `operation` label; all `loadAccount`, `fetchBaseFee`, `submitTransaction` call sites labelled
- `backend/src/services/horizonWorker.js` — updates `websocket_active_connections` gauge on stream open/close
- `backend/src/app.js` — mounts `GET /metrics` with optional Bearer token auth; adds `metricsMiddleware` globally
- `backend/.env.example` — documents `METRICS_TOKEN`

## Metrics exposed

| Metric | Type | Labels |
|---|---|---|
| `http_request_duration_seconds` | Histogram | method, route, status_code |
| `horizon_request_duration_seconds` | Histogram | operation, success |
| `db_query_duration_seconds` | Histogram | success |
| `websocket_active_connections` | Gauge | — |
| Node.js defaults | Various | — |

## Security

Set `METRICS_TOKEN` in your environment. The endpoint returns `401` for any request without `Authorization: Bearer <token>`. Leave unset in dev to skip auth.

## Grafana

Import `monitoring/grafana-dashboard.json` into Grafana (Dashboards → Import). Select your Prometheus datasource when prompted. Panels included:
- HTTP request rate & 5xx error rate
- HTTP p95 latency by route
- Horizon API p95 latency & error rate by operation
- DB query p95 latency
- Active WebSocket streams (stat)
- Node.js heap usage

## Notes
- Route labels use `req.route.path` (e.g. `/api/payments/send`) not the raw URL, preventing high-cardinality label explosion from path parameters
- No user PII is included in any metric label