### PR TITLE
fix: block private/internal URLs in webhook registration (SSRF)

### DIFF
--- a/backend/src/__tests__/webhookSsrf.test.js
+++ b/backend/src/__tests__/webhookSsrf.test.js
@@ -1,0 +1,124 @@
+'use strict';
+/**
+ * Tests for SSRF protection in POST /api/webhooks (issue #261)
+ */
+
+jest.mock('../db');
+jest.mock('../middleware/auth', () => (req, res, next) => {
+  req.user = { userId: 'user-test-id' };
+  next();
+});
+
+// Mock dns.lookup so tests don't make real network calls
+jest.mock('dns', () => ({
+  promises: {
+    lookup: jest.fn(),
+  },
+}));
+
+const request = require('supertest');
+const express = require('express');
+const dns = require('dns').promises;
+const db = require('../db');
+const webhookRouter = require('../routes/webhooks');
+
+const app = express();
+app.use(express.json());
+app.use('/api/webhooks', webhookRouter);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: resolve to a public IP
+  dns.lookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+});
+
+describe('POST /api/webhooks — SSRF protection', () => {
+  test('rejects http:// URLs', async () => {
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'http://example.com/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/public HTTPS endpoint/i);
+  });
+
+  test('rejects localhost URL', async () => {
+    dns.lookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://localhost/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/public HTTPS endpoint/i);
+  });
+
+  test('rejects AWS metadata endpoint (169.254.169.254)', async () => {
+    dns.lookup.mockResolvedValue({ address: '169.254.169.254', family: 4 });
+
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://169.254.169.254/latest/meta-data/', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/public HTTPS endpoint/i);
+  });
+
+  test('rejects RFC 1918 address (10.x.x.x)', async () => {
+    dns.lookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://internal.corp/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/public HTTPS endpoint/i);
+  });
+
+  test('rejects RFC 1918 address (192.168.x.x)', async () => {
+    dns.lookup.mockResolvedValue({ address: '192.168.1.1', family: 4 });
+
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://router.local/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('rejects bare private IP in URL', async () => {
+    // dns.lookup won't be called for bare IPs — the IP check runs first
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://10.0.0.1/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/public HTTPS endpoint/i);
+  });
+
+  test('accepts a valid public HTTPS URL', async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'wh-1', url: 'https://example.com/hook',
+        events: ['payment.sent'], active: true, created_at: new Date().toISOString(),
+      }],
+    });
+
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://example.com/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.url).toBe('https://example.com/hook');
+  });
+
+  test('rejects unresolvable hostname', async () => {
+    dns.lookup.mockRejectedValue(new Error('ENOTFOUND'));
+
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({ url: 'https://does-not-exist.invalid/hook', events: ['payment.sent'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/public HTTPS endpoint/i);
+  });
+});

--- a/backend/src/controllers/webhookController.js
+++ b/backend/src/controllers/webhookController.js
@@ -1,14 +1,62 @@
 const crypto = require('crypto');
+const dns = require('dns').promises;
 const db = require('../db');
 
 const VALID_EVENTS = ['payment.sent', 'payment.received', 'payment.failed'];
+
+// RFC 1918, loopback, link-local, and cloud metadata ranges
+const BLOCKED_CIDRS = [
+  [0x0a000000, 0xff000000],   // 10.0.0.0/8
+  [0xac100000, 0xfff00000],   // 172.16.0.0/12
+  [0xc0a80000, 0xffff0000],   // 192.168.0.0/16
+  [0x7f000000, 0xff000000],   // 127.0.0.0/8  (loopback)
+  [0xa9fe0000, 0xffff0000],   // 169.254.0.0/16 (link-local / metadata)
+  [0x64400000, 0xffc00000],   // 100.64.0.0/10 (shared address space)
+  [0x00000000, 0xff000000],   // 0.0.0.0/8
+  [0xe0000000, 0xf0000000],   // 224.0.0.0/4  (multicast)
+  [0xf0000000, 0xf0000000],   // 240.0.0.0/4  (reserved)
+];
+
+function ipToInt(ip) {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+}
+
+function isPrivateIp(ip) {
+  // IPv6 loopback / link-local
+  if (ip === '::1' || ip.startsWith('fe80') || ip.startsWith('fc') || ip.startsWith('fd')) return true;
+  // Only check IPv4
+  if (!/^\d{1,3}(\.\d{1,3}){3}$/.test(ip)) return false;
+  const n = ipToInt(ip);
+  return BLOCKED_CIDRS.some(([net, mask]) => (n & mask) === (net & mask));
+}
+
+async function validatePublicUrl(url) {
+  let parsed;
+  try { parsed = new URL(url); } catch { return false; }
+  if (parsed.protocol !== 'https:') return false;
+
+  // Reject if hostname is a bare IP
+  const hostname = parsed.hostname;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+    if (isPrivateIp(hostname)) return false;
+  }
+
+  // Resolve hostname and check all returned IPs
+  try {
+    const { address } = await dns.lookup(hostname);
+    if (isPrivateIp(address)) return false;
+  } catch {
+    return false; // unresolvable hostname
+  }
+  return true;
+}
 
 async function create(req, res, next) {
   try {
     const { url, events } = req.body;
 
-    if (!url || !url.startsWith('https://')) {
-      return res.status(400).json({ error: 'Webhook URL must use HTTPS' });
+    if (!await validatePublicUrl(url)) {
+      return res.status(400).json({ error: 'Webhook URL must point to a public HTTPS endpoint' });
     }
 
     const invalidEvents = (events || []).filter((e) => !VALID_EVENTS.includes(e));

--- a/backend/src/services/webhook.js
+++ b/backend/src/services/webhook.js
@@ -1,9 +1,47 @@
 const crypto = require('crypto');
 const https = require('https');
+const dns = require('dns').promises;
 const db = require('../db');
 const logger = require('../utils/logger');
 
 const MAX_ATTEMPTS = 3;
+
+// Reuse the same private-IP check as the controller
+const BLOCKED_CIDRS = [
+  [0x0a000000, 0xff000000],
+  [0xac100000, 0xfff00000],
+  [0xc0a80000, 0xffff0000],
+  [0x7f000000, 0xff000000],
+  [0xa9fe0000, 0xffff0000],
+  [0x64400000, 0xffc00000],
+  [0x00000000, 0xff000000],
+  [0xe0000000, 0xf0000000],
+  [0xf0000000, 0xf0000000],
+];
+
+function ipToInt(ip) {
+  return ip.split('.').reduce((acc, o) => (acc << 8) + parseInt(o, 10), 0) >>> 0;
+}
+
+function isPrivateIp(ip) {
+  if (ip === '::1' || ip.startsWith('fe80') || ip.startsWith('fc') || ip.startsWith('fd')) return true;
+  if (!/^\d{1,3}(\.\d{1,3}){3}$/.test(ip)) return false;
+  const n = ipToInt(ip);
+  return BLOCKED_CIDRS.some(([net, mask]) => (n & mask) === (net & mask));
+}
+
+async function isPublicHttpsUrl(url) {
+  let parsed;
+  try { parsed = new URL(url); } catch { return false; }
+  if (parsed.protocol !== 'https:') return false;
+  const hostname = parsed.hostname;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) && isPrivateIp(hostname)) return false;
+  try {
+    const { address } = await dns.lookup(hostname);
+    if (isPrivateIp(address)) return false;
+  } catch { return false; }
+  return true;
+}
 
 function sign(secret, payload) {
   return crypto.createHmac('sha256', secret).update(payload).digest('hex');
@@ -34,6 +72,11 @@ function httpsPost(url, body, signature) {
 }
 
 async function deliverWithRetry(url, secret, payload, attempt = 0) {
+  // Re-validate URL before each delivery to catch DNS rebinding / stale records
+  if (!await isPublicHttpsUrl(url)) {
+    logger.error('Webhook delivery blocked: URL failed SSRF validation', { url });
+    return;
+  }
   const body = JSON.stringify(payload);
   const signature = sign(secret, body);
   try {


### PR DESCRIPTION
## Summary

Fixes the SSRF vulnerability in `POST /api/webhooks` (issue #261).

An attacker could register `http://169.254.169.254/latest/meta-data/` or `http://localhost:5432` to probe internal services via the webhook delivery mechanism.

## Changes

**`webhookController.js`**
- Replaced the bare `url.startsWith('https://')` check with `validatePublicUrl()`
- Resolves the hostname via `dns.lookup` and rejects any IP in RFC 1918, loopback (127/8), link-local (169.254/16), shared address space (100.64/10), multicast, and reserved ranges
- Returns `400 { error: 'Webhook URL must point to a public HTTPS endpoint' }` for all blocked URLs

**`services/webhook.js`**
- Added the same `isPublicHttpsUrl()` check inside `deliverWithRetry` so stale/rebinding attacks are caught at delivery time too

**`src/__tests__/webhookSsrf.test.js`** (new)
- 8 tests: http scheme, localhost, 169.254.169.254, 10.x, 192.168.x, bare private IP, valid public URL, unresolvable hostname

## Testing

```
npx jest src/__tests__/webhookSsrf.test.js
# 8 passed
```

Closes #261