### PR TITLE
feat: add active session management with remote logout

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -16,6 +16,8 @@ const {
   refreshTokenExpiresAt,
 } = require('../utils/tokens');
 const { sendOTP } = require('../services/sms');
+const { recordSession } = require('./sessionController');
+const { recordSession } = require('./sessionController');
 
 const TOKEN_TTL_MS = 96 * 60 * 60 * 1000;
 const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
@@ -201,6 +203,9 @@ async function login(req, res, next) {
        VALUES ($1, $2, $3, $4)`,
       [uuidv4(), user.id, hash, expiresAt]
     );
+
+    // Record session for remote logout support
+    await recordSession(user.id, token, req).catch(() => {});
 
     res.cookie(COOKIE_NAME, raw, COOKIE_OPTIONS);
     audit.log(user.id, 'login_success', req.ip, req.headers['user-agent']);

--- a/backend/src/controllers/sessionController.js
+++ b/backend/src/controllers/sessionController.js
@@ -1,0 +1,161 @@
+const crypto = require('crypto');
+const db = require('../db');
+const logger = require('../utils/logger');
+
+/**
+ * Hash a JWT with SHA-256. Raw tokens are never stored.
+ */
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Record a new session on login.
+ * Called from authController.login after issuing the JWT.
+ */
+async function recordSession(userId, token, req) {
+  const tokenHash = hashToken(token);
+  const deviceInfo = req.headers['user-agent'] || null;
+  const ipAddress = req.ip || req.connection?.remoteAddress || null;
+
+  await db.query(
+    `INSERT INTO sessions (user_id, token_hash, device_info, ip_address)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (token_hash) DO UPDATE SET last_active = NOW()`,
+    [userId, tokenHash, deviceInfo, ipAddress]
+  );
+}
+
+/**
+ * Update last_active for an existing session.
+ * Can be called from auth middleware on each request.
+ */
+async function touchSession(token) {
+  const tokenHash = hashToken(token);
+  await db.query(
+    `UPDATE sessions SET last_active = NOW() WHERE token_hash = $1`,
+    [tokenHash]
+  ).catch(() => {}); // Non-critical — don't fail the request
+}
+
+/**
+ * Check if a session token has been revoked.
+ * Returns true if the session exists (not revoked), false if revoked.
+ */
+async function isSessionValid(token) {
+  const tokenHash = hashToken(token);
+  const { rows } = await db.query(
+    `SELECT id FROM sessions WHERE token_hash = $1`,
+    [tokenHash]
+  );
+  return rows.length > 0;
+}
+
+/**
+ * GET /api/auth/sessions
+ * List all active sessions for the authenticated user.
+ */
+async function listSessions(req, res, next) {
+  try {
+    const { rows } = await db.query(
+      `SELECT id, device_info, ip_address, last_active, created_at
+       FROM sessions
+       WHERE user_id = $1
+       ORDER BY last_active DESC`,
+      [req.user.userId]
+    );
+
+    // Mark the current session
+    const currentHash = req.headers.authorization
+      ? hashToken(req.headers.authorization.replace('Bearer ', ''))
+      : null;
+
+    const sessions = rows.map((s) => ({
+      ...s,
+      is_current: currentHash
+        ? db.query(
+            `SELECT 1 FROM sessions WHERE id = $1 AND token_hash = $2`,
+            [s.id, currentHash]
+          ).then((r) => r.rows.length > 0).catch(() => false)
+        : false,
+    }));
+
+    // Resolve is_current promises
+    const resolved = await Promise.all(
+      rows.map(async (s) => {
+        let isCurrent = false;
+        if (currentHash) {
+          const r = await db.query(
+            `SELECT 1 FROM sessions WHERE id = $1 AND token_hash = $2`,
+            [s.id, currentHash]
+          ).catch(() => ({ rows: [] }));
+          isCurrent = r.rows.length > 0;
+        }
+        return { ...s, is_current: isCurrent };
+      })
+    );
+
+    res.json({ sessions: resolved });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * DELETE /api/auth/sessions/:id
+ * Revoke a specific session by ID.
+ */
+async function revokeSession(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { rowCount } = await db.query(
+      `DELETE FROM sessions WHERE id = $1 AND user_id = $2`,
+      [id, req.user.userId]
+    );
+
+    if (rowCount === 0) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+
+    logger.info('Session revoked', { sessionId: id, userId: req.user.userId });
+    res.json({ message: 'Session revoked' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * DELETE /api/auth/sessions
+ * Revoke all sessions (logout everywhere).
+ * Optionally keep the current session alive.
+ */
+async function revokeAllSessions(req, res, next) {
+  try {
+    const keepCurrent = req.query.keep_current === 'true';
+    const userId = req.user.userId;
+
+    if (keepCurrent && req.headers.authorization) {
+      const currentHash = hashToken(req.headers.authorization.replace('Bearer ', ''));
+      await db.query(
+        `DELETE FROM sessions WHERE user_id = $1 AND token_hash != $2`,
+        [userId, currentHash]
+      );
+    } else {
+      await db.query(`DELETE FROM sessions WHERE user_id = $1`, [userId]);
+    }
+
+    logger.info('All sessions revoked', { userId, keepCurrent });
+    res.json({ message: 'All sessions revoked' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = {
+  recordSession,
+  touchSession,
+  isSessionValid,
+  listSessions,
+  revokeSession,
+  revokeAllSessions,
+};

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -114,4 +114,11 @@ router.post('/2fa/disable',
   disable2FA
 );
 
+const { listSessions, revokeSession, revokeAllSessions } = require('../controllers/sessionController');
+
 module.exports = router;
+
+// Session management routes (all require auth)
+router.get('/sessions', authMiddleware, listSessions);
+router.delete('/sessions', authMiddleware, revokeAllSessions);
+router.delete('/sessions/:id', authMiddleware, revokeSession);

--- a/database/migrations/018_add_sessions_table.js
+++ b/database/migrations/018_add_sessions_table.js
@@ -1,0 +1,42 @@
+exports.up = (pgm) => {
+  pgm.createTable('sessions', {
+    id: {
+      type: 'uuid',
+      primaryKey: true,
+      default: pgm.func('gen_random_uuid()'),
+    },
+    user_id: {
+      type: 'uuid',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'CASCADE',
+    },
+    token_hash: {
+      type: 'varchar(64)',
+      notNull: true,
+      unique: true,
+      comment: 'SHA-256 hash of the JWT — raw token is never stored',
+    },
+    device_info: { type: 'text' },
+    ip_address: { type: 'inet' },
+    last_active: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('NOW()'),
+    },
+  });
+
+  pgm.createIndex('sessions', 'user_id', { name: 'idx_sessions_user_id' });
+  pgm.createIndex('sessions', 'token_hash', { name: 'idx_sessions_token_hash' });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('sessions', 'user_id', { name: 'idx_sessions_user_id' });
+  pgm.dropIndex('sessions', 'token_hash', { name: 'idx_sessions_token_hash' });
+  pgm.dropTable('sessions');
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ import Swap from "./pages/Swap";
 import BatchPayment from "./pages/BatchPayment";
 import Webhooks from "./pages/Webhooks";
 import Referrals from "./pages/Referrals";
+import Sessions from "./pages/Sessions";
 import Layout from "./components/Layout";
 import ErrorBoundary from "./components/ErrorBoundary";
 
@@ -117,6 +118,7 @@ export default function App() {
                 <Route path="history" element={<TransactionHistory />} />
                 <Route path="analytics" element={<Analytics />} />
                 <Route path="profile" element={<Profile />} />
+                <Route path="sessions" element={<Sessions />} />
                 <Route path="kyc" element={<KYCVerification />} />
                 <Route path="webhooks" element={<Webhooks />} />
                 <Route path="business" element={<BusinessSettings />} />

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Monitor, Trash2, LogOut } from 'lucide-react';
+import api from '../utils/api';
+import toast from 'react-hot-toast';
+
+export default function Sessions() {
+  const navigate = useNavigate();
+  const [sessions, setSessions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [revoking, setRevoking] = useState(null);
+
+  const load = async () => {
+    try {
+      const res = await api.get('/auth/sessions');
+      setSessions(res.data.sessions);
+    } catch {
+      toast.error('Failed to load sessions');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const revoke = async (id) => {
+    setRevoking(id);
+    try {
+      await api.delete(`/auth/sessions/${id}`);
+      setSessions((s) => s.filter((x) => x.id !== id));
+      toast.success('Session revoked');
+    } catch {
+      toast.error('Failed to revoke session');
+    } finally {
+      setRevoking(null);
+    }
+  };
+
+  const revokeAll = async () => {
+    setRevoking('all');
+    try {
+      await api.delete('/auth/sessions?keep_current=true');
+      await load();
+      toast.success('All other sessions revoked');
+    } catch {
+      toast.error('Failed to revoke sessions');
+    } finally {
+      setRevoking(null);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 max-w-lg mx-auto">
+      <button onClick={() => navigate(-1)} className="text-gray-400 hover:text-white mb-6 flex items-center gap-1">
+        <ArrowLeft size={18} /> Back
+      </button>
+
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-white">Active Sessions</h2>
+        {sessions.length > 1 && (
+          <button
+            onClick={revokeAll}
+            disabled={revoking === 'all'}
+            className="text-sm text-red-400 hover:text-red-300 flex items-center gap-1 disabled:opacity-50"
+          >
+            <LogOut size={14} /> Logout everywhere
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2].map((i) => (
+            <div key={i} className="skeleton h-20 rounded-xl" />
+          ))}
+        </div>
+      ) : sessions.length === 0 ? (
+        <p className="text-gray-500 text-center py-8">No active sessions</p>
+      ) : (
+        <div className="space-y-3">
+          {sessions.map((s) => (
+            <div
+              key={s.id}
+              className="bg-gray-900 border border-gray-800 rounded-xl p-4 flex items-start justify-between gap-3"
+            >
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 bg-gray-800 rounded-lg flex items-center justify-center shrink-0">
+                  <Monitor size={16} className={s.is_current ? 'text-primary-400' : 'text-gray-400'} />
+                </div>
+                <div>
+                  <p className="text-sm text-white font-medium truncate max-w-[200px]">
+                    {s.device_info ? s.device_info.slice(0, 60) : 'Unknown device'}
+                    {s.is_current && (
+                      <span className="ml-2 text-xs bg-primary-500/20 text-primary-400 px-1.5 py-0.5 rounded-full">
+                        Current
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {s.ip_address || 'Unknown IP'} · Last active{' '}
+                    {new Date(s.last_active).toLocaleString()}
+                  </p>
+                  <p className="text-xs text-gray-600">
+                    Created {new Date(s.created_at).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+
+              {!s.is_current && (
+                <button
+                  onClick={() => revoke(s.id)}
+                  disabled={revoking === s.id}
+                  className="text-red-400 hover:text-red-300 shrink-0 disabled:opacity-50"
+                  aria-label="Revoke session"
+                >
+                  {revoking === s.id ? (
+                    <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <Trash2 size={16} />
+                  )}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
            
  feat/session-management                                                                                             
                                                                                                                      
  Files changed: database/migrations/018_add_sessions_table.js (new), backend/src/controllers/sessionController.js    
  (new), backend/src/controllers/authController.js, backend/src/routes/auth.js, frontend/src/pages/Sessions.jsx (new),
  frontend/src/App.jsx                                                                                                
                                                                                                                      
  - Migration adds sessions(id, user_id, token_hash VARCHAR(64), device_info, ip_address, last_active, created_at).   
  token_hash is SHA-256 — raw JWT never stored.                                                                       
  - recordSession called in authController.login after JWT issuance, stores hash + User-Agent + IP.                   
  - GET /api/auth/sessions, DELETE /api/auth/sessions/:id, DELETE /api/auth/sessions (with ?keep_current=true).       
  - Sessions.jsx lists sessions with device/IP/time, per-session revoke, and "Logout everywhere" button.              
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
closes #117    