### PR TITLE
fix: add Access-Control-Max-Age to reduce CORS preflight requests

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -34,7 +34,7 @@ app.use(helmet({
     },
   },
 }));
-app.use(cors({ origin: process.env.FRONTEND_URL, credentials: true }));
+app.use(cors({ origin: process.env.FRONTEND_URL, credentials: true, maxAge: 86400 }));
 app.use(express.json());
 
 const limiter = rateLimit({

--- a/backend/tests/security-headers.test.js
+++ b/backend/tests/security-headers.test.js
@@ -25,6 +25,24 @@ const ROUTES = [
   { method: 'get',  path: '/health' },
 ];
 
+describe('CORS preflight', () => {
+  test('OPTIONS request returns Access-Control-Max-Age: 86400', async () => {
+    const res = await request(app)
+      .options('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .set('Access-Control-Request-Method', 'POST');
+    expect(res.headers['access-control-max-age']).toBe('86400');
+  });
+
+  test('OPTIONS request still restricts origin', async () => {
+    const res = await request(app)
+      .options('/api/auth/login')
+      .set('Origin', 'http://evil.com')
+      .set('Access-Control-Request-Method', 'POST');
+    expect(res.headers['access-control-allow-origin']).not.toBe('http://evil.com');
+  });
+});
+
 describe('Security headers', () => {
   test.each(ROUTES)('$method $path has required security headers', async ({ method, path }) => {
     const res = await request(app)[method](path).send({});


### PR DESCRIPTION
Closes #102
The CORS configuration was missing Access-Control-Max-Age, causing browsers to send a preflight OPTIONS request before every cross-origin request. On mobile networks this doubles the number of HTTP round trips, adding unnecessary latency.