### PR TITLE
fix(wallet): indicate unfunded account in balance response (#258)

### DIFF
--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -63,13 +63,13 @@ async function getWallet(req, res, next) {
 
     const cached = await cache.get(cacheKey);
     if (cached) {
-      return res.json({ id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default, balances: cached, cached: true });
+      return res.json({ id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default, ...cached, cached: true });
     }
 
-    const balances = await getBalance(public_key);
-    await cache.set(cacheKey, balances, cache.BALANCE_TTL);
+    const balanceData = await getBalance(public_key);
+    await cache.set(cacheKey, balanceData, cache.BALANCE_TTL);
 
-    res.json({ id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default, balances, cached: false });
+    res.json({ id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default, ...balanceData, cached: false });
   } catch (err) {
     next(err);
   }
@@ -89,16 +89,16 @@ async function listWallets(req, res, next) {
     const wallets = await Promise.all(
       result.rows.map(async (w) => {
         const cacheKey = `balance:${w.public_key}`;
-        let balances = await cache.get(cacheKey);
-        if (!balances) {
+        let balanceData = await cache.get(cacheKey);
+        if (!balanceData) {
           try {
-            balances = await getBalance(w.public_key);
-            await cache.set(cacheKey, balances, cache.BALANCE_TTL);
+            balanceData = await getBalance(w.public_key);
+            await cache.set(cacheKey, balanceData, cache.BALANCE_TTL);
           } catch {
-            balances = [];
+            balanceData = { account_exists: false, balances: [] };
           }
         }
-        return { ...w, balances };
+        return { ...w, ...balanceData };
       }),
     );
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -157,21 +157,24 @@ async function getBalance(publicKey) {
     const numSubentries = account.subentry_count || 0;
     const minBalance = (2 + numSubentries) * BASE_RESERVE;
 
-    return account.balances.map(b => {
-      if (b.asset_type === 'native') {
-        const total = parseFloat(b.balance);
-        const available = Math.max(0, total - minBalance);
-        return {
-          asset: 'XLM',
-          balance: b.balance,
-          available_balance: available.toFixed(7),
-          min_balance: minBalance.toFixed(7),
-        };
-      }
-      return { asset: b.asset_code, balance: b.balance };
-    });
+    return {
+      account_exists: true,
+      balances: account.balances.map(b => {
+        if (b.asset_type === 'native') {
+          const total = parseFloat(b.balance);
+          const available = Math.max(0, total - minBalance);
+          return {
+            asset: 'XLM',
+            balance: b.balance,
+            available_balance: available.toFixed(7),
+            min_balance: minBalance.toFixed(7),
+          };
+        }
+        return { asset: b.asset_code, balance: b.balance };
+      }),
+    };
   } catch (e) {
-    if (e.response?.status === 404) return [];
+    if (e.response?.status === 404) return { account_exists: false, balances: [] };
     throw e;
   }
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -202,6 +202,7 @@ export default function Dashboard() {
 
   const xlmBalance = wallet?.balances?.find((b) => b.asset === 'XLM')?.balance || '0';
   const xlmAvailable = wallet?.balances?.find((b) => b.asset === 'XLM')?.available_balance || null;
+  const accountExists = wallet?.account_exists !== false; // treat undefined (cached) as true
   const displayBalance =
     selectedCurrency === 'XLM' ? xlmBalance : convertFromXLM(xlmBalance, selectedCurrency);
 
@@ -236,13 +237,28 @@ export default function Dashboard() {
             <FlaskConical size={15} />
             <span>Testnet mode — funds have no real value</span>
           </div>
-          <button
-            onClick={fundWallet}
-            disabled={funding}
-            className="text-xs bg-yellow-500 hover:bg-yellow-600 disabled:opacity-50 text-black font-semibold px-3 py-1.5 rounded-lg transition-colors"
-          >
-            {funding ? 'Funding…' : 'Fund wallet'}
-          </button>
+          {!accountExists && (
+            <button
+              onClick={fundWallet}
+              disabled={funding}
+              className="text-xs bg-yellow-500 hover:bg-yellow-600 disabled:opacity-50 text-black font-semibold px-3 py-1.5 rounded-lg transition-colors"
+            >
+              {funding ? 'Funding…' : 'Fund wallet'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Unfunded account prompt */}
+      {!accountExists && (
+        <div className="flex items-center gap-3 bg-blue-500/10 border border-blue-500/30 rounded-xl px-4 py-3">
+          <Download size={18} className="text-blue-400 shrink-0" />
+          <div className="flex-1">
+            <p className="text-blue-300 text-sm font-medium">Fund your wallet to get started</p>
+            <p className="text-blue-400/70 text-xs mt-0.5">
+              This account doesn't exist on-chain yet. Send XLM to activate it.
+            </p>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
- getBalance returns { account_exists, balances } instead of bare array
- 404 from Horizon returns { account_exists: false, balances: [] }
- getWallet and listWallets spread balanceData so account_exists propagates
- Dashboard shows 'Fund your wallet' prompt when account_exists is false
- Friendbot button on testnet only shown when account_exists is false
Problem
  
  When Horizon returns 404 for an account, getBalance returned [] and the
  controller returned HTTP 200 with balances: []. The frontend showed 0 XLM with
  no explanation that the account doesn't exist on-chain yet.
  
  Changes
  
  stellar.js — getBalance now returns { account_exists, balances } instead of a
  bare array:
  
  - account_exists: true with populated balances on success
  - account_exists: false, balances: [] on Horizon 404
  
  walletController.js — getWallet and listWallets spread the full balance object
  so account_exists propagates through the API response.
  
  Dashboard.jsx:
  
  - Shows a "Fund your wallet to get started" prompt when account_exists is false
  - Friendbot button (testnet) only appears when account_exists is false — no
  point offering it on an already-funded account
  
  API response shape
  
  - { "balances": [] }
  + { "balances": [], "account_exists": false }
  
  Closes #258 