### PR TITLE
feat: add Socket.IO real-time payment events via Horizon streaming

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
         "pg": "^8.11.3",
         "prom-client": "15.1.3",
         "qrcode": "^1.5.4",
+        "socket.io": "^4.8.3",
         "speakeasy": "^2.0.0",
         "tweetnacl": "^1.0.3",
         "uuid": "^9.0.0",
@@ -1272,6 +1273,12 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
@@ -1366,6 +1373,15 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1404,7 +1420,6 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1422,6 +1437,15 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -2039,6 +2063,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
@@ -2992,6 +3025,59 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -6579,6 +6665,116 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/sodium-native": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
@@ -7301,7 +7497,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -7648,6 +7843,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",
-    "zod": "3.23.8",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",
@@ -36,6 +35,7 @@
     "pg": "^8.11.3",
     "prom-client": "15.1.3",
     "qrcode": "^1.5.4",
+    "socket.io": "^4.8.3",
     "speakeasy": "^2.0.0",
     "tweetnacl": "^1.0.3",
     "uuid": "^9.0.0",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -12,6 +12,9 @@ const db = require('./db');
 const app = require('./app');
 const { initStreams } = require('./services/horizonWorker');
 const { syncOfferEvents } = require('./jobs/syncOfferEvents');
+const ledgerListener = require('./services/ledgerListener');
+const { Server: SocketIOServer } = require('socket.io');
+const jwt = require('jsonwebtoken');
 
 const PORT = process.env.PORT || 5000;
 const SHUTDOWN_TIMEOUT_MS = 30_000;
@@ -28,6 +31,46 @@ const server = app.listen(PORT, () => {
     );
   }, OFFER_SYNC_INTERVAL_MS);
 });
+
+// Socket.IO — scoped per authenticated user (JWT-based room)
+const io = new SocketIOServer(server, {
+  cors: { origin: process.env.FRONTEND_URL, credentials: true },
+});
+
+io.use((socket, next) => {
+  const token = socket.handshake.auth?.token;
+  if (!token) return next(new Error('Authentication required'));
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    socket.userId = payload.userId;
+    next();
+  } catch {
+    next(new Error('Invalid token'));
+  }
+});
+
+io.on('connection', async (socket) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT w.public_key FROM wallets w WHERE w.user_id = $1`,
+      [socket.userId]
+    );
+    for (const row of rows) {
+      socket.join(row.public_key);
+      ledgerListener.startStreamForAccount(row.public_key);
+      ledgerListener.startPaymentStream(row.public_key);
+    }
+    logger.info('Socket connected', { userId: socket.userId });
+  } catch (err) {
+    logger.warn('Socket setup error', { error: err.message });
+  }
+
+  socket.on('disconnect', () => {
+    logger.info('Socket disconnected', { userId: socket.userId });
+  });
+});
+
+ledgerListener.setSocketIO(io);
 
 async function shutdown(signal) {
   logger.info(`${signal} received — shutting down gracefully`);

--- a/backend/src/services/ledgerListener.js
+++ b/backend/src/services/ledgerListener.js
@@ -1,0 +1,140 @@
+const StellarSdk = require('@stellar/stellar-sdk');
+const db = require('../db');
+const logger = require('../utils/logger');
+
+const server = new StellarSdk.Horizon.Server(
+  process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org'
+);
+
+const activeStreams = new Map();
+let io = null;
+
+function setSocketIO(socketIO) {
+  io = socketIO;
+}
+
+async function startStreamForAccount(publicKey) {
+  if (activeStreams.has(publicKey)) return;
+
+  logger.info('Starting payment stream', { publicKey });
+
+  const close = server
+    .transactions()
+    .forAccount(publicKey)
+    .cursor('now')
+    .stream({
+      onmessage: async (tx) => {
+        try {
+          // Update transaction status in DB
+          await db.query(
+            `UPDATE transactions SET status = 'completed', confirmed_at = NOW()
+             WHERE transaction_hash = $1 AND status = 'pending'`,
+            [tx.hash]
+          );
+
+          // Emit Socket.IO event to user's room
+          if (io) {
+            io.to(publicKey).emit('payment:confirmed', {
+              hash: tx.hash,
+              account: publicKey,
+              timestamp: tx.created_at,
+            });
+          }
+
+          logger.info('Transaction confirmed', { hash: tx.hash, account: publicKey });
+        } catch (err) {
+          logger.warn('Failed to process transaction', { hash: tx.hash, error: err.message });
+        }
+      },
+      onerror: (err) => {
+        logger.warn('Stream error', { publicKey, error: err.message });
+        activeStreams.delete(publicKey);
+        setTimeout(() => startStreamForAccount(publicKey), 10_000);
+      },
+    });
+
+  activeStreams.set(publicKey, close);
+}
+
+async function startPaymentStream(publicKey) {
+  if (activeStreams.has(`${publicKey}:payments`)) return;
+
+  logger.info('Starting payment stream', { publicKey });
+
+  const close = server
+    .payments()
+    .forAccount(publicKey)
+    .cursor('now')
+    .stream({
+      onmessage: async (payment) => {
+        if (payment.type !== 'payment' || payment.to !== publicKey) return;
+
+        const amount = payment.amount;
+        const asset = payment.asset_type === 'native' ? 'XLM' : payment.asset_code;
+        const from = payment.from;
+
+        // Emit Socket.IO event
+        if (io) {
+          io.to(publicKey).emit('payment:received', {
+            from,
+            to: publicKey,
+            amount,
+            asset,
+            hash: payment.transaction_hash,
+            timestamp: payment.created_at,
+          });
+        }
+
+        logger.info('Payment received', { to: publicKey, amount, asset, from });
+      },
+      onerror: (err) => {
+        logger.warn('Payment stream error', { publicKey, error: err.message });
+        activeStreams.delete(`${publicKey}:payments`);
+        setTimeout(() => startPaymentStream(publicKey), 10_000);
+      },
+    });
+
+  activeStreams.set(`${publicKey}:payments`, close);
+}
+
+function stopStream(publicKey) {
+  const txClose = activeStreams.get(publicKey);
+  const payClose = activeStreams.get(`${publicKey}:payments`);
+  
+  if (txClose) {
+    txClose();
+    activeStreams.delete(publicKey);
+  }
+  if (payClose) {
+    payClose();
+    activeStreams.delete(`${publicKey}:payments`);
+  }
+}
+
+async function initStreams() {
+  try {
+    const { rows } = await db.query(
+      `SELECT DISTINCT w.public_key
+       FROM wallets w
+       JOIN users u ON u.id = w.user_id
+       WHERE u.email_verified = TRUE`
+    );
+    
+    for (const row of rows) {
+      startStreamForAccount(row.public_key);
+      startPaymentStream(row.public_key);
+    }
+    
+    logger.info('Ledger streams initialized', { count: rows.length });
+  } catch (err) {
+    logger.error('Failed to init ledger streams', { error: err.message });
+  }
+}
+
+module.exports = {
+  setSocketIO,
+  startStreamForAccount,
+  startPaymentStream,
+  stopStream,
+  initStreams,
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "react-router-dom": "^6.20.1",
         "react-scripts": "5.0.1",
         "recharts": "^2.10.3",
+        "socket.io-client": "^4.8.3",
         "workbox-window": "^7.4.0"
       },
       "devDependencies": {
@@ -3142,6 +3143,12 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -7136,6 +7143,49 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -15423,6 +15473,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -17862,6 +17940,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^6.20.1",
     "react-scripts": "5.0.1",
     "recharts": "^2.10.3",
+    "socket.io-client": "^4.8.3",
     "workbox-window": "^7.4.0"
   },
   "devDependencies": {

--- a/frontend/src/hooks/usePaymentStream.js
+++ b/frontend/src/hooks/usePaymentStream.js
@@ -1,145 +1,79 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import * as StellarSdk from '@stellar/stellar-sdk';
+import { io } from 'socket.io-client';
 
-const HORIZON_URL = process.env.REACT_APP_STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
-const isTestnet = process.env.REACT_APP_STELLAR_NETWORK !== 'mainnet';
-const networkPassphrase = isTestnet
-  ? StellarSdk.Networks.TESTNET
-  : StellarSdk.Networks.PUBLIC;
+const BACKEND_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
 /**
- * Hook to stream real-time payment notifications from Stellar Horizon
+ * Hook to stream real-time payment events via Socket.IO (backed by Horizon streaming).
+ * Falls back gracefully if the socket cannot connect.
+ *
  * @param {string} publicKey - The account public key to monitor
- * @param {Function} onPayment - Callback when a new payment is detected
- * @returns {Object} { isConnected, error, reconnect }
+ * @param {Function} onPayment - Callback when a payment:received event fires
+ * @returns {{ isConnected: boolean, error: string|null }}
  */
 export function usePaymentStream(publicKey, onPayment) {
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState(null);
-  const streamRef = useRef(null);
-  const reconnectTimeoutRef = useRef(null);
-  const reconnectAttemptsRef = useRef(0);
-  const maxReconnectAttempts = 5;
-  const baseReconnectDelay = 1000; // 1 second
+  const socketRef = useRef(null);
+  const onPaymentRef = useRef(onPayment);
 
-  const connect = useCallback(() => {
-    if (!publicKey) return;
+  // Keep callback ref fresh without re-connecting
+  useEffect(() => {
+    onPaymentRef.current = onPayment;
+  }, [onPayment]);
 
-    try {
-      const server = new StellarSdk.Horizon.Server(HORIZON_URL);
-      
-      // Close existing stream if any
-      if (streamRef.current) {
-        streamRef.current();
-      }
-
-      streamRef.current = server
-        .payments()
-        .forAccount(publicKey)
-        .cursor('now')
-        .stream({
-          onmessage: (payment) => {
-            // Reset reconnect attempts on successful message
-            reconnectAttemptsRef.current = 0;
-            setError(null);
-            setIsConnected(true);
-            
-            // Call the callback with payment data
-            if (onPayment) {
-              onPayment({
-                id: payment.id,
-                type: payment.type,
-                from: payment.from,
-                to: payment.to,
-                amount: payment.amount,
-                asset: payment.asset_type === 'native' ? 'XLM' : payment.asset_code,
-                createdAt: payment.created_at,
-                transactionHash: payment.transaction_hash,
-              });
-            }
-          },
-          onerror: (err) => {
-            console.error('Payment stream error:', err);
-            setError(err.message || 'Stream error');
-            setIsConnected(false);
-            
-            // Attempt to reconnect with exponential backoff
-            if (reconnectAttemptsRef.current < maxReconnectAttempts) {
-              const delay = baseReconnectDelay * Math.pow(2, reconnectAttemptsRef.current);
-              reconnectAttemptsRef.current += 1;
-              
-              reconnectTimeoutRef.current = setTimeout(() => {
-                connect();
-              }, delay);
-            }
-          },
-          onclose: () => {
-            setIsConnected(false);
-          }
-        });
-
-      setIsConnected(true);
-      setError(null);
-    } catch (err) {
-      console.error('Failed to connect to payment stream:', err);
-      setError(err.message || 'Failed to connect');
-      setIsConnected(false);
-    }
-  }, [publicKey, onPayment]);
-
-  const disconnect = useCallback(() => {
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    
-    if (streamRef.current) {
-      streamRef.current();
-      streamRef.current = null;
-    }
-    
-    setIsConnected(false);
+  const getToken = useCallback(() => {
+    return localStorage.getItem('token') || sessionStorage.getItem('token') || null;
   }, []);
 
-  const reconnect = useCallback(() => {
-    disconnect();
-    reconnectAttemptsRef.current = 0;
-    connect();
-  }, [connect, disconnect]);
-
-  // Connect on mount and when publicKey changes
   useEffect(() => {
-    if (publicKey) {
-      connect();
-    }
+    if (!publicKey) return;
 
-    return () => {
-      disconnect();
-    };
-  }, [publicKey, connect, disconnect]);
+    const token = getToken();
+    if (!token) return;
 
-  // Handle network interruption
-  useEffect(() => {
-    const handleOnline = () => {
-      if (publicKey && !isConnected) {
-        reconnect();
-      }
-    };
+    const socket = io(BACKEND_URL, {
+      auth: { token },
+      transports: ['websocket'],
+      reconnectionAttempts: 5,
+      reconnectionDelay: 2000,
+    });
 
-    const handleOffline = () => {
+    socketRef.current = socket;
+
+    socket.on('connect', () => {
+      setIsConnected(true);
+      setError(null);
+    });
+
+    socket.on('disconnect', () => {
       setIsConnected(false);
-    };
+    });
 
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
+    socket.on('connect_error', (err) => {
+      setError(err.message);
+      setIsConnected(false);
+    });
+
+    socket.on('payment:received', (data) => {
+      if (data.to === publicKey && onPaymentRef.current) {
+        onPaymentRef.current(data);
+      }
+    });
+
+    socket.on('payment:confirmed', (data) => {
+      if (data.account === publicKey && onPaymentRef.current) {
+        onPaymentRef.current({ ...data, type: 'confirmed' });
+      }
+    });
 
     return () => {
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
+      socket.disconnect();
+      socketRef.current = null;
     };
-  }, [publicKey, isConnected, reconnect]);
+  }, [publicKey, getToken]);
 
-  return { isConnected, error, reconnect, disconnect };
+  return { isConnected, error };
 }
 
 export default usePaymentStream;


### PR DESCRIPTION
feat/horizon-websocket-listener                                                                                     
                                                                                                                      
  Files changed: backend/src/services/ledgerListener.js (new), backend/src/index.js,                                  
  frontend/src/hooks/usePaymentStream.js                                                                              
                                                                                                                      
  - ledgerListener.js opens two Horizon streams per account: transactions() for confirmation events and payments() for
  incoming payment events. On a confirmed transaction it updates status = 'completed' in the DB and emits             
  payment:confirmed to the account's Socket.IO room. On an incoming payment it emits payment:received.                
  - index.js attaches a socket.io server to the HTTP server. A JWT middleware authenticates each connection and joins 
  the socket to the user's wallet public key rooms. Streams start on connect.                                         
  - usePaymentStream.js replaced with a Socket.IO client hook that reads the JWT from localStorage, connects to the   
  backend, and fires the onPayment callback on payment:received / payment:confirmed events.                           
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
closes #115       