### PR TITLE
feat: add Sentry error reporting and Horizon history import

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,9 @@
 PORT=5000
 NODE_ENV=development
 
+# Sentry error tracking (leave empty to disable)
+SENTRY_DSN=https://your-dsn@sentry.io/project-id
+
 # Health checks: max wait (ms) for DB SELECT 1 and Horizon ledger probe (default 3000)
 # HEALTH_CHECK_TIMEOUT_MS=3000
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const cookieParser = require('cookie-parser');
+const Sentry = require('@sentry/node');
 
 const requestId = require('./middleware/requestId');
 const metricsMiddleware = require('./middleware/metricsMiddleware');
@@ -38,6 +39,7 @@ const { runHealthChecks } = require('./services/health');
 
 const app = express();
 
+app.use(Sentry.Handlers.requestHandler());
 app.use(requestId);
 app.use((req, res, next) => {
   req.logger = logger.child({ requestId: req.requestId });
@@ -179,6 +181,8 @@ app.get('/metrics', async (req, res) => {
   res.set('Content-Type', registry.contentType);
   res.end(await registry.metrics());
 });
+
+app.use(Sentry.Handlers.errorHandler());
 
 app.use((err, req, res, next) => {
   req.logger.error(err.message, { stack: err.stack, status: err.status });

--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -515,6 +515,25 @@ async function clearInflationDestinationHandler(req, res, next) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// POST /wallet/import-history
+// Fetches complete payment history from Horizon and stores it idempotently.
+// ---------------------------------------------------------------------------
+const { importWalletHistory } = require('../services/horizonService');
+
+async function importTransactionHistory(req, res, next) {
+  try {
+    const walletId = req.body.wallet_id || null;
+    const wallet = await resolveWallet(req.user.userId, walletId);
+    if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
+
+    const imported = await importWalletHistory(wallet.id, wallet.public_key);
+    res.json({ message: 'Import complete', imported });
+  } catch (err) {
+    next(err);
+  }
+}
+
 module.exports = {
   getWallet,
   listWallets,
@@ -536,4 +555,5 @@ module.exports = {
   setEntry,
   deleteEntry,
   getWalletFlags,
+  importTransactionHistory,
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,5 +1,27 @@
 require('dotenv').config();
 
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  enabled: !!process.env.SENTRY_DSN,
+  beforeSend(event) {
+    // Scrub sensitive fields from request body
+    if (event.request?.data) {
+      const scrubFields = ['password', 'secret', 'privateKey', 'token', 'pin', 'encryptedSecretKey'];
+      scrubFields.forEach((f) => {
+        if (event.request.data[f]) event.request.data[f] = '[Filtered]';
+      });
+    }
+    // Remove authorization header
+    if (event.request?.headers?.authorization) {
+      event.request.headers.authorization = '[Filtered]';
+    }
+    return event;
+  },
+});
+
 const validateEnv = require('./utils/validateEnv');
 const logger = require('./utils/logger');
 
@@ -51,5 +73,12 @@ async function shutdown(signal) {
 
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 process.on('SIGINT', () => shutdown('SIGINT'));
+
+process.on('unhandledRejection', (reason) => {
+  Sentry.captureException(reason);
+});
+process.on('uncaughtException', (error) => {
+  Sentry.captureException(error);
+});
 
 module.exports = { app, server, shutdown };

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,4 +1,10 @@
 const jwt = require('jsonwebtoken');
+const Sentry = require('@sentry/node');
+
+function maskWalletAddress(address) {
+  if (!address || address.length < 8) return address;
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
 
 module.exports = function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
@@ -8,6 +14,10 @@ module.exports = function authMiddleware(req, res, next) {
   const token = authHeader.split(' ')[1];
   try {
     req.user = jwt.verify(token, process.env.JWT_SECRET);
+    Sentry.setUser({
+      id: req.user.userId,
+      wallet: maskWalletAddress(req.user.walletAddress),
+    });
     next();
   } catch {
     res.status(401).json({ error: 'Invalid or expired token' });

--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -23,6 +23,7 @@ const {
   setEntry,
   deleteEntry,
   getWalletFlags,
+  importTransactionHistory,
 } = require('../controllers/walletController');
 const { getContacts, addContact, deleteContact } = require('../controllers/contactsController');
 const { getStatus } = require('../services/horizonRateLimit');
@@ -176,5 +177,13 @@ router.delete('/data-entry/:key', deleteEntry);
 
 // Account authorization flags
 router.get('/flags', getWalletFlags);
+
+// Horizon history import
+router.post(
+  '/import-history',
+  [body('wallet_id').optional().isUUID().withMessage('wallet_id must be a valid UUID')],
+  validate,
+  importTransactionHistory,
+);
 
 module.exports = router;

--- a/backend/src/services/horizonService.js
+++ b/backend/src/services/horizonService.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const StellarSdk = require('@stellar/stellar-sdk');
+const db = require('../db');
+const logger = require('../utils/logger');
+
+const primaryUrl = process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const server = new StellarSdk.Horizon.Server(primaryUrl);
+
+const PAGE_LIMIT = 200;
+
+/**
+ * Parse a Horizon payment record into the transactions table schema.
+ */
+function parsePaymentRecord(record, walletAddress) {
+  const isIncoming = record.to === walletAddress;
+  const amount = record.amount || '0';
+  const asset = record.asset_type === 'native' ? 'XLM' : record.asset_code || 'UNKNOWN';
+
+  return {
+    stellar_transaction_id: record.transaction_hash,
+    from_address: record.from || record.source_account || walletAddress,
+    to_address: record.to || record.into || walletAddress,
+    amount,
+    asset,
+    memo: record.transaction?.memo || null,
+    direction: isIncoming ? 'incoming' : 'outgoing',
+    status: 'completed',
+    created_at: record.created_at,
+  };
+}
+
+/**
+ * Import a batch of Horizon payment records idempotently.
+ * Returns the count of newly inserted records.
+ */
+async function importBatch(records, walletId, walletAddress) {
+  let inserted = 0;
+  for (const record of records) {
+    if (!record.transaction_hash) continue;
+
+    const existing = await db.query(
+      'SELECT id FROM transactions WHERE stellar_transaction_id = $1 AND wallet_id = $2',
+      [record.transaction_hash, walletId],
+    );
+    if (existing.rows.length > 0) continue;
+
+    const parsed = parsePaymentRecord(record, walletAddress);
+    await db.query(
+      `INSERT INTO transactions
+         (wallet_id, stellar_transaction_id, from_address, to_address, amount, asset, memo, direction, status, source, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'horizon_import', $10)
+       ON CONFLICT DO NOTHING`,
+      [
+        walletId,
+        parsed.stellar_transaction_id,
+        parsed.from_address,
+        parsed.to_address,
+        parsed.amount,
+        parsed.asset,
+        parsed.memo,
+        parsed.direction,
+        parsed.status,
+        parsed.created_at,
+      ],
+    );
+    inserted++;
+  }
+  return inserted;
+}
+
+/**
+ * Fetch and import all payment history for a wallet from Horizon.
+ * Uses cursor-based pagination to handle large histories.
+ * Returns total number of imported records.
+ */
+async function importWalletHistory(walletId, walletAddress) {
+  let cursor = null;
+  let totalImported = 0;
+
+  do {
+    let builder = server.payments().forAccount(walletAddress).limit(PAGE_LIMIT).order('asc');
+    if (cursor) builder = builder.cursor(cursor);
+
+    let page;
+    try {
+      page = await builder.call();
+    } catch (err) {
+      // Account not found on Horizon (unfunded) — treat as empty history
+      if (err.response?.status === 404) break;
+      throw err;
+    }
+
+    const records = page.records || [];
+    if (records.length === 0) break;
+
+    const imported = await importBatch(records, walletId, walletAddress);
+    totalImported += imported;
+
+    cursor = records[records.length - 1]?.paging_token || null;
+
+    // Stop if we got fewer records than the page limit (last page)
+    if (records.length < PAGE_LIMIT) break;
+  } while (cursor);
+
+  logger.info('Horizon history import complete', { walletId, totalImported });
+  return totalImported;
+}
+
+module.exports = { importWalletHistory };

--- a/database/migrations/018_add_transaction_source.js
+++ b/database/migrations/018_add_transaction_source.js
@@ -1,0 +1,13 @@
+exports.up = (pgm) => {
+  pgm.addColumn('transactions', {
+    source: {
+      type: 'VARCHAR(50)',
+      notNull: true,
+      default: 'afripay',
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn('transactions', 'source');
+};

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,8 @@
 REACT_APP_API_URL=http://localhost:5000/api
 REACT_APP_STELLAR_NETWORK=testnet
 
+# Sentry error tracking (leave empty to disable)
+REACT_APP_SENTRY_DSN=https://your-dsn@sentry.io/project-id
+
 # Web Push — must match VAPID_PUBLIC_KEY in backend .env
 REACT_APP_VAPID_PUBLIC_KEY=your_vapid_public_key_here

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,11 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 import api from '../utils/api';
+
+function maskWalletAddress(address) {
+  if (!address || address.length < 8) return address;
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
 
 export const AuthContext = createContext(null);
 
@@ -23,6 +29,10 @@ export function AuthProvider({ children }) {
     const res = await api.post('/auth/login', { email, password });
     localStorage.setItem('token', res.data.token);
     setUser(res.data.user);
+    Sentry.setUser({
+      id: res.data.user.id,
+      wallet: maskWalletAddress(res.data.user.walletAddress),
+    });
     return res.data;
   };
 
@@ -39,6 +49,7 @@ export function AuthProvider({ children }) {
     }
     localStorage.removeItem('token');
     setUser(null);
+    Sentry.setUser(null);
   };
 
   return (

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,13 +1,42 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import * as Sentry from '@sentry/react';
 import './index.css';
 import './i18n';
 import App from './App';
 import { register as registerSW } from './serviceWorker';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<React.StrictMode><App /></React.StrictMode>);
+Sentry.init({
+  dsn: process.env.REACT_APP_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  enabled: !!process.env.REACT_APP_SENTRY_DSN,
+  beforeSend(event) {
+    // Scrub sensitive request/form data
+    if (event.request?.data) {
+      const scrubFields = ['password', 'secret', 'privateKey', 'token', 'pin'];
+      scrubFields.forEach((field) => {
+        if (event.request.data[field]) event.request.data[field] = '[Filtered]';
+      });
+    }
+    return event;
+  },
+});
 
-// Register the service worker for offline support.
-// Only activates in production builds (see serviceWorker.js).
+const fallback = (
+  <div style={{ padding: '2rem', textAlign: 'center' }}>
+    <h2>Something went wrong</h2>
+    <p>Please refresh the page. If the problem persists, contact support.</p>
+    <button onClick={() => window.location.reload()}>Refresh</button>
+  </div>
+);
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <Sentry.ErrorBoundary fallback={fallback}>
+      <App />
+    </Sentry.ErrorBoundary>
+  </React.StrictMode>
+);
+
 registerSW();

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -40,6 +40,21 @@ export default function Profile() {
   const [closePassword, setClosePassword] = useState('');
   const [closeLoading, setCloseLoading] = useState(false);
 
+  // Horizon history import state (issue #130)
+  const [importingHistory, setImportingHistory] = useState(false);
+
+  const handleImportHistory = async () => {
+    setImportingHistory(true);
+    try {
+      const res = await api.post('/wallet/import-history');
+      toast.success(`Import complete — ${res.data.imported} new transactions added`);
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Import failed');
+    } finally {
+      setImportingHistory(false);
+    }
+  };
+
   // Security section state (issues #141, #142)
   const [signers, setSigners] = useState(null);
   const [signersLoading, setSignersLoading] = useState(false);
@@ -682,6 +697,23 @@ export default function Profile() {
         {signers === null && !signersLoading && (
           <p className="text-gray-600 text-xs text-center py-2">Click "Load" to fetch live signer data from Horizon.</p>
         )}
+      </div>
+
+      {/* Import Horizon History */}
+      <div className="bg-gray-900 rounded-2xl p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-white">Import Transaction History</h3>
+            <p className="text-xs text-gray-400 mt-0.5">Fetch your complete Stellar history from Horizon</p>
+          </div>
+          <button
+            onClick={handleImportHistory}
+            disabled={importingHistory}
+            className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            {importingHistory ? 'Importing…' : 'Import History'}
+          </button>
+        </div>
       </div>
 
       {/* Close Account */}


### PR DESCRIPTION
## Summary

Implements issues #128, #129, and #130.

---

### Issue #128 — Frontend Sentry Error Reporting

- Initializes `@sentry/react` in `frontend/src/index.js` with `beforeSend` PII scrubbing (passwords, tokens, private keys)
- Wraps `<App />` in `<Sentry.ErrorBoundary>` with a user-friendly fallback UI
- Sets masked user context (`id` + first/last 4 chars of wallet address) on login; clears on logout via `AuthContext.jsx`
- Adds `REACT_APP_SENTRY_DSN` to `frontend/.env.example`

### Issue #129 — Backend Sentry Error Reporting

- Initializes `@sentry/node` in `backend/src/index.js` before all other code, with `beforeSend` scrubbing sensitive body fields and `Authorization` headers
- Adds `Sentry.Handlers.requestHandler()` as first Express middleware and `Sentry.Handlers.errorHandler()` before the error handler in `app.js`
- Captures `unhandledRejection` and `uncaughtException` process events
- Sets masked user context in `auth.js` middleware after JWT verification
- Adds `SENTRY_DSN` to `backend/.env.example`

### Issue #130 — Stellar Horizon History Import

- Migration `018_add_transaction_source.js`: adds `source VARCHAR(50) DEFAULT 'afripay'` to `transactions`
- New `backend/src/services/horizonService.js`: cursor-based Horizon payments pagination, idempotent batch insert (`ON CONFLICT DO NOTHING`), handles unfunded accounts (404)
- New `POST /api/wallet/import-history` endpoint in `walletController.js` + `routes/wallet.js`
- Import History card added to `Profile.jsx` with loading state and toast feedback

## Installation

```bash
# Frontend
cd frontend && npm install @sentry/react

# Backend
cd backend && npm install @sentry/node

# Run migration
cd backend && npm run migrate
```

Closes #128
Closes #129
Closes #130