### PR TITLE
fix: guard sendPath catch block and add clawback input validation

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -807,11 +807,13 @@ async function sendPath(req, res, next) {
       transaction: { id: txId, tx_hash: transactionHash, ledger, source_amount, source_asset, destination_asset, recipient: recipient_address },
     });
   } catch (err) {
-    await db.query(
-      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status, request_id, is_encrypted, encrypted_memo)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,'failed',$8,$9,$10)`,
-      [txId, public_key || "", recipient_address || "", source_amount || "0", source_asset || "XLM", null, null, req.requestId, false, null],
-    ).catch(() => {});
+    if (public_key) {
+      await db.query(
+        `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status, request_id, is_encrypted, encrypted_memo)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,'failed',$8,$9,$10)`,
+        [txId, public_key, recipient_address || "", source_amount || "0", source_asset || "XLM", null, null, req.requestId, false, null],
+      ).catch(() => {});
+    }
 
     if (err.status === 400 || err.status === 500) {
       return res.status(err.status).json({ error: err.message });
@@ -946,11 +948,13 @@ async function sendStrictReceivePath(req, res, next) {
       transaction: { id: txId, tx_hash: transactionHash, ledger, destination_amount, destination_asset, recipient: recipient_address, status: 'confirming' },
     });
   } catch (err) {
-    await db.query(
-      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status, request_id, is_encrypted, encrypted_memo)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,'failed',$8,$9,$10)`,
-      [txId, public_key || "", recipient_address || "", "0", source_asset || "XLM", null, null, req.requestId, false, null],
-    ).catch(() => {});
+    if (public_key) {
+      await db.query(
+        `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status, request_id, is_encrypted, encrypted_memo)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,'failed',$8,$9,$10)`,
+        [txId, public_key, recipient_address || "", "0", source_asset || "XLM", null, null, req.requestId, false, null],
+      ).catch(() => {});
+    }
 
     if (err.status === 400 || err.status === 500) {
       return res.status(err.status).json({ error: err.message });

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -66,10 +66,10 @@ router.post('/clawback',
         return true;
       }),
     body('asset').trim().notEmpty().withMessage('asset is required')
-      .isAlphanumeric().isLength({ max: 12 }).withMessage('Invalid asset code'),
+      .isIn(['USDC', 'XLM']).withMessage('asset must be USDC or XLM'),
     body('amount').notEmpty().withMessage('amount is required')
-      .isFloat({ gt: 0 }).withMessage('amount must be greater than 0'),
-    body('reason').optional().trim().isLength({ max: 500 }),
+      .isFloat({ gt: 0.0000001 }).withMessage('amount must be greater than 0.0000001'),
+    body('reason').optional().trim().isLength({ max: 500 }).withMessage('reason must be 500 characters or fewer'),
   ],
   validate,
   clawback

--- a/backend/tests/sendPath.test.js
+++ b/backend/tests/sendPath.test.js
@@ -1,0 +1,123 @@
+/**
+ * Tests for issue #240:
+ * sendPath / sendStrictReceivePath catch blocks must NOT insert a failed
+ * transaction record when public_key is still undefined (i.e. the error
+ * occurred before wallet resolution).
+ */
+jest.mock('../src/db');
+jest.mock('../src/services/stellar');
+jest.mock('../src/services/fraudDetection', () => ({
+  checkFraud: jest.fn().mockResolvedValue({ blocked: false }),
+  logFraudBlock: jest.fn(),
+}));
+
+const db = require('../src/db');
+const { sendPath, sendStrictReceivePath } = require('../src/controllers/paymentController');
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function baseReq(body = {}) {
+  return {
+    user: { userId: 1 },
+    requestId: 'req-test',
+    logger: { info: jest.fn(), error: jest.fn() },
+    body: {
+      recipient_address: 'GDEST000000000000000000000000000000000000000000000000000',
+      source_asset: 'XLM',
+      source_amount: '10',
+      destination_asset: 'USDC',
+      destination_min_amount: '9',
+      path: [],
+      ...body,
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('sendPath — #240', () => {
+  test('skips DB insert when error occurs before wallet resolution', async () => {
+    // Simulate a DB error on the very first query (KYC / wallet lookup)
+    db.query.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    const req = baseReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await sendPath(req, res, next);
+
+    // next() should have been called with the error
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+
+    // db.query should have been called once (the failing query) — no INSERT
+    const insertCalls = db.query.mock.calls.filter(
+      ([sql]) => typeof sql === 'string' && sql.includes("'failed'"),
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  test('inserts failed record when error occurs after wallet resolution', async () => {
+    const { sendPathPayment } = require('../src/services/stellar');
+
+    // wallet lookup succeeds
+    db.query
+      .mockResolvedValueOnce({ rows: [{ kyc_status: 'verified', phone_verified: true }] }) // KYC/phone check
+      .mockResolvedValueOnce({ rows: [{ public_key: 'GSENDER00000000000000000000000000000000000000000000000000', encrypted_secret_key: 'enc' }] }) // wallet
+      .mockResolvedValue({ rows: [] }); // INSERT and any other calls
+
+    // Stellar call fails after wallet is resolved
+    sendPathPayment.mockRejectedValueOnce(Object.assign(new Error('Stellar error'), { status: 400 }));
+
+    const req = baseReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await sendPath(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+
+    const insertCalls = db.query.mock.calls.filter(
+      ([sql]) => typeof sql === 'string' && sql.includes("'failed'"),
+    );
+    expect(insertCalls).toHaveLength(1);
+    // sender_wallet must be the resolved public key, not empty
+    expect(insertCalls[0][1][1]).toBe('GSENDER00000000000000000000000000000000000000000000000000');
+  });
+});
+
+describe('sendStrictReceivePath — #240', () => {
+  test('skips DB insert when error occurs before wallet resolution', async () => {
+    db.query.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    const req = {
+      user: { userId: 1 },
+      requestId: 'req-test',
+      body: {
+        recipient_address: 'GDEST000000000000000000000000000000000000000000000000000',
+        source_asset: 'XLM',
+        source_max_amount: '10',
+        destination_asset: 'USDC',
+        destination_amount: '9',
+        path: [],
+      },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await sendStrictReceivePath(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+
+    const insertCalls = db.query.mock.calls.filter(
+      ([sql]) => typeof sql === 'string' && sql.includes("'failed'"),
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two backend bugs in a single PR.

---

## Fix #240 — sendPath catch block inserts failed tx with empty sender_wallet

**Problem:** In `paymentController.js`, the `sendPath` and `sendStrictReceivePath` catch blocks unconditionally inserted a failed transaction record. If the error occurred before `public_key` was assigned (e.g. a DB failure during the KYC/wallet lookup), an empty string `""` was stored as `sender_wallet`, polluting the transactions table with unlinked records.

**Fix:** Wrapped the `INSERT` in both catch blocks behind `if (public_key)`. When `public_key` is still `undefined` at the time of the error, the insert is skipped entirely.

**Test:** Added `backend/tests/sendPath.test.js` with three cases:
- Error before wallet resolution → no DB insert (the core regression guard)
- Error after wallet resolution → insert fires with the correct non-empty `sender_wallet`
- Same pre-wallet-resolution guard for `sendStrictReceivePath`

---

## Fix #241 — Missing input validation on POST /api/admin/clawback

**Problem:** The clawback endpoint read `from`, `asset`, `amount`, and `reason` directly from `req.body` without sufficient validation. A malformed Stellar address, unsupported asset, or negative amount caused an unhandled Stellar SDK error that leaked internal stack traces.

**Fix:** Tightened the existing `express-validator` rules on the route:
- `from`: validated as a Stellar Ed25519 public key (was already present, kept)
- `asset`: changed from a loose alphanumeric/length check to `.isIn(['USDC', 'XLM'])` — only supported assets are accepted
- `amount`: changed from `gt: 0` to `gt: 0.0000001` (Stellar minimum meaningful amount)
- `reason`: added explicit error message for the 500-char limit

All invalid inputs return `400` with field-level errors before any Stellar SDK call is made.

---

## Files changed

| File | Change |
|------|--------|
| `backend/src/controllers/paymentController.js` | Guard `sendPath` and `sendStrictReceivePath` catch-block inserts behind `if (public_key)` |
| `backend/src/routes/admin.js` | Restrict `asset` to `USDC`/`XLM`, tighten `amount` minimum, add `reason` error message |
| `backend/tests/sendPath.test.js` | New test file covering the #240 regression |

Closes #240
Closes #241