### PR TITLE
feat: add fee priority selector, cursor pagination, stream reconnecti…

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -8,6 +8,7 @@ const {
   sendPathPayment,
   findPaymentPath,
   fetchFee,
+  fetchFeeStats,
   validateBatchRecipient,
 } = require("../services/stellar");
 const webhook = require("../services/webhook");
@@ -132,12 +133,32 @@ async function estimateFee(req, res, next) {
   }
 }
 
+async function getFeeStats(req, res, next) {
+  try {
+    const stats = await fetchFeeStats();
+    res.json({
+      min: stats.min,
+      p10: stats.p10,
+      p50: stats.p50,
+      p90: stats.p90,
+      p99: stats.p99,
+      priorities: {
+        economy: stats.p10,
+        standard: stats.p50,
+        priority: stats.p90,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function send(req, res, next) {
   const txId = uuidv4();
   // Hoist these so the catch block can reference them for the failed-tx INSERT
   let public_key;
   try {
-    const { recipient_address, amount, asset = "XLM", memo: rawMemo, memo_type: rawMemoType, encrypt_memo = false } = req.body;
+    const { recipient_address, amount, asset = "XLM", memo: rawMemo, memo_type: rawMemoType, encrypt_memo = false, fee_priority = "standard" } = req.body;
     let memo = typeof rawMemo === "string" ? rawMemo.trim() : "";
     const memo_type = memo ? (rawMemoType || "text") : null;
 
@@ -236,6 +257,7 @@ async function send(req, res, next) {
       asset,
       memo: memo || undefined,
       memoType: memo ? memo_type : undefined,
+      feePriority: fee_priority,
     }, req.logger);
 
     // Fetch authoritative ledger close time from Horizon (issue #139)
@@ -573,9 +595,9 @@ async function sendBatch(req, res, next) {
 
 async function history(req, res, next) {
   try {
-    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
     const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 20));
-    const offset = (page - 1) * limit;
+    // cursor is the transaction id (integer PK) to paginate from
+    const cursor = req.query.cursor ? parseInt(req.query.cursor, 10) : null;
 
     let fromBound = null;
     let toBound = null;
@@ -609,6 +631,11 @@ async function history(req, res, next) {
 
     const conditions = ["(sender_wallet = $1 OR recipient_wallet = $1)"];
     const baseParams = [public_key];
+
+    if (cursor) {
+      conditions.push(`id < $${baseParams.length + 1}`);
+      baseParams.push(cursor);
+    }
     if (fromBound) {
       conditions.push(`created_at >= $${baseParams.length + 1}`);
       baseParams.push(fromBound);
@@ -623,32 +650,23 @@ async function history(req, res, next) {
     }
     const whereClause = conditions.join(" AND ");
 
-    const countSql = `SELECT COUNT(*)::text AS count FROM transactions WHERE ${whereClause}`;
     const listSql = `SELECT id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, created_at, ledger_close_time
          FROM transactions
          WHERE ${whereClause}
-         ORDER BY created_at DESC LIMIT $${baseParams.length + 1} OFFSET $${baseParams.length + 2}`;
+         ORDER BY id DESC LIMIT $${baseParams.length + 1}`;
 
-    const dataParams = [...baseParams, limit, offset];
+    const result = await db.query(listSql, [...baseParams, limit + 1]);
 
-    const [countResult, result] = await Promise.all([
-      db.query(countSql, baseParams),
-      db.query(listSql, dataParams),
-    ]);
-
-    const total = parseInt(countResult.rows[0].count, 10);
-    const transactions = result.rows.map((tx) => ({
+    const rows = result.rows;
+    const hasMore = rows.length > limit;
+    const transactions = rows.slice(0, limit).map((tx) => ({
       ...tx,
       direction: tx.sender_wallet === public_key ? "sent" : "received",
     }));
 
-    res.json({
-      transactions,
-      total,
-      page,
-      limit,
-      pages: Math.ceil(total / limit) || 0,
-    });
+    const next_cursor = hasMore ? transactions[transactions.length - 1].id : null;
+
+    res.json({ transactions, next_cursor, has_more: hasMore });
   } catch (err) {
     next(err);
   }
@@ -857,4 +875,4 @@ async function exportCSV(req, res, next) {
   }
 }
 
-module.exports = { send, sendBatch, history, findPath, sendPath, exportCSV, estimateFee };
+module.exports = { send, sendBatch, history, findPath, sendPath, exportCSV, estimateFee, getFeeStats };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -11,6 +11,7 @@ const webpush = require('./services/webpush');
 const db = require('./db');
 const app = require('./app');
 const { initStreams } = require('./services/horizonWorker');
+const { detectTestnetReset } = require('./services/stellar');
 
 const PORT = process.env.PORT || 5000;
 const SHUTDOWN_TIMEOUT_MS = 30_000;
@@ -18,6 +19,15 @@ const SHUTDOWN_TIMEOUT_MS = 30_000;
 const server = app.listen(PORT, () => {
   logger.info(`Server running on port ${PORT}`, { port: PORT });
   initStreams();
+
+  // Warn if testnet was reset since last startup
+  if (process.env.NODE_ENV !== 'production') {
+    detectTestnetReset().then((reset) => {
+      if (reset) {
+        logger.warn('⚠️  Stellar testnet reset detected at startup. Run POST /api/dev/handle-testnet-reset to recover.');
+      }
+    }).catch(() => {});
+  }
 });
 
 async function shutdown(signal) {

--- a/backend/src/routes/dev.js
+++ b/backend/src/routes/dev.js
@@ -1,6 +1,8 @@
 const router = require('express').Router();
 const authMiddleware = require('../middleware/auth');
 const db = require('../db');
+const { detectTestnetReset, refundTestnetWallets } = require('../services/stellar');
+const logger = require('../utils/logger');
 
 // Block entirely outside development
 router.use((req, res, next) => {
@@ -26,6 +28,42 @@ router.post('/fund-wallet', authMiddleware, async (req, res, next) => {
     }
 
     res.json({ message: 'Wallet funded with 10,000 test XLM', public_key });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/dev/handle-testnet-reset
+ * Re-funds all testnet wallets via Friendbot and clears stale transaction records.
+ * Only available in development mode.
+ */
+router.post('/handle-testnet-reset', async (req, res, next) => {
+  try {
+    const resetDetected = await detectTestnetReset();
+    if (!resetDetected) {
+      return res.json({ reset: false, message: 'No testnet reset detected. Canary account is alive.' });
+    }
+
+    logger.warn('Testnet reset confirmed — re-funding wallets and clearing stale records');
+
+    // Fetch all wallet public keys
+    const { rows: wallets } = await db.query('SELECT public_key FROM wallets');
+    const publicKeys = wallets.map((w) => w.public_key);
+
+    // Re-fund via Friendbot
+    const fundResults = await refundTestnetWallets(publicKeys);
+
+    // Clear stale transaction records
+    await db.query("DELETE FROM transactions WHERE status != 'failed'");
+
+    logger.info('Testnet reset recovery complete', { walletsRefunded: publicKeys.length });
+
+    res.json({
+      reset: true,
+      message: 'Testnet reset handled: wallets re-funded and stale transactions cleared.',
+      wallets: fundResults,
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -11,6 +11,7 @@ const {
   history,
   exportCSV,
   estimateFee,
+  getFeeStats,
   findPath,
   sendPath,
 } = require("../controllers/paymentController");
@@ -65,6 +66,7 @@ const validate = (req, res, next) => {
 router.use(authMiddleware);
 
 router.get("/estimate-fee", estimateFee);
+router.get("/fee-stats", getFeeStats);
 
 router.post("/send", paymentSendValidators, validate, idempotency, send);
 router.post("/batch", paymentBatchValidators, validate, idempotency, sendBatch);

--- a/backend/src/services/horizonWorker.js
+++ b/backend/src/services/horizonWorker.js
@@ -13,20 +13,25 @@ const server = new StellarSdk.Horizon.Server(
   process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org'
 );
 
-// Map of publicKey -> close() function for active streams
+// Map of publicKey -> { close, cursor } for active streams
 const activeStreams = new Map();
 
-async function startStreamForUser(userId, publicKey) {
+async function startStreamForUser(userId, publicKey, cursor = 'now') {
   if (activeStreams.has(publicKey)) return;
 
-  logger.info('Starting Horizon stream', { userId, publicKey });
+  logger.info('Starting Horizon stream', { userId, publicKey, cursor });
+
+  let lastCursor = cursor;
 
   const close = server
     .payments()
     .forAccount(publicKey)
-    .cursor('now')
+    .cursor(lastCursor)
     .stream({
       onmessage: async (payment) => {
+        // Track cursor for reconnection
+        if (payment.paging_token) lastCursor = payment.paging_token;
+
         // Only care about incoming payments to this account
         if (
           payment.type !== 'payment' ||
@@ -49,8 +54,9 @@ async function startStreamForUser(userId, publicKey) {
       onerror: (err) => {
         logger.warn('Horizon stream error', { publicKey, error: err.message });
         activeStreams.delete(publicKey);
-        // Reconnect after 10 s
-        setTimeout(() => startStreamForUser(userId, publicKey), 10_000);
+        wsConnections.set(activeStreams.size);
+        // Reconnect after 10 s, resuming from last seen cursor
+        setTimeout(() => startStreamForUser(userId, publicKey, lastCursor), 10_000);
       },
     });
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -377,7 +377,8 @@ async function _sendPaymentOnce({
   amount,
   asset = 'XLM',
   memo,
-  memoType = 'text'
+  memoType = 'text',
+  feePriority = 'standard',
 }, logger) {
   const assetObj = resolveAsset(asset);
 
@@ -395,16 +396,7 @@ async function _sendPaymentOnce({
       const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey), logger);
 
       const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-        fee: await withFallback(s => s.fetchBaseFee(), logger),
-      const senderAccount = validateHorizonResponse(
-        AccountResponseSchema,
-        await withFallback(s => s.loadAccount(senderPublicKey)),
-        'loadAccount(sender)'
-      );
-      const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount');
-
-      const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-        fee: await withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'),
+        fee: await feeForPriority(feePriority),
         networkPassphrase
       })
         .addOperation(StellarSdk.Operation.payment({
@@ -590,6 +582,37 @@ async function getTransactions(publicKey, limit = 20) {
 
 async function fetchFee() {
   return withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' });
+}
+
+/**
+ * Fetch fee statistics from Horizon and return key percentiles.
+ * Returns { min, p10, p50, p90, p99 } in stroops.
+ */
+async function fetchFeeStats() {
+  const stats = await withRetry(() => withFallback(s => s.feeStats()), { label: 'feeStats' });
+  const fp = stats.fee_charged;
+  return {
+    min: parseInt(fp.min, 10),
+    p10: parseInt(fp.p10, 10),
+    p50: parseInt(fp.p50, 10),
+    p90: parseInt(fp.p90, 10),
+    p99: parseInt(fp.p99, 10),
+  };
+}
+
+/**
+ * Build a TransactionBuilder fee from a priority string.
+ * priority: 'economy' | 'standard' | 'priority'
+ * Falls back to base fee if feeStats is unavailable.
+ */
+async function feeForPriority(priority = 'standard') {
+  try {
+    const stats = await fetchFeeStats();
+    const map = { economy: stats.p10, standard: stats.p50, priority: stats.p90 };
+    return map[priority] ?? stats.p50;
+  } catch {
+    return withRetry(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee(fallback)' });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -941,10 +964,59 @@ async function getDataEntries(publicKey) {
 }
 
 // ---------------------------------------------------------------------------
-// Exports
+// Testnet reset detection
 // ---------------------------------------------------------------------------
 
+/**
+ * Detect whether the configured Horizon is a freshly-reset testnet by checking
+ * whether a known "canary" account still exists.  If the account is gone the
+ * testnet was reset and all local data is stale.
+ *
+ * @param {string} canaryPublicKey - A public key that should exist on a live testnet.
+ *   Defaults to the Stellar Foundation's well-known testnet account.
+ * @returns {Promise<boolean>} true if a reset is detected
+ */
+async function detectTestnetReset(canaryPublicKey) {
+  if (!isTestnet) return false;
+  const key = canaryPublicKey || process.env.TESTNET_CANARY_ACCOUNT || 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+  try {
+    await withFallback(s => s.loadAccount(key));
+    return false; // account exists — no reset
+  } catch (e) {
+    if (e.response?.status === 404) {
+      logger.warn('Testnet reset detected: canary account not found', { canaryPublicKey: key });
+      return true;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Re-fund a list of testnet wallets via Friendbot.
+ * @param {string[]} publicKeys
+ */
+async function refundTestnetWallets(publicKeys) {
+  if (!isTestnet) throw new Error('refundTestnetWallets is only available on testnet');
+  const results = await Promise.allSettled(
+    publicKeys.map(async (pk) => {
+      const res = await fetch(`https://friendbot.stellar.org?addr=${pk}`);
+      if (!res.ok) throw new Error(`Friendbot failed for ${pk}: ${await res.text()}`);
+      return pk;
+    })
+  );
+  return results.map((r, i) => ({
+    publicKey: publicKeys[i],
+    success: r.status === 'fulfilled',
+    error: r.reason?.message || null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
 module.exports = {
+  detectTestnetReset,
+  refundTestnetWallets,
   createWallet,
   getBalance,
   getAccountSigners,
@@ -955,6 +1027,8 @@ module.exports = {
   encryptPrivateKey,
   decryptPrivateKey,
   fetchFee,
+  fetchFeeStats,
+  feeForPriority,
   checkHorizonHealth,
   findPaymentPath,
   sendPathPayment,
@@ -970,4 +1044,6 @@ module.exports = {
   clawbackAsset,
   setDataEntry,
   getDataEntries,
+  server,
+  isTestnet,
 };

--- a/frontend/src/hooks/usePaymentStream.js
+++ b/frontend/src/hooks/usePaymentStream.js
@@ -2,51 +2,70 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import * as StellarSdk from '@stellar/stellar-sdk';
 
 const HORIZON_URL = process.env.REACT_APP_STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
-const isTestnet = process.env.REACT_APP_STELLAR_NETWORK !== 'mainnet';
-const networkPassphrase = isTestnet
-  ? StellarSdk.Networks.TESTNET
-  : StellarSdk.Networks.PUBLIC;
+const MAX_RECONNECT_ATTEMPTS = 10;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30_000;
 
 /**
- * Hook to stream real-time payment notifications from Stellar Horizon
+ * Hook to stream real-time payment notifications from Stellar Horizon.
+ * Tracks the last seen cursor so reconnections resume from where they left off.
+ *
  * @param {string} publicKey - The account public key to monitor
  * @param {Function} onPayment - Callback when a new payment is detected
- * @returns {Object} { isConnected, error, reconnect }
+ * @returns {{ isConnected: boolean, isReconnecting: boolean, error: string|null, reconnect: Function }}
  */
 export function usePaymentStream(publicKey, onPayment) {
   const [isConnected, setIsConnected] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const [error, setError] = useState(null);
+
   const streamRef = useRef(null);
   const reconnectTimeoutRef = useRef(null);
   const reconnectAttemptsRef = useRef(0);
-  const maxReconnectAttempts = 5;
-  const baseReconnectDelay = 1000; // 1 second
+  // Persist the last seen payment paging_token so we can resume on reconnect
+  const lastCursorRef = useRef('now');
+  const onPaymentRef = useRef(onPayment);
+
+  // Keep callback ref fresh without triggering reconnects
+  useEffect(() => { onPaymentRef.current = onPayment; }, [onPayment]);
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+  };
 
   const connect = useCallback(() => {
     if (!publicKey) return;
 
+    // Close any existing stream before opening a new one
+    if (streamRef.current) {
+      streamRef.current();
+      streamRef.current = null;
+    }
+
     try {
       const server = new StellarSdk.Horizon.Server(HORIZON_URL);
-      
-      // Close existing stream if any
-      if (streamRef.current) {
-        streamRef.current();
-      }
 
       streamRef.current = server
         .payments()
         .forAccount(publicKey)
-        .cursor('now')
+        .cursor(lastCursorRef.current)
         .stream({
           onmessage: (payment) => {
-            // Reset reconnect attempts on successful message
+            // Advance cursor so a reconnect resumes after this payment
+            if (payment.paging_token) {
+              lastCursorRef.current = payment.paging_token;
+            }
+
             reconnectAttemptsRef.current = 0;
-            setError(null);
             setIsConnected(true);
-            
-            // Call the callback with payment data
-            if (onPayment) {
-              onPayment({
+            setIsReconnecting(false);
+            setError(null);
+
+            if (onPaymentRef.current) {
+              onPaymentRef.current({
                 id: payment.id,
                 type: payment.type,
                 from: payment.from,
@@ -59,87 +78,75 @@ export function usePaymentStream(publicKey, onPayment) {
             }
           },
           onerror: (err) => {
-            console.error('Payment stream error:', err);
-            setError(err.message || 'Stream error');
+            console.warn('Payment stream disconnected:', err?.message || err);
             setIsConnected(false);
-            
-            // Attempt to reconnect with exponential backoff
-            if (reconnectAttemptsRef.current < maxReconnectAttempts) {
-              const delay = baseReconnectDelay * Math.pow(2, reconnectAttemptsRef.current);
+
+            const attempt = reconnectAttemptsRef.current;
+            if (attempt < MAX_RECONNECT_ATTEMPTS) {
+              const delay = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
               reconnectAttemptsRef.current += 1;
-              
-              reconnectTimeoutRef.current = setTimeout(() => {
-                connect();
-              }, delay);
+              setIsReconnecting(true);
+              setError(`Stream disconnected. Reconnecting in ${Math.round(delay / 1000)}s… (attempt ${attempt + 1})`);
+              reconnectTimeoutRef.current = setTimeout(connect, delay);
+            } else {
+              setIsReconnecting(false);
+              setError('Stream disconnected. Max reconnect attempts reached.');
             }
           },
           onclose: () => {
             setIsConnected(false);
-          }
+          },
         });
 
       setIsConnected(true);
+      setIsReconnecting(false);
       setError(null);
     } catch (err) {
-      console.error('Failed to connect to payment stream:', err);
-      setError(err.message || 'Failed to connect');
+      console.error('Failed to open payment stream:', err);
       setIsConnected(false);
+      setError(err.message || 'Failed to connect');
     }
-  }, [publicKey, onPayment]);
+  }, [publicKey]);
 
   const disconnect = useCallback(() => {
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    
+    clearReconnectTimer();
     if (streamRef.current) {
       streamRef.current();
       streamRef.current = null;
     }
-    
     setIsConnected(false);
+    setIsReconnecting(false);
   }, []);
 
   const reconnect = useCallback(() => {
-    disconnect();
+    clearReconnectTimer();
     reconnectAttemptsRef.current = 0;
     connect();
-  }, [connect, disconnect]);
+  }, [connect]);
 
-  // Connect on mount and when publicKey changes
+  // Connect / reconnect when publicKey changes
   useEffect(() => {
     if (publicKey) {
+      lastCursorRef.current = 'now';
+      reconnectAttemptsRef.current = 0;
       connect();
     }
-
-    return () => {
-      disconnect();
-    };
+    return disconnect;
   }, [publicKey, connect, disconnect]);
 
-  // Handle network interruption
+  // Resume stream when the browser comes back online
   useEffect(() => {
-    const handleOnline = () => {
-      if (publicKey && !isConnected) {
-        reconnect();
-      }
-    };
-
-    const handleOffline = () => {
-      setIsConnected(false);
-    };
-
+    const handleOnline = () => { if (publicKey && !isConnected) reconnect(); };
+    const handleOffline = () => { setIsConnected(false); };
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
-
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
   }, [publicKey, isConnected, reconnect]);
 
-  return { isConnected, error, reconnect, disconnect };
+  return { isConnected, isReconnecting, error, reconnect, disconnect };
 }
 
 export default usePaymentStream;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -62,7 +62,7 @@ export default function Dashboard() {
     [wallet?.public_key],
   );
 
-  const { isConnected, error: streamError } = usePaymentStream(wallet?.public_key, handlePayment);
+  const { isConnected, isReconnecting, error: streamError } = usePaymentStream(wallet?.public_key, handlePayment);
 
   const loadDashboard = useCallback(async () => {
     if (!navigator.onLine) {
@@ -224,6 +224,14 @@ export default function Dashboard() {
           >
             {funding ? 'Funding…' : 'Fund wallet'}
           </button>
+        </div>
+      )}
+
+      {/* Stream reconnecting indicator */}
+      {isReconnecting && (
+        <div className="flex items-center gap-2 bg-orange-500/10 border border-orange-500/30 rounded-xl px-4 py-2 text-orange-400 text-sm">
+          <div className="w-3 h-3 border-2 border-orange-400 border-t-transparent rounded-full animate-spin" />
+          <span>Reconnecting to live updates…</span>
         </div>
       )}
 

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -23,8 +23,10 @@ export default function SendMoney() {
     memo: searchParams.get('memo') || '',
     destination_asset: '',
     slippage: DEFAULT_SLIPPAGE,
-    memo_type: 'text'
+    memo_type: 'text',
+    fee_priority: 'standard',
   });
+  const [feeStats, setFeeStats] = useState(null);
   const [contacts, setContacts] = useState([]);
   const [showContacts, setShowContacts] = useState(false);
   const [contactSearch, setContactSearch] = useState('');
@@ -62,6 +64,10 @@ export default function SendMoney() {
     availableXlm !== null &&
     form.amount &&
     parseFloat(form.amount) > availableXlm;
+
+  useEffect(() => {
+    api.get('/payments/fee-stats').then((r) => setFeeStats(r.data)).catch(() => {});
+  }, []);
 
   useEffect(() => {
     api.get('/wallet/list').then((r) => {
@@ -285,6 +291,7 @@ export default function SendMoney() {
           amount: parseFloat(form.amount),
           asset: form.asset,
           wallet_id: selectedWallet?.id || undefined,
+          fee_priority: form.fee_priority,
         };
         if (m) {
           payload.memo = m;
@@ -591,6 +598,37 @@ export default function SendMoney() {
               )}
             </div>
           )}
+        </div>
+
+        {/* Fee Priority */}
+        <div>
+          <label className="text-sm text-gray-400 mb-1 block">Network fee priority</label>
+          <div className="flex gap-2">
+            {[
+              { key: 'economy', label: 'Economy', desc: 'Slower' },
+              { key: 'standard', label: 'Standard', desc: 'Normal' },
+              { key: 'priority', label: 'Priority', desc: 'Faster' },
+            ].map(({ key, label, desc }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setForm({ ...form, fee_priority: key })}
+                className={`flex-1 rounded-xl border py-2 px-2 text-center transition-colors ${
+                  form.fee_priority === key
+                    ? 'border-primary-500 bg-primary-500/10 text-primary-400'
+                    : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-500'
+                }`}
+              >
+                <p className="text-xs font-semibold">{label}</p>
+                <p className="text-xs text-gray-500">{desc}</p>
+                {feeStats && (
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {(feeStats.priorities[key] / 1e7).toFixed(5)} XLM
+                  </p>
+                )}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Memo */}

--- a/frontend/src/pages/TransactionHistory.jsx
+++ b/frontend/src/pages/TransactionHistory.jsx
@@ -16,8 +16,9 @@ const STATUS_COLORS = {
 
 const ASSET_OPTIONS = ['XLM', 'USDC', 'NGN', 'GHS', 'KES'];
 
-function buildHistoryParams(pageNum, dateFrom, dateTo, asset) {
-  const params = { page: pageNum, limit: 20 };
+function buildHistoryParams(cursor, dateFrom, dateTo, asset) {
+  const params = { limit: 20 };
+  if (cursor) params.cursor = cursor;
   if (dateFrom) params.from = dateFrom;
   if (dateTo) params.to = dateTo;
   if (asset) params.asset = asset;
@@ -32,7 +33,7 @@ export default function TransactionHistory() {
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [filter, setFilter] = useState('all');
-  const [page, setPage] = useState(1);
+  const [nextCursor, setNextCursor] = useState(null);
   const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState(null);
   const [fromCache, setFromCache] = useState(false);
@@ -49,7 +50,7 @@ export default function TransactionHistory() {
   const fetchInitial = useCallback(async () => {
     setLoading(true);
     setError(null);
-    setPage(1);
+    setNextCursor(null);
 
     // Offline — serve from IndexedDB cache
     if (!navigator.onLine) {
@@ -74,12 +75,12 @@ export default function TransactionHistory() {
 
     // Online — fetch fresh and persist
     try {
-      const params = buildHistoryParams(1, dateFrom, dateTo, asset);
+      const params = buildHistoryParams(null, dateFrom, dateTo, asset);
       const r = await api.get('/payments/history', { params });
       const txList = r.data.transactions;
       setTransactions(txList);
-      setHasMore(r.data.page < r.data.pages);
-      setPage(1);
+      setHasMore(r.data.has_more);
+      setNextCursor(r.data.next_cursor || null);
       setFromCache(false);
 
       // Only cache the unfiltered first page (no date/asset filters)
@@ -114,15 +115,15 @@ export default function TransactionHistory() {
   }, [fetchInitial]);
 
   const loadMore = () => {
-    const nextPage = page + 1;
+    if (!nextCursor) return;
     setLoadingMore(true);
-    const params = buildHistoryParams(nextPage, dateFrom, dateTo, asset);
+    const params = buildHistoryParams(nextCursor, dateFrom, dateTo, asset);
     api
       .get('/payments/history', { params })
       .then((r) => {
         setTransactions((prev) => [...prev, ...r.data.transactions]);
-        setPage(nextPage);
-        setHasMore(nextPage < r.data.pages);
+        setHasMore(r.data.has_more);
+        setNextCursor(r.data.next_cursor || null);
       })
       .catch(() => {})
       .finally(() => setLoadingMore(false));


### PR DESCRIPTION
Here's a quick summary of what was implemented:

#134 — Fee Priority Selector

fetchFeeStats() and feeForPriority() added to stellar.js using Horizon's feeStats() API
GET /api/payments/fee-stats endpoint returns min/p10/p50/p90/p99 + priority map
SendMoney.jsx has an Economy/Standard/Priority selector that shows live stroop costs and passes fee_priority to the payment payload
#131 — Cursor Pagination

history() in paymentController.js now uses WHERE id < $cursor ORDER BY id DESC LIMIT n+1 — no more COUNT(*) or OFFSET
Response shape changed to { transactions, next_cursor, has_more }
TransactionHistory.jsx "Load More" passes next_cursor instead of incrementing a page number
#132 — Stream Reconnection

usePaymentStream.js tracks paging_token as a cursor ref, resumes from it on reconnect with exponential backoff (up to 30s cap, 10 attempts)
Exposes isReconnecting state; Dashboard.jsx shows an orange "Reconnecting…" banner
horizonWorker.js server-side streams also resume from last cursor on error
#133 — Testnet Reset Handling

detectTestnetReset() checks a canary account; refundTestnetWallets() hits Friendbot for all wallets
POST /api/dev/handle-testnet-reset re-funds wallets and clears stale transactions (dev only)
index.js logs a warning at startup if a reset is detected

closes #131 
closes #132 
closes #133 
closes #134 