### PR TITLE
fix(#269): validate agent is registered before escrow creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,48 @@ node-pg-migrate tracks applied migrations in a `pgmigrations` table that it crea
 | POST   | /api/support/tickets      | Yes  | Create a support/dispute ticket    |
 | GET    | /api/support/tickets      | Yes  | List user's support tickets        |
 | POST   | /api/admin/clawback       | Admin| Clawback asset for compliance      |
+| GET    | /api/admin/health         | Admin| Full service health diagnostics    |
+| POST   | /api/escrow/create        | Yes  | Create agent escrow (approved agents only) |
+| POST   | /api/escrow/:id/confirm   | Yes  | Agent confirms payout              |
+| POST   | /api/escrow/:id/cancel    | Yes  | Sender cancels escrow              |
+
+---
+
+## Agent Registration and Approval
+
+AfriPay uses a registered agent network for fiat distribution. Only **approved** agents may be used as the `agent_wallet` parameter in `POST /api/escrow/create`.
+
+### Agent Lifecycle
+
+```
+1. Agent applies → POST /api/auth/register (creates a user account)
+2. Agent submits their Stellar wallet address for approval
+3. Admin reviews and approves → INSERT INTO agents (wallet_address, status='approved')
+4. Agent is now eligible to receive escrow assignments
+5. Admin may suspend an agent by setting status='suspended'
+```
+
+### agents Table
+
+| Column           | Type        | Description                              |
+|------------------|-------------|------------------------------------------|
+| id               | uuid        | Primary key                              |
+| user_id          | uuid        | FK to users table                        |
+| wallet_address   | text        | Agent's Stellar public key (unique)      |
+| status           | varchar(20) | `pending` / `approved` / `suspended`     |
+| country          | varchar(10) | ISO country code (optional)              |
+| created_at       | timestamptz | Registration timestamp                   |
+| approved_at      | timestamptz | Admin approval timestamp                 |
+
+### Validation
+
+`POST /api/escrow/create` checks the `agents` table before creating any on-chain escrow:
+
+- If `agent_wallet` is not found with `status = 'approved'`, the request is rejected with HTTP 400:
+  ```json
+  { "error": "Agent is not registered in the AfriPay network" }
+  ```
+- Only after a successful agent lookup does the backend proceed to sign and broadcast the Soroban escrow transaction.
 
 ---
 

--- a/backend/src/controllers/agentEscrowController.js
+++ b/backend/src/controllers/agentEscrowController.js
@@ -25,6 +25,15 @@ async function create(req, res, next) {
   try {
     const { agent_wallet, recipient_wallet, amount, asset = "USDC" } = req.body;
 
+    // Validate that the agent is a registered, approved AfriPay agent
+    const agentResult = await db.query(
+      "SELECT id FROM agents WHERE wallet_address = $1 AND status = 'approved'",
+      [agent_wallet]
+    );
+    if (!agentResult.rows[0]) {
+      return res.status(400).json({ error: "Agent is not registered in the AfriPay network" });
+    }
+
     const walletResult = await db.query(
       "SELECT public_key, encrypted_secret_key FROM wallets WHERE user_id = $1",
       [req.user.userId]

--- a/backend/tests/agentRegistration.test.js
+++ b/backend/tests/agentRegistration.test.js
@@ -1,0 +1,97 @@
+/**
+ * Tests for issue #269:
+ * POST /api/escrow/create must validate that agent_wallet belongs to an
+ * approved agent in the AfriPay agents table.
+ */
+jest.mock('../src/db');
+jest.mock('../src/services/agentEscrow', () => ({
+  createEscrow: jest.fn().mockResolvedValue({ escrowId: 'esc-1', txHash: 'txhash123' }),
+  confirmPayout: jest.fn(),
+  cancelEscrow: jest.fn(),
+}));
+
+const db = require('../src/db');
+const { create } = require('../src/controllers/agentEscrowController');
+
+const AGENT_WALLET = 'GAGENT00000000000000000000000000000000000000000000000000';
+const SENDER_WALLET = 'GSENDER00000000000000000000000000000000000000000000000000';
+const RECIPIENT_WALLET = 'GRECIP00000000000000000000000000000000000000000000000000';
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function baseReq() {
+  return {
+    user: { userId: 'user-1' },
+    body: {
+      agent_wallet: AGENT_WALLET,
+      recipient_wallet: RECIPIENT_WALLET,
+      amount: '100',
+      asset: 'USDC',
+    },
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('POST /api/escrow/create — agent validation (#269)', () => {
+  test('returns 400 when agent_wallet is not in the agents table', async () => {
+    // agents query returns no rows (unregistered agent)
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    const req = baseReq();
+    const res = mockRes();
+    await create(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Agent is not registered in the AfriPay network',
+    });
+  });
+
+  test('returns 400 when agent exists but is not approved (pending)', async () => {
+    // The query filters on status = 'approved', so pending agents return no rows
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    const req = baseReq();
+    const res = mockRes();
+    await create(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Agent is not registered in the AfriPay network',
+    });
+  });
+
+  test('proceeds to create escrow when agent is approved', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1' }] }) // agents check
+      .mockResolvedValueOnce({ rows: [{ public_key: SENDER_WALLET, encrypted_secret_key: 'enc' }] }) // wallet
+      .mockResolvedValue({ rows: [] }); // INSERT
+
+    const req = baseReq();
+    const res = mockRes();
+    await create(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: 'Escrow created' }));
+  });
+
+  test('agents query uses wallet_address and status = approved', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    const req = baseReq();
+    const res = mockRes();
+    await create(req, res, jest.fn());
+
+    const firstCall = db.query.mock.calls[0];
+    expect(firstCall[0]).toMatch(/agents/);
+    expect(firstCall[0]).toMatch(/wallet_address/);
+    expect(firstCall[0]).toMatch(/approved/);
+    expect(firstCall[1]).toContain(AGENT_WALLET);
+  });
+});

--- a/database/migrations/019_add_agents_table.js
+++ b/database/migrations/019_add_agents_table.js
@@ -1,0 +1,31 @@
+/**
+ * Migration: 019_add_agents_table
+ *
+ * Creates the agents table for registered AfriPay payout agents.
+ * Agent registration is admin-approved; only approved agents may be used
+ * as the agent parameter in POST /api/escrow/create.
+ */
+
+exports.up = (pgm) => {
+  pgm.createTable('agents', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    user_id: { type: 'uuid', notNull: true, references: '"users"', onDelete: 'CASCADE' },
+    wallet_address: { type: 'text', notNull: true, unique: true },
+    status: {
+      type: 'varchar(20)',
+      notNull: true,
+      default: 'pending',
+      check: "status IN ('pending', 'approved', 'suspended')",
+    },
+    country: { type: 'varchar(10)' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    approved_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('agents', 'wallet_address');
+  pgm.createIndex('agents', 'status');
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('agents');
+};


### PR DESCRIPTION
## Summary

Closes #269

`POST /api/escrow/create` accepted any Stellar public key as `agent_wallet` without verifying it belongs to a registered, approved agent in the AfriPay system.

## Changes

- **`agentEscrowController.js`**: query the `agents` table for `wallet_address = agent_wallet AND status = 'approved'` before proceeding; return HTTP 400 with `{ "error": "Agent is not registered in the AfriPay network" }` if not found
- **`019_add_agents_table.js`**: migration creating the `agents` table (id, user_id, wallet_address, status, country, created_at, approved_at)
- **`README.md`**: document agent registration lifecycle, agents table schema, and validation behaviour
- **`agentRegistration.test.js`**: 4 tests covering unregistered agent, pending agent, approved agent, and query structure

## Testing

```
npx jest tests/agentRegistration.test.js
```
All 4 tests pass.