### PR TITLE
fix(sep10): verify network passphrase in postChallenge (#256)

### DIFF
--- a/backend/src/__tests__/sep10.test.js
+++ b/backend/src/__tests__/sep10.test.js
@@ -1,0 +1,79 @@
+const { postChallenge } = require('../controllers/sep10Controller');
+const StellarSdk = require('@stellar/stellar-sdk');
+
+const TESTNET_PASSPHRASE = 'Test SDF Network ; September 2015';
+const MAINNET_PASSPHRASE = 'Public Global Stellar Network ; September 2015';
+
+// Mock stellar.js so networkPassphrase is the testnet value
+jest.mock('../services/stellar', () => ({
+  networkPassphrase: 'Test SDF Network ; September 2015',
+}));
+
+// Mock sep10 service — not under test here
+jest.mock('../services/sep10', () => ({
+  generateChallenge: jest.fn(),
+  verifyChallenge: jest.fn().mockReturnValue(true),
+}));
+
+// Mock db
+jest.mock('../db', () => ({
+  query: jest.fn().mockResolvedValue({ rows: [{ id: 'user-1', email: 'test@example.com' }] }),
+}));
+
+function makeReq(body) {
+  return { body, query: {} };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+// Build a valid testnet XDR once for all tests
+const keypair = StellarSdk.Keypair.random();
+const validXDR = (() => {
+  const account = new StellarSdk.Account(keypair.publicKey(), '0');
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: TESTNET_PASSPHRASE,
+  })
+    .addOperation(StellarSdk.Operation.manageData({ name: 'test', value: 'x' }))
+    .setTimeout(30)
+    .build();
+  tx.sign(keypair);
+  return tx.toEnvelope().toXDR('base64');
+})();
+
+describe('postChallenge — network passphrase verification', () => {
+  test('returns 400 when network_passphrase is missing', async () => {
+    const req = makeReq({ transaction: validXDR });
+    const res = makeRes();
+    await postChallenge(req, res, jest.fn());
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid network passphrase' });
+  });
+
+  test('returns 400 when network_passphrase is mainnet (cross-network replay)', async () => {
+    const req = makeReq({ transaction: validXDR, network_passphrase: MAINNET_PASSPHRASE });
+    const res = makeRes();
+    await postChallenge(req, res, jest.fn());
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid network passphrase' });
+  });
+
+  test('proceeds when network_passphrase matches configured network', async () => {
+    const req = makeReq({ transaction: validXDR, network_passphrase: TESTNET_PASSPHRASE });
+    const res = makeRes();
+    const next = jest.fn();
+    await postChallenge(req, res, next);
+    // Passphrase check passed — no 400 for passphrase mismatch
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    // Either a token was issued or next() was called with a non-passphrase error
+    const passphraseMismatch = res.json.mock.calls.some(
+      ([body]) => body && body.error === 'Invalid network passphrase'
+    );
+    expect(passphraseMismatch).toBe(false);
+  });
+});

--- a/backend/src/controllers/sep10Controller.js
+++ b/backend/src/controllers/sep10Controller.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const { generateChallenge, verifyChallenge } = require('../services/sep10');
+const { networkPassphrase } = require('../services/stellar');
 const db = require('../db');
 
 async function getChallenge(req, res, next) {
@@ -18,9 +19,13 @@ async function getChallenge(req, res, next) {
 
 async function postChallenge(req, res, next) {
   try {
-    const { transaction } = req.body;
+    const { transaction, network_passphrase } = req.body;
     if (!transaction) {
       return res.status(400).json({ error: 'transaction required' });
+    }
+
+    if (network_passphrase !== networkPassphrase) {
+      return res.status(400).json({ error: 'Invalid network passphrase' });
     }
 
     // Extract account from transaction


### PR DESCRIPTION
- Import networkPassphrase from stellar.js
- Return 400 'Invalid network passphrase' if request network_passphrase does not match the configured network, blocking cross-network replay
- Add tests for missing passphrase, mainnet replay, and matching passphrase
Problem
  
  postChallenge accepted any signed transaction without checking the
  network_passphrase field. A challenge transaction signed on testnet could be
  submitted to a mainnet server and pass validation, allowing cross-network
  authentication bypass.
  
  Changes
  
  - Import networkPassphrase from stellar.js into sep10Controller.js
  - Reject requests where network_passphrase is missing or doesn't match the
  configured network with 400 "Invalid network passphrase"
  - Add sep10.test.js covering: missing passphrase, mainnet passphrase on testnet
  server (replay attack), and matching passphrase
  
  Testing
  
  PASS src/__tests__/sep10.test.js
    ✓ returns 400 when network_passphrase is missing
    ✓ returns 400 when network_passphrase is mainnet (cross-network replay)
    ✓ proceeds when network_passphrase matches configured network
  
  Closes #256