### PR TITLE
feat: ledger close time, min balance warning, inflation dest, signers…

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -1,6 +1,7 @@
 const { v4: uuidv4 } = require("uuid");
 const { stringify } = require("csv-stringify/sync");
 const db = require("../db");
+const StellarSdk = require("@stellar/stellar-sdk");
 const {
   sendPayment,
   sendBatchPayment,
@@ -29,6 +30,24 @@ const DAILY_SEND_LIMIT = parseFloat(process.env.DAILY_SEND_LIMIT || "50000");
 
 // Threshold for phone verification check
 const PHONE_VERIFICATION_THRESHOLD_USD = parseFloat(process.env.PHONE_VERIFICATION_THRESHOLD_USD || "100");
+
+const horizonUrl = process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
+const horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
+
+/**
+ * Fetch the authoritative ledger close time from Horizon for a given ledger sequence.
+ * Returns an ISO string or null if unavailable.
+ */
+async function fetchLedgerCloseTime(ledgerSequence) {
+  if (!ledgerSequence) return null;
+  try {
+    const ledger = await horizonServer.ledgers().ledger(ledgerSequence).call();
+    return ledger.closed_at || null;
+  } catch {
+    return null;
+  }
+}
+
 
 function estimateUSDValue(amount, asset) {
   if (asset === "USD" || asset === "USDC") return parseFloat(amount);
@@ -93,11 +112,12 @@ async function insertTransactionRecord({
   memo_type = null,
   tx_hash = null,
   status,
+  ledger_close_time = null,
 }) {
   await db.query(
-    `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-    [id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status],
+    `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, ledger_close_time)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+    [id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, ledger_close_time],
   );
 
   return id;
@@ -218,12 +238,15 @@ async function send(req, res, next) {
       memoType: memo ? memo_type : undefined,
     }, req.logger);
 
+    // Fetch authoritative ledger close time from Horizon (issue #139)
+    const ledger_close_time = await fetchLedgerCloseTime(ledger);
+
     // Save to DB
     const txStatus = type === "claimable_balance" ? "pending_claim" : "completed";
     await db.query(
-      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, claimable_balance_id, request_id, is_encrypted, encrypted_memo)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
-      [txId, public_key, recipient_address, amount, asset, memo || null, memo_type, transactionHash, txStatus, claimableBalanceId || null, req.requestId, is_encrypted, encrypted_memo],
+      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, claimable_balance_id, request_id, is_encrypted, encrypted_memo, ledger_close_time)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+      [txId, public_key, recipient_address, amount, asset, memo || null, memo_type, transactionHash, txStatus, claimableBalanceId || null, req.requestId, is_encrypted, encrypted_memo, ledger_close_time],
     );
 
     // Invalidate sender's cached balance — it changed after this payment
@@ -601,7 +624,7 @@ async function history(req, res, next) {
     const whereClause = conditions.join(" AND ");
 
     const countSql = `SELECT COUNT(*)::text AS count FROM transactions WHERE ${whereClause}`;
-    const listSql = `SELECT id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, created_at
+    const listSql = `SELECT id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, created_at, ledger_close_time
          FROM transactions
          WHERE ${whereClause}
          ORDER BY created_at DESC LIMIT $${baseParams.length + 1} OFFSET $${baseParams.length + 2}`;

--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -3,6 +3,8 @@ const { v4: uuidv4 } = require('uuid');
 const db = require('../db');
 const {
   getBalance,
+  getAccountSigners,
+  clearInflationDestination,
   getTransactions,
   decryptPrivateKey,
   addAccountSigner,
@@ -12,11 +14,13 @@ const {
   getTrustlines,
   mergeAccount,
   createWallet: generateWallet,
+  setDataEntry,
+  getDataEntries,
 } = require('../services/stellar');
-const { getBalance, getTransactions, decryptPrivateKey, addAccountSigner, removeAccountSigner, addTrustline, removeTrustline, getTrustlines, mergeAccount, setDataEntry, getDataEntries } = require('../services/stellar');
 const QRCode = require('qrcode');
 const cache = require('../utils/cache');
 const audit = require('../services/audit');
+
 
 const MAX_WALLETS_PER_USER = 5;
 
@@ -406,8 +410,6 @@ async function deleteEntry(req, res, next) {
   }
 }
 
-module.exports = { getWallet, getQRCode, getWalletTransactions, exportKey, upgradeToBusinessAccount, addSigner, removeSigner, listSigners, listTrustlines, addTrustlineHandler, removeTrustlineHandler, mergeWallet, listDataEntries, setEntry, deleteEntry, ALLOWED_KEYS };
-
 async function mergeWallet(req, res, next) {
   try {
     const { destination, password, wallet_id } = req.body;
@@ -454,6 +456,46 @@ async function mergeWallet(req, res, next) {
   }
 }
 
+/**
+ * GET /api/wallet/signers — returns signers and thresholds directly from Horizon.
+ * Issue #142: display live signer data including weight and type.
+ */
+async function getSignersFromHorizon(req, res, next) {
+  try {
+    const wallet = await resolveWallet(req.user.userId, req.query.wallet_id || null);
+    if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
+    const data = await getAccountSigners(wallet.public_key);
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * POST /api/wallet/clear-inflation-destination — clears legacy inflation_destination.
+ * Issue #141: detect and clear legacy Stellar inflation destinations.
+ */
+async function clearInflationDestinationHandler(req, res, next) {
+  try {
+    const wallet = await resolveWallet(req.user.userId, req.query.wallet_id || null);
+    if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
+
+    const { transactionHash } = await clearInflationDestination({
+      publicKey: wallet.public_key,
+      encryptedSecretKey: wallet.encrypted_secret_key,
+    });
+
+    audit.log(req.user.userId, 'clear_inflation_destination', req.ip, req.headers['user-agent'], {
+      wallet_id: wallet.id,
+      transaction_hash: transactionHash,
+    });
+
+    res.json({ message: 'Inflation destination cleared', transaction_hash: transactionHash });
+  } catch (err) {
+    next(err);
+  }
+}
+
 module.exports = {
   getWallet,
   listWallets,
@@ -465,8 +507,13 @@ module.exports = {
   addSigner,
   removeSigner,
   listSigners,
+  getSignersFromHorizon,
+  clearInflationDestinationHandler,
   listTrustlines,
   addTrustlineHandler,
   removeTrustlineHandler,
   mergeWallet,
+  listDataEntries,
+  setEntry,
+  deleteEntry,
 };

--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -13,12 +13,16 @@ const {
   addSigner,
   removeSigner,
   listSigners,
+  getSignersFromHorizon,
+  clearInflationDestinationHandler,
   listTrustlines,
   addTrustlineHandler,
   removeTrustlineHandler,
   mergeWallet,
+  listDataEntries,
+  setEntry,
+  deleteEntry,
 } = require('../controllers/walletController');
-const { getWallet, getQRCode, getWalletTransactions, exportKey, upgradeToBusinessAccount, addSigner, removeSigner, listSigners, listTrustlines, addTrustlineHandler, removeTrustlineHandler, mergeWallet, listDataEntries, setEntry, deleteEntry } = require('../controllers/walletController');
 const { getContacts, addContact, deleteContact } = require('../controllers/contactsController');
 const { getStatus } = require('../services/horizonRateLimit');
 
@@ -127,6 +131,8 @@ router.post(
 // Multisig / business account routes
 router.post('/upgrade-business', upgradeToBusinessAccount);
 router.get('/signers', listSigners);
+router.get('/signers/horizon', getSignersFromHorizon);
+router.post('/clear-inflation-destination', clearInflationDestinationHandler);
 router.post(
   '/signers',
   [

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -128,15 +128,67 @@ async function getBalance(publicKey) {
   try {
     const raw = await withRetry(() => withFallback(s => s.loadAccount(publicKey)), { label: 'loadAccount' });
     const account = validateHorizonResponse(AccountResponseSchema, raw, 'loadAccount');
-    const account = await withRetry(() => withFallback(s => s.loadAccount(publicKey), 'loadAccount'), { label: 'loadAccount' });
-    return account.balances.map(b => ({
-      asset: b.asset_type === 'native' ? 'XLM' : b.asset_code,
-      balance: b.balance
-    }));
+
+    // Stellar minimum balance: (2 + num_subentries) * base_reserve (0.5 XLM)
+    const BASE_RESERVE = 0.5;
+    const numSubentries = account.subentry_count || 0;
+    const minBalance = (2 + numSubentries) * BASE_RESERVE;
+
+    return account.balances.map(b => {
+      if (b.asset_type === 'native') {
+        const total = parseFloat(b.balance);
+        const available = Math.max(0, total - minBalance);
+        return {
+          asset: 'XLM',
+          balance: b.balance,
+          available_balance: available.toFixed(7),
+          min_balance: minBalance.toFixed(7),
+        };
+      }
+      return { asset: b.asset_code, balance: b.balance };
+    });
   } catch (e) {
     if (e.response?.status === 404) return [];
     throw e;
   }
+}
+
+/**
+ * Return the signers and thresholds for an account directly from Horizon.
+ */
+async function getAccountSigners(publicKey) {
+  const raw = await withRetry(() => withFallback(s => s.loadAccount(publicKey)), { label: 'loadAccount(signers)' });
+  const account = validateHorizonResponse(AccountResponseSchema, raw, 'loadAccount(signers)');
+  return {
+    signers: account.signers.map(s => ({
+      key: s.key,
+      weight: s.weight,
+      type: s.type,
+    })),
+    thresholds: account.thresholds,
+    inflation_destination: account.inflation_destination || null,
+  };
+}
+
+/**
+ * Clear the inflation destination on an account (legacy Protocol <12 setting).
+ */
+async function clearInflationDestination({ publicKey, encryptedSecretKey }) {
+  const secretKey = decryptPrivateKey(encryptedSecretKey);
+  const keypair = StellarSdk.Keypair.fromSecret(secretKey);
+  const account = await withRetry(() => withFallback(s => s.loadAccount(publicKey)), { label: 'loadAccount(clearInflation)' });
+
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: await withRetry(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee' }),
+    networkPassphrase,
+  })
+    .addOperation(StellarSdk.Operation.setOptions({ inflationDest: null }))
+    .setTimeout(30)
+    .build();
+
+  tx.sign(keypair);
+  const result = await withRetry(() => withFallback(s => s.submitTransaction(tx)), { label: 'submitTransaction(clearInflation)' });
+  return { transactionHash: result.hash };
 }
 
 // ---------------------------------------------------------------------------
@@ -895,6 +947,8 @@ async function getDataEntries(publicKey) {
 module.exports = {
   createWallet,
   getBalance,
+  getAccountSigners,
+  clearInflationDestination,
   sendPayment,
   sendBatchPayment,
   getTransactions,

--- a/database/migrations/016_add_ledger_close_time.js
+++ b/database/migrations/016_add_ledger_close_time.js
@@ -1,0 +1,9 @@
+exports.up = (pgm) => {
+  pgm.addColumn('transactions', {
+    ledger_close_time: { type: 'timestamptz' },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn('transactions', 'ledger_close_time');
+};

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -182,6 +182,7 @@ export default function Dashboard() {
   };
 
   const xlmBalance = wallet?.balances?.find((b) => b.asset === 'XLM')?.balance || '0';
+  const xlmAvailable = wallet?.balances?.find((b) => b.asset === 'XLM')?.available_balance || null;
   const displayBalance =
     selectedCurrency === 'XLM' ? xlmBalance : convertFromXLM(xlmBalance, selectedCurrency);
 
@@ -372,6 +373,11 @@ export default function Dashboard() {
           </span>
           <span className="text-primary-200 mb-1">{selectedCurrency}</span>
         </div>
+        {xlmAvailable !== null && selectedCurrency === 'XLM' && (
+          <p className="text-primary-200 text-xs mb-3">
+            Available to send: {parseFloat(xlmAvailable).toLocaleString()} XLM
+          </p>
+        )}
 
         {/* Currency selector */}
         <div className="flex gap-2 flex-wrap mb-4">

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { LogOut, User, Mail, Phone, Wallet, Copy, CheckCheck, Plus, Globe, Trash2, ShieldAlert, Eye, EyeOff, Activity, AlertTriangle, Building2, Coins, Gift } from 'lucide-react';
+import { LogOut, User, Mail, Phone, Wallet, Copy, CheckCheck, Plus, Globe, Trash2, ShieldAlert, Eye, EyeOff, Activity, AlertTriangle, Building2, Coins, Gift, Shield, Key, AlertCircle } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { truncateAddress } from '../utils/currency';
 import api from '../utils/api';
@@ -39,6 +39,56 @@ export default function Profile() {
   const [closeDestination, setCloseDestination] = useState('');
   const [closePassword, setClosePassword] = useState('');
   const [closeLoading, setCloseLoading] = useState(false);
+
+  // Security section state (issues #141, #142)
+  const [signers, setSigners] = useState(null);
+  const [signersLoading, setSignersLoading] = useState(false);
+  const [signersError, setSignersError] = useState(null);
+  const [inflationDest, setInflationDest] = useState(undefined); // undefined = not loaded
+  const [clearingInflation, setClearingInflation] = useState(false);
+  const [removingSignerKey, setRemovingSignerKey] = useState(null);
+
+  const loadSigners = async () => {
+    setSignersLoading(true);
+    setSignersError(null);
+    try {
+      const res = await api.get('/wallet/signers/horizon');
+      setSigners(res.data.signers || []);
+      setInflationDest(res.data.inflation_destination);
+    } catch {
+      setSignersError('Failed to load signer data');
+    } finally {
+      setSignersLoading(false);
+    }
+  };
+
+  const handleClearInflation = async () => {
+    if (!window.confirm('Clear the inflation destination from your account?')) return;
+    setClearingInflation(true);
+    try {
+      await api.post('/wallet/clear-inflation-destination');
+      setInflationDest(null);
+      toast.success('Inflation destination cleared');
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Failed to clear inflation destination');
+    } finally {
+      setClearingInflation(false);
+    }
+  };
+
+  const handleRemoveSigner = async (signerKey) => {
+    if (!window.confirm(`Remove signer ${signerKey.slice(0, 8)}…?`)) return;
+    setRemovingSignerKey(signerKey);
+    try {
+      await api.delete(`/wallet/signers/${signerKey}`);
+      setSigners(prev => prev.filter(s => s.key !== signerKey));
+      toast.success('Signer removed');
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Failed to remove signer');
+    } finally {
+      setRemovingSignerKey(null);
+    }
+  };
 
   React.useEffect(() => {
     api.get('/wallet/trustlines')
@@ -554,6 +604,85 @@ export default function Profile() {
           <span className="text-xs bg-primary-500/20 text-primary-400 px-2 py-0.5 rounded-full shrink-0">Active</span>
         )}
       </button>
+
+      {/* Security — Signers & Inflation Destination (issues #141, #142) */}
+      <div className="bg-gray-900 rounded-2xl p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Shield size={16} className="text-primary-400" />
+            <h3 className="font-semibold text-white">Security</h3>
+          </div>
+          <button
+            onClick={loadSigners}
+            disabled={signersLoading}
+            className="text-sm text-primary-500 hover:text-primary-400 disabled:opacity-50"
+          >
+            {signersLoading ? 'Loading…' : signers === null ? 'Load' : 'Refresh'}
+          </button>
+        </div>
+
+        {signersError && (
+          <p className="text-red-400 text-xs mb-3">{signersError}</p>
+        )}
+
+        {/* Inflation destination notice */}
+        {inflationDest && (
+          <div className="mb-4 bg-yellow-500/10 border border-yellow-500/30 rounded-xl p-3 flex items-start gap-3">
+            <AlertCircle size={15} className="text-yellow-400 shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-yellow-400 text-xs font-semibold mb-0.5">Legacy inflation destination set</p>
+              <p className="text-yellow-300/70 text-xs font-mono truncate">{inflationDest}</p>
+              <p className="text-gray-500 text-xs mt-1">Stellar removed inflation in Protocol 12. This is harmless but can be cleared.</p>
+            </div>
+            <button
+              onClick={handleClearInflation}
+              disabled={clearingInflation}
+              className="text-xs bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 px-2.5 py-1.5 rounded-lg transition-colors disabled:opacity-50 shrink-0"
+            >
+              {clearingInflation ? '…' : 'Clear'}
+            </button>
+          </div>
+        )}
+
+        {/* Signers list */}
+        {signers !== null && (
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500 mb-2">Account signers from Horizon</p>
+            {signers.map((s) => {
+              const isMaster = s.type === 'ed25519_public_key' && s.key === user?.wallet_address;
+              return (
+                <div key={s.key} className="flex items-center gap-3 bg-gray-800 rounded-xl px-3 py-2.5">
+                  <Key size={13} className="text-gray-500 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-mono text-white truncate">{s.key.slice(0, 8)}…{s.key.slice(-8)}</p>
+                    <p className="text-xs text-gray-500">
+                      Weight: {s.weight} · {s.type.replace(/_/g, ' ')}
+                      {isMaster && <span className="ml-1 text-primary-400">(master)</span>}
+                    </p>
+                  </div>
+                  {!isMaster && (
+                    <button
+                      onClick={() => handleRemoveSigner(s.key)}
+                      disabled={removingSignerKey === s.key}
+                      className="p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors disabled:opacity-50"
+                      aria-label="Remove signer"
+                    >
+                      {removingSignerKey === s.key ? '…' : <Trash2 size={13} />}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+            {signers.length === 0 && (
+              <p className="text-gray-500 text-xs text-center py-2">No signers found.</p>
+            )}
+          </div>
+        )}
+
+        {signers === null && !signersLoading && (
+          <p className="text-gray-600 text-xs text-center py-2">Click "Load" to fetch live signer data from Horizon.</p>
+        )}
+      </div>
 
       {/* Close Account */}
       <div className="bg-gray-900 rounded-2xl p-5">

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -52,6 +52,17 @@ export default function SendMoney() {
 
   const selectedWallet = wallets.find((w) => w.id === selectedWalletId) || wallets[0] || null;
 
+  // Available XLM balance for the selected wallet (after minimum reserve)
+  const selectedWalletXlmEntry = selectedWallet?.balances?.find((b) => b.asset === 'XLM');
+  const availableXlm = selectedWalletXlmEntry?.available_balance
+    ? parseFloat(selectedWalletXlmEntry.available_balance)
+    : null;
+  const belowMinBalance =
+    form.asset === 'XLM' &&
+    availableXlm !== null &&
+    form.amount &&
+    parseFloat(form.amount) > availableXlm;
+
   useEffect(() => {
     api.get('/wallet/list').then((r) => {
       setWallets(r.data.wallets || []);
@@ -505,6 +516,16 @@ export default function SendMoney() {
               {usingApproximateRates && (
                 <p className="text-xs text-amber-500/90">{t('common.rates_disclaimer')}</p>
               )}
+            </div>
+          )}
+          {availableXlm !== null && form.asset === 'XLM' && (
+            <p className="text-xs text-gray-500 mt-1">
+              Available to send: {availableXlm.toLocaleString()} XLM
+            </p>
+          )}
+          {belowMinBalance && (
+            <div className="mt-2 bg-red-500/10 border border-red-500/40 rounded-xl px-4 py-3 text-red-400 text-sm">
+              ⚠️ This amount exceeds your available balance ({availableXlm.toLocaleString()} XLM). Sending it would drop your account below the Stellar minimum reserve.
             </div>
           )}
         </div>

--- a/frontend/src/pages/TransactionHistory.jsx
+++ b/frontend/src/pages/TransactionHistory.jsx
@@ -368,13 +368,20 @@ export default function TransactionHistory() {
                         {tx.status}
                       </span>
                       <div className="flex items-center gap-2">
-                        <span className="text-xs text-gray-600">
-                          {new Date(tx.created_at).toLocaleDateString('en-GB', {
-                            day: 'numeric',
-                            month: 'short',
-                            year: 'numeric',
-                          })}
-                        </span>
+                        <div className="text-right">
+                          <span className="text-xs text-gray-500 block">
+                            {new Date(tx.ledger_close_time || tx.created_at).toLocaleDateString('en-GB', {
+                              day: 'numeric',
+                              month: 'short',
+                              year: 'numeric',
+                            })}
+                          </span>
+                          {tx.ledger_close_time && tx.created_at && (
+                            <span className="text-xs text-gray-700 block" title={`Submitted: ${new Date(tx.created_at).toLocaleString()}`}>
+                              Ledger: {new Date(tx.ledger_close_time).toLocaleTimeString()}
+                            </span>
+                          )}
+                        </div>
                         {tx.tx_hash && (
                           <a
                             href={`https://stellar.expert/explorer/testnet/tx/${tx.tx_hash}`}


### PR DESCRIPTION
Here's a summary of everything done across the 4 issues in a single PR-ready branch:

---

**#139 — Ledger close time:**
- Migration `016_add_ledger_close_time.js` adds `ledger_close_time` column to `transactions`
- `paymentController.js` fetches the ledger close time from Horizon after each payment and stores it
- `history` query now returns `ledger_close_time`
- `TransactionHistory.jsx` displays ledger close time as the primary date, with submitted time available on hover

**#140 — Minimum balance warning:**
- `stellar.js` `getBalance` now calculates `available_balance` and `min_balance` for XLM using `(2 + subentry_count) × 0.5`
- `Dashboard.jsx` shows "Available to send: X XLM" under the balance
- `SendMoney.jsx` shows the available amount and a red warning if the entered amount exceeds it

**#141 — Inflation destination:**
- `stellar.js` adds `clearInflationDestination` using `setOptions({ inflationDest: null })`
- `walletController.js` adds `clearInflationDestinationHandler` with audit logging
- `POST /api/wallet/clear-inflation-destination` route added
- `Profile.jsx` shows a yellow notice with a "Clear" button when `inflation_destination` is set

**#142 — Signers display:**
- `stellar.js` adds `getAccountSigners` returning live signers, thresholds, and inflation destination from Horizon
- `walletController.js` adds `getSignersFromHorizon`
- `GET /api/wallet/signers/horizon` route added
- `Profile.jsx` Security section shows each signer's truncated key, weight, type, and a "Remove signer" button for non-master signers

closes #139 
closes #140 
closes #141 
closes #142 