### PR TITLE
feat: add service worker offline mode with cached balance and payment…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^1.7.17",
         "axios": "^1.6.2",
         "i18next": "^25.10.5",
+        "idb": "^8.0.3",
         "lucide-react": "^0.294.0",
         "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
@@ -19,7 +20,9 @@
         "react-i18next": "^16.6.2",
         "react-qr-reader": "^3.0.0-beta-1",
         "react-router-dom": "^6.20.1",
-        "react-scripts": "5.0.1"
+        "react-scripts": "5.0.1",
+        "recharts": "^2.10.3",
+        "workbox-window": "^7.4.0"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -3594,6 +3597,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -5676,6 +5742,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6413,6 +6488,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6505,6 +6701,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6739,6 +6941,16 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -7948,6 +8160,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -9202,9 +9423,9 @@
       }
     },
     "node_modules/idb": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
     },
     "node_modules/identity-obj-proxy": {
@@ -9336,6 +9557,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -14137,6 +14367,37 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -14171,6 +14432,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
@@ -16079,6 +16378,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -16645,6 +16950,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -17126,6 +17453,12 @@
         "workbox-core": "6.6.0"
       }
     },
+    "node_modules/workbox-background-sync/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/workbox-broadcast-update": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.6.0.tgz",
@@ -17276,6 +17609,16 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "node_modules/workbox-build/node_modules/workbox-window": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.6.0.tgz",
+      "integrity": "sha512-L4N9+vka17d16geaJXXRjENLFldvkWy7JyGxElRD0JvBxvFEd8LOhr+uXCcar/NzAmIBRv9EZ+M+Qr4mOoBITw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2",
+        "workbox-core": "6.6.0"
+      }
+    },
     "node_modules/workbox-cacheable-response": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.6.0.tgz",
@@ -17301,6 +17644,12 @@
         "idb": "^7.0.1",
         "workbox-core": "6.6.0"
       }
+    },
+    "node_modules/workbox-expiration/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/workbox-google-analytics": {
       "version": "6.6.0",
@@ -17431,14 +17780,20 @@
       }
     },
     "node_modules/workbox-window": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.6.0.tgz",
-      "integrity": "sha512-L4N9+vka17d16geaJXXRjENLFldvkWy7JyGxElRD0JvBxvFEd8LOhr+uXCcar/NzAmIBRv9EZ+M+Qr4mOoBITw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
+      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "6.6.0"
+        "workbox-core": "7.4.0"
       }
+    },
+    "node_modules/workbox-window/node_modules/workbox-core": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
+      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "@headlessui/react": "^1.7.17",
     "axios": "^1.6.2",
     "i18next": "^25.10.5",
+    "idb": "^8.0.3",
     "lucide-react": "^0.294.0",
     "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
@@ -15,7 +16,8 @@
     "react-qr-reader": "^3.0.0-beta-1",
     "react-router-dom": "^6.20.1",
     "react-scripts": "5.0.1",
-    "recharts": "^2.10.3"
+    "recharts": "^2.10.3",
+    "workbox-window": "^7.4.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,9 +1,146 @@
-// Service Worker — handles Web Push notifications
+/**
+ * AfriPay Service Worker
+ *
+ * Responsibilities:
+ *  1. Web Push notifications (existing)
+ *  2. Offline caching of app shell + API responses (Workbox strategies)
+ *  3. Background Sync — replay queued payment requests when connectivity returns
+ *
+ * Workbox is loaded from the CDN so we don't need to eject CRA.
+ * The SW is registered manually via workbox-window in src/serviceWorker.js.
+ */
+
+importScripts(
+  'https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js'
+);
+
+// ─── Workbox config ──────────────────────────────────────────────────────────
+workbox.setConfig({ debug: false });
+
+const { registerRoute } = workbox.routing;
+const { CacheFirst, NetworkFirst, StaleWhileRevalidate } = workbox.strategies;
+const { ExpirationPlugin } = workbox.expiration;
+const { CacheableResponsePlugin } = workbox.cacheableResponse;
+const { BackgroundSyncPlugin, Queue } = workbox.backgroundSync;
+
+// ─── Cache names ─────────────────────────────────────────────────────────────
+const SHELL_CACHE   = 'afripay-shell-v1';
+const API_CACHE     = 'afripay-api-v1';
+const SYNC_TAG      = 'afripay-payment-queue';
+
+// ─── App shell — cache-first for static assets ───────────────────────────────
+// CRA puts hashed filenames in /static/**, so cache-first is safe.
+registerRoute(
+  ({ request }) =>
+    request.destination === 'script' ||
+    request.destination === 'style'  ||
+    request.destination === 'font'   ||
+    request.destination === 'image',
+  new CacheFirst({
+    cacheName: SHELL_CACHE,
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 60, maxAgeSeconds: 30 * 24 * 60 * 60 }),
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+    ],
+  })
+);
+
+// ─── HTML navigation — network-first so the app always gets fresh HTML ───────
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  new NetworkFirst({
+    cacheName: SHELL_CACHE,
+    plugins: [new CacheableResponsePlugin({ statuses: [200] })],
+  })
+);
+
+// ─── API: wallet balance — network-first, fall back to cache ─────────────────
+// Cache key: /api/wallet/balance
+registerRoute(
+  ({ url }) => url.pathname.includes('/wallet/balance'),
+  new NetworkFirst({
+    cacheName: API_CACHE,
+    networkTimeoutSeconds: 5,
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 1, maxAgeSeconds: 60 * 60 }),   // 1 h
+      new CacheableResponsePlugin({ statuses: [200] }),
+    ],
+  })
+);
+
+// ─── API: payment history — stale-while-revalidate ───────────────────────────
+// Users see the last known list instantly; fresh data loads in the background.
+registerRoute(
+  ({ url }) => url.pathname.includes('/payments/history'),
+  new StaleWhileRevalidate({
+    cacheName: API_CACHE,
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 5, maxAgeSeconds: 24 * 60 * 60 }),
+      new CacheableResponsePlugin({ statuses: [200] }),
+    ],
+  })
+);
+
+// ─── Background Sync — payment queue ─────────────────────────────────────────
+// Any POST to /payments/send that fails while offline is stored in the queue
+// and replayed automatically when the network comes back.
+const paymentQueue = new Queue(SYNC_TAG, {
+  maxRetentionTime: 24 * 60,   // keep for 24 hours (minutes)
+  onSync: async ({ queue }) => {
+    let entry;
+    while ((entry = await queue.shiftRequest())) {
+      try {
+        await fetch(entry.request.clone());
+        // Notify all open clients that a queued payment was replayed
+        const clients = await self.clients.matchAll({ type: 'window' });
+        clients.forEach((client) =>
+          client.postMessage({ type: 'PAYMENT_SYNCED' })
+        );
+      } catch {
+        // Network still down — put it back and stop
+        await queue.unshiftRequest(entry);
+        throw new Error('Replay failed — network still unavailable');
+      }
+    }
+  },
+});
+
+// Intercept POST /payments/send — if the fetch fails, enqueue it
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (
+    request.method === 'POST' &&
+    request.url.includes('/payments/send')
+  ) {
+    const bgSyncLogic = async () => {
+      try {
+        return await fetch(request.clone());
+      } catch {
+        await paymentQueue.pushRequest({ request });
+        // Return a synthetic "queued" response so the UI can react
+        return new Response(
+          JSON.stringify({ queued: true, message: 'Payment queued for when you are back online.' }),
+          {
+            status: 202,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+    };
+    event.respondWith(bgSyncLogic());
+  }
+});
+
+// ─── Web Push (existing) ─────────────────────────────────────────────────────
 self.addEventListener('push', (event) => {
   if (!event.data) return;
 
   let data = {};
-  try { data = event.data.json(); } catch { data = { title: 'AfriPay', body: event.data.text() }; }
+  try {
+    data = event.data.json();
+  } catch {
+    data = { title: 'AfriPay', body: event.data.text() };
+  }
 
   event.waitUntil(
     self.registration.showNotification(data.title || 'AfriPay', {
@@ -18,9 +155,16 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   event.waitUntil(
-    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((list) => {
-      if (list.length > 0) return list[0].focus();
-      return clients.openWindow('/dashboard');
-    })
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((list) => {
+        if (list.length > 0) return list[0].focus();
+        return self.clients.openWindow('/dashboard');
+      })
   );
+});
+
+// ─── Activate — claim clients immediately so the new SW takes effect ─────────
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
 });

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 import { usePushNotifications } from '../hooks/usePushNotifications';
 import { useStellarStatus } from '../hooks/useStellarStatus';
+import OfflineBanner from './OfflineBanner';
 
 const navItems = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
@@ -33,6 +34,8 @@ export default function Layout() {
           ⚠️ TESTNET — Do not use real funds
         </div>
       )}
+      {/* Offline / back-online banner */}
+      <OfflineBanner />
       {/* Stellar Network Status Banner */}
       {isDegraded && (
         <div className="bg-yellow-500 text-yellow-900 text-center text-xs font-semibold py-2 px-4 flex items-center justify-center gap-2">

--- a/frontend/src/components/OfflineBanner.jsx
+++ b/frontend/src/components/OfflineBanner.jsx
@@ -1,0 +1,75 @@
+/**
+ * OfflineBanner
+ *
+ * Displays a persistent banner when the device is offline.
+ * Also shows a transient "Back online — syncing payments…" notice
+ * when connectivity is restored after an offline period.
+ *
+ * Rendered inside Layout so it appears on every authenticated page.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { WifiOff, Wifi, Clock } from 'lucide-react';
+import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import { getQueueCount } from '../utils/offlineDB';
+
+export default function OfflineBanner({ onPaymentSynced }) {
+  const { isOnline, wasOffline } = useOnlineStatus({ onPaymentSynced });
+  const [showBackOnline, setShowBackOnline]   = useState(false);
+  const [queueCount,     setQueueCount]       = useState(0);
+
+  // Refresh queue count whenever online status changes
+  useEffect(() => {
+    getQueueCount()
+      .then(setQueueCount)
+      .catch(() => setQueueCount(0));
+  }, [isOnline]);
+
+  // Show the "back online" notice for 4 seconds after reconnecting
+  useEffect(() => {
+    if (isOnline && wasOffline) {
+      setShowBackOnline(true);
+      const t = setTimeout(() => setShowBackOnline(false), 4000);
+      return () => clearTimeout(t);
+    }
+  }, [isOnline, wasOffline]);
+
+  if (!isOnline) {
+    return (
+      <div
+        role="status"
+        aria-live="assertive"
+        className="bg-red-600 text-white text-xs font-semibold py-2 px-4 flex items-center justify-center gap-2"
+      >
+        <WifiOff size={14} aria-hidden="true" />
+        <span>You're offline — showing cached data</span>
+        {queueCount > 0 && (
+          <span className="flex items-center gap-1 ml-2 bg-red-700 rounded-full px-2 py-0.5">
+            <Clock size={11} aria-hidden="true" />
+            {queueCount} payment{queueCount !== 1 ? 's' : ''} queued
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (showBackOnline) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="bg-primary-500 text-white text-xs font-semibold py-2 px-4 flex items-center justify-center gap-2"
+      >
+        <Wifi size={14} aria-hidden="true" />
+        <span>
+          Back online
+          {queueCount > 0
+            ? ` — syncing ${queueCount} queued payment${queueCount !== 1 ? 's' : ''}…`
+            : ' — all caught up'}
+        </span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/hooks/useOnlineStatus.js
+++ b/frontend/src/hooks/useOnlineStatus.js
@@ -1,0 +1,55 @@
+/**
+ * useOnlineStatus
+ *
+ * Returns { isOnline, wasOffline } where:
+ *  - isOnline   : current navigator.onLine value, updated on network events
+ *  - wasOffline : true if the user went offline at least once this session
+ *                 (useful for showing a "back online" toast)
+ *
+ * Also listens for the PAYMENT_SYNCED message posted by the service worker
+ * after it successfully replays a queued payment, and calls the optional
+ * onPaymentSynced callback so the UI can refresh data.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * @param {{ onPaymentSynced?: () => void }} [options]
+ */
+export function useOnlineStatus({ onPaymentSynced } = {}) {
+  const [isOnline, setIsOnline]     = useState(() => navigator.onLine);
+  const [wasOffline, setWasOffline] = useState(false);
+
+  const handleOnline = useCallback(() => {
+    setIsOnline(true);
+  }, []);
+
+  const handleOffline = useCallback(() => {
+    setIsOnline(false);
+    setWasOffline(true);
+  }, []);
+
+  // Listen for the SW → client message when a queued payment is replayed
+  const handleMessage = useCallback(
+    (event) => {
+      if (event.data?.type === 'PAYMENT_SYNCED' && onPaymentSynced) {
+        onPaymentSynced();
+      }
+    },
+    [onPaymentSynced]
+  );
+
+  useEffect(() => {
+    window.addEventListener('online',  handleOnline);
+    window.addEventListener('offline', handleOffline);
+    navigator.serviceWorker?.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('online',  handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      navigator.serviceWorker?.removeEventListener('message', handleMessage);
+    };
+  }, [handleOnline, handleOffline, handleMessage]);
+
+  return { isOnline, wasOffline };
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import './i18n';
 import App from './App';
+import { register as registerSW } from './serviceWorker';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<React.StrictMode><App /></React.StrictMode>);
+
+// Register the service worker for offline support.
+// Only activates in production builds (see serviceWorker.js).
+registerSW();

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Send, Download, RefreshCw, Copy, CheckCheck, FlaskConical, Plus, Minus } from 'lucide-react';
+import { Send, Download, RefreshCw, Copy, CheckCheck, FlaskConical, Plus, Minus, WifiOff } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { BalanceCardSkeleton, TransactionRowSkeleton } from '../components/Skeleton';
 import api from '../utils/api';
 import { truncateAddress } from '../utils/currency';
 import { useExchangeRates } from '../hooks/useExchangeRates';
 import { usePaymentStream } from '../hooks/usePaymentStream';
+import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import { setCacheEntry, getCacheEntry } from '../utils/offlineDB';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
@@ -23,7 +25,9 @@ export default function Dashboard() {
   const [selectedCurrency, setSelectedCurrency] = useState('XLM');
   const [funding, setFunding] = useState(false);
   const [balanceIncreased, setBalanceIncreased] = useState(false);
+  const [fromCache, setFromCache] = useState(false);
   const { currencies, convertFromXLM, usingApproximateRates } = useExchangeRates();
+  const { isOnline } = useOnlineStatus();
 
   // Handle incoming payment from stream
   const handlePayment = useCallback((payment) => {
@@ -51,14 +55,73 @@ export default function Dashboard() {
   const { isConnected, error: streamError } = usePaymentStream(wallet?.public_key, handlePayment);
 
   useEffect(() => {
-    Promise.all([
-      api.get('/wallet/balance'),
-      api.get('/payments/history')
-    ]).then(([walletRes, txRes]) => {
-      setWallet(walletRes.data);
-      setTransactions(txRes.data.transactions.slice(0, 5));
-    }).catch(() => toast.error('Failed to load wallet data'))
-      .finally(() => setLoading(false));
+    async function loadDashboard() {
+      // If offline, try to serve from IndexedDB cache immediately
+      if (!navigator.onLine) {
+        try {
+          const [cachedWallet, cachedHistory] = await Promise.all([
+            getCacheEntry('balance'),
+            getCacheEntry('history'),
+          ]);
+          if (cachedWallet?.data) {
+            setWallet(cachedWallet.data);
+            setFromCache(true);
+          }
+          if (cachedHistory?.data) {
+            setTransactions(cachedHistory.data.slice(0, 5));
+          }
+        } catch {
+          // IndexedDB unavailable — nothing to show
+        } finally {
+          setLoading(false);
+        }
+        return;
+      }
+
+      // Online — fetch fresh data and persist to cache
+      try {
+        const [walletRes, txRes] = await Promise.all([
+          api.get('/wallet/balance'),
+          api.get('/payments/history'),
+        ]);
+        const walletData = walletRes.data;
+        const txData     = txRes.data.transactions;
+
+        setWallet(walletData);
+        setTransactions(txData.slice(0, 5));
+        setFromCache(false);
+
+        // Persist to IndexedDB for offline use
+        await Promise.all([
+          setCacheEntry('balance', walletData),
+          setCacheEntry('history', txData),
+        ]);
+      } catch {
+        // Network failed — fall back to cache
+        try {
+          const [cachedWallet, cachedHistory] = await Promise.all([
+            getCacheEntry('balance'),
+            getCacheEntry('history'),
+          ]);
+          if (cachedWallet?.data) {
+            setWallet(cachedWallet.data);
+            setFromCache(true);
+          }
+          if (cachedHistory?.data) {
+            setTransactions(cachedHistory.data.slice(0, 5));
+          }
+          if (!cachedWallet?.data) {
+            toast.error('Failed to load wallet data');
+          }
+        } catch {
+          toast.error('Failed to load wallet data');
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadDashboard();
   }, []);
 
   const copyAddress = () => {
@@ -151,7 +214,15 @@ export default function Dashboard() {
 
       {/* Balance Card */}
       <div className={`bg-gradient-to-br from-primary-600 to-primary-700 rounded-2xl p-5 shadow-lg shadow-primary-500/20 transition-all duration-500 ${balanceIncreased ? 'ring-4 ring-green-400 ring-opacity-50' : ''}`}>
-        <p className="text-primary-100 text-sm mb-1">{t('dashboard.total_balance')}</p>
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-primary-100 text-sm">{t('dashboard.total_balance')}</p>
+          {fromCache && (
+            <span className="flex items-center gap-1 text-primary-200 text-xs bg-primary-800/40 rounded-full px-2 py-0.5">
+              <WifiOff size={10} aria-hidden="true" />
+              Cached
+            </span>
+          )}
+        </div>
         <div className="flex items-end gap-2 mb-4">
           <span className="text-4xl font-bold text-white">{parseFloat(displayBalance).toLocaleString()}</span>
           <span className="text-primary-200 mb-1">{selectedCurrency}</span>

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -201,8 +201,9 @@ export default function SendMoney() {
   const handlePINVerified = async () => {
     setLoading(true);
     try {
+      let res;
       if (isCrossAsset && pathResult) {
-        await api.post('/payments/send-path', {
+        res = await api.post('/payments/send-path', {
           recipient_address: form.recipient_address,
           source_asset: form.asset,
           source_amount: parseFloat(form.amount),
@@ -212,40 +213,41 @@ export default function SendMoney() {
           memo: form.memo || undefined,
         });
       } else {
-        await api.post('/payments/send', {
-          recipient_address: form.recipient_address,
+        const m = form.memo.trim();
+        let recipientAddress = form.recipient_address;
+
+        // Resolve federation address if needed
+        if (recipientAddress.includes('*')) {
+          const fedRes = await api.get('/payments/resolve-federation', { params: { address: recipientAddress } });
+          recipientAddress = fedRes.data.public_key;
+        }
+
+        const payload = {
+          recipient_address: recipientAddress,
           amount: parseFloat(form.amount),
           asset: form.asset,
-          memo: form.memo || undefined,
-        });
+        };
+        if (m) {
+          payload.memo = m;
+          payload.memo_type = form.memo_type;
+        }
+        res = await api.post('/payments/send', payload);
       }
-      const m = form.memo.trim();
-      let recipientAddress = form.recipient_address;
-      
-      // Resolve federation address if needed
-      if (recipientAddress.includes('*')) {
-        const res = await api.get('/payments/resolve-federation', { params: { address: recipientAddress } });
-        recipientAddress = res.data.public_key;
+
+      // Offline queue — the api interceptor returns { queued: true }
+      if (res.data?.queued) {
+        toast.success('You\'re offline. Payment queued — it will send automatically when you reconnect.', { duration: 5000 });
+        navigate('/dashboard');
+        return;
       }
-      
-      const payload = {
-        recipient_address: recipientAddress,
-        amount: parseFloat(form.amount),
-        asset: form.asset
-      };
-      if (m) {
-        payload.memo = m;
-        payload.memo_type = form.memo_type;
-      }
-      const res = await api.post('/payments/send', payload);
-      
+
       // Mark payment request as claimed if applicable
       if (requestId) {
         await api.post(`/payment-requests/${requestId}/claim`, {
-          txHash: res.data.transaction.tx_hash
+          txHash: res.data?.transaction?.tx_hash,
         }).catch(() => {});
       }
-      
+
       toast.success(t('send.success'));
       navigate('/dashboard');
     } catch (err) {

--- a/frontend/src/pages/TransactionHistory.jsx
+++ b/frontend/src/pages/TransactionHistory.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Send, Download, ExternalLink, Filter, Search, Flag, X } from 'lucide-react';
+import { ArrowLeft, Send, Download, ExternalLink, Filter, Search, Flag, X, WifiOff } from 'lucide-react';
 import api from '../utils/api';
 import { truncateAddress } from '../utils/currency';
 import { TransactionCardSkeleton } from '../components/Skeleton';
+import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import { setCacheEntry, getCacheEntry } from '../utils/offlineDB';
 import { useTranslation } from 'react-i18next';
 
 const STATUS_COLORS = {
@@ -25,6 +27,7 @@ function buildHistoryParams(pageNum, dateFrom, dateTo, asset) {
 export default function TransactionHistory() {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { isOnline } = useOnlineStatus();
   const [transactions, setTransactions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -32,6 +35,7 @@ export default function TransactionHistory() {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState(null);
+  const [fromCache, setFromCache] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [search, setSearch] = useState('');
   const [dateFrom, setDateFrom] = useState('');
@@ -46,16 +50,60 @@ export default function TransactionHistory() {
     setLoading(true);
     setError(null);
     setPage(1);
+
+    // Offline — serve from IndexedDB cache
+    if (!navigator.onLine) {
+      try {
+        const cached = await getCacheEntry('history');
+        if (cached?.data) {
+          setTransactions(cached.data);
+          setFromCache(true);
+          setHasMore(false);
+        } else {
+          setError(t('history.load_error'));
+          setTransactions([]);
+        }
+      } catch {
+        setError(t('history.load_error'));
+        setTransactions([]);
+      } finally {
+        setLoading(false);
+      }
+      return;
+    }
+
+    // Online — fetch fresh and persist
     try {
       const params = buildHistoryParams(1, dateFrom, dateTo, asset);
       const r = await api.get('/payments/history', { params });
-      setTransactions(r.data.transactions);
+      const txList = r.data.transactions;
+      setTransactions(txList);
       setHasMore(r.data.page < r.data.pages);
       setPage(1);
+      setFromCache(false);
+
+      // Only cache the unfiltered first page (no date/asset filters)
+      if (!dateFrom && !dateTo && !asset) {
+        await setCacheEntry('history', txList);
+      }
     } catch {
-      setError(t('history.load_error'));
-      setTransactions([]);
-      setHasMore(false);
+      // Network failed — try cache
+      try {
+        const cached = await getCacheEntry('history');
+        if (cached?.data) {
+          setTransactions(cached.data);
+          setFromCache(true);
+          setHasMore(false);
+        } else {
+          setError(t('history.load_error'));
+          setTransactions([]);
+          setHasMore(false);
+        }
+      } catch {
+        setError(t('history.load_error'));
+        setTransactions([]);
+        setHasMore(false);
+      }
     } finally {
       setLoading(false);
     }
@@ -157,7 +205,15 @@ export default function TransactionHistory() {
       </button>
 
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-bold text-white">{t('history.title')}</h2>
+        <h2 className="text-2xl font-bold text-white">
+          {t('history.title')}
+          {fromCache && (
+            <span className="ml-2 inline-flex items-center gap-1 text-xs font-normal text-gray-400 bg-gray-800 rounded-full px-2 py-0.5 align-middle">
+              <WifiOff size={10} aria-hidden="true" />
+              Cached
+            </span>
+          )}
+        </h2>
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/frontend/src/serviceWorker.js
+++ b/frontend/src/serviceWorker.js
@@ -1,0 +1,53 @@
+/**
+ * serviceWorker.js
+ *
+ * Registers the AfriPay service worker (public/sw.js) using workbox-window.
+ * workbox-window handles:
+ *  - Waiting for the SW to be installed before prompting
+ *  - Detecting when a new SW is waiting (for future update prompts)
+ *  - Logging in development
+ *
+ * Call register() once from src/index.js.
+ */
+
+import { Workbox } from 'workbox-window';
+
+export function register() {
+  // Only register in production and when the browser supports service workers.
+  // In development CRA serves files from memory, so the SW would intercept
+  // hot-reload requests and break the dev experience.
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    !('serviceWorker' in navigator)
+  ) {
+    return;
+  }
+
+  const wb = new Workbox(`${process.env.PUBLIC_URL}/sw.js`);
+
+  // When a new SW has installed and is waiting to activate, you could show
+  // an "Update available — reload?" prompt here. For now we skip-wait
+  // automatically so users always get the latest SW without manual action.
+  wb.addEventListener('waiting', () => {
+    wb.messageSkipWaiting();
+  });
+
+  wb.addEventListener('activated', (event) => {
+    // On first activation claim all open clients immediately
+    if (!event.isUpdate) {
+      console.log('[SW] Service worker activated for the first time.');
+    }
+  });
+
+  wb.register().catch((err) => {
+    console.error('[SW] Registration failed:', err);
+  });
+}
+
+export function unregister() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready
+      .then((registration) => registration.unregister())
+      .catch((err) => console.error('[SW] Unregister failed:', err));
+  }
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { enqueuePayment } from './offlineDB';
 
 const baseURL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 
@@ -53,9 +54,49 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+/**
+ * Offline payment interceptor
+ *
+ * When the device has no network and the request is POST /payments/send,
+ * we enqueue the payload in IndexedDB and resolve with a synthetic
+ * { queued: true } response so the UI can show a "queued" confirmation
+ * instead of a hard error.
+ *
+ * The service worker's Background Sync handler will replay the request
+ * automatically once connectivity is restored.
+ */
+api.interceptors.request.use(async (config) => {
+  const isPaymentSend =
+    config.method?.toLowerCase() === 'post' &&
+    (config.url?.includes('/payments/send'));
+
+  if (isPaymentSend && !navigator.onLine) {
+    await enqueuePayment(config.data ?? {});
+    // Throw a special sentinel so the response interceptor can surface it
+    const offlineErr = new Error('OFFLINE_QUEUED');
+    offlineErr.isOfflineQueued = true;
+    offlineErr.config = config;
+    throw offlineErr;
+  }
+
+  return config;
+});
+
 api.interceptors.response.use(
   (res) => res,
   async (err) => {
+    // Payment was queued offline — surface a clean resolved response
+    if (err.isOfflineQueued) {
+      return Promise.resolve({
+        data: {
+          queued: true,
+          message: 'You are offline. Your payment has been queued and will be sent automatically when your connection is restored.',
+        },
+        status: 202,
+        config: err.config,
+      });
+    }
+
     const originalRequest = err.config;
     if (!originalRequest || !shouldAttemptRefresh(err, originalRequest)) {
       if (err.response?.status === 401) {

--- a/frontend/src/utils/offlineDB.js
+++ b/frontend/src/utils/offlineDB.js
@@ -1,0 +1,114 @@
+/**
+ * offlineDB.js
+ *
+ * Thin IndexedDB layer (via `idb`) for AfriPay offline mode.
+ *
+ * Stores:
+ *  - "cache"   : last-known API snapshots  (balance, transaction history)
+ *  - "queue"   : outgoing payment requests that failed while offline
+ *
+ * The service worker handles Background Sync replay automatically.
+ * This module is used by React components to read cached data and
+ * to let the UI display the pending-payment queue to the user.
+ */
+
+import { openDB } from 'idb';
+
+const DB_NAME    = 'afripay-offline';
+const DB_VERSION = 1;
+
+/** Lazily-opened singleton promise */
+let _db = null;
+
+function getDB() {
+  if (_db) return _db;
+  _db = openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      // Key-value store for API snapshots
+      if (!db.objectStoreNames.contains('cache')) {
+        db.createObjectStore('cache');
+      }
+      // Ordered store for queued payment requests
+      if (!db.objectStoreNames.contains('queue')) {
+        const store = db.createObjectStore('queue', {
+          keyPath: 'id',
+          autoIncrement: true,
+        });
+        store.createIndex('by_created', 'createdAt');
+      }
+    },
+  });
+  return _db;
+}
+
+// ─── Cache helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Persist an API response snapshot.
+ * @param {string} key   - e.g. 'balance' | 'history'
+ * @param {*}      value - serialisable JS value
+ */
+export async function setCacheEntry(key, value) {
+  const db = await getDB();
+  await db.put('cache', { data: value, savedAt: Date.now() }, key);
+}
+
+/**
+ * Read a cached snapshot.
+ * @param {string} key
+ * @returns {{ data: *, savedAt: number } | undefined}
+ */
+export async function getCacheEntry(key) {
+  const db = await getDB();
+  return db.get('cache', key);
+}
+
+// ─── Payment queue helpers ────────────────────────────────────────────────────
+
+/**
+ * Add a payment to the offline queue.
+ * @param {{ recipient_address: string, amount: string, asset: string, memo?: string, memo_type?: string }} payload
+ */
+export async function enqueuePayment(payload) {
+  const db = await getDB();
+  await db.add('queue', {
+    payload,
+    createdAt: Date.now(),
+    status: 'pending',   // 'pending' | 'syncing' | 'failed'
+  });
+}
+
+/**
+ * Return all queued payments, oldest first.
+ * @returns {Promise<Array>}
+ */
+export async function getQueuedPayments() {
+  const db = await getDB();
+  return db.getAllFromIndex('queue', 'by_created');
+}
+
+/**
+ * Remove a queued payment by its auto-incremented id.
+ * @param {number} id
+ */
+export async function removeQueuedPayment(id) {
+  const db = await getDB();
+  await db.delete('queue', id);
+}
+
+/**
+ * Clear every entry in the payment queue (e.g. after a successful bulk sync).
+ */
+export async function clearPaymentQueue() {
+  const db = await getDB();
+  await db.clear('queue');
+}
+
+/**
+ * Return the number of payments currently queued.
+ * @returns {Promise<number>}
+ */
+export async function getQueueCount() {
+  const db = await getDB();
+  return db.count('queue');
+}


### PR DESCRIPTION
closes #119 

Adds offline-first support for AfriPay users on unreliable African mobile networks. When connectivity drops, the app now serves cached data instead of a blank error state, and queues outgoing payments for automatic replay when the connection returns.

Changes

Registered a service worker via workbox-window (production only, no CRA eject required)
Extended 
sw.js
 with Workbox caching strategies:
CacheFirst for static assets
NetworkFirst (5s timeout) for /wallet/balance
StaleWhileRevalidate for /payments/history
BackgroundSyncPlugin queue for POST /payments/send — replays automatically on reconnect
Added offlineDB.js — IndexedDB layer (idb) for persisting balance/history snapshots and the payment queue
Added useOnlineStatus hook — reacts to online/offline events and SW PAYMENT_SYNCED messages
Added OfflineBanner component — red persistent banner when offline (shows queued payment count), green transient banner on reconnect
Dashboard and TransactionHistory now read from IndexedDB when offline and write to it after every successful fetch; stale data is labelled with a "Cached" indicator
api.js offline interceptor enqueues POST /payments/send to IndexedDB when offline and returns a synthetic 202 queued response so the UI gives clear feedback instead of an error
SendMoney handles the queued: true response with an informative toast
Testing

Load the app online — balance and history are cached automatically
Go offline (DevTools → Network → Offline)
Navigate to Dashboard and History — cached data renders, "Offline" banner appears
Submit a payment — toast confirms it's queued, no error shown
Go back online — SW replays the queued payment, "Back online — syncing" banner appears briefly