### PR TITLE
deprecate: add Deprecation header to GET /api/wallet/transactions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,3 +25,20 @@
 
 Current progress: Starting step 1.
 
+
+---
+
+## Deprecation Removal TODO
+
+### GET /api/wallet/transactions (issue #270)
+
+- **Status**: Deprecated as of 2025-04-27
+- **Replacement**: `GET /api/payments/history`
+- **Sunset date**: 2026-01-01
+- **Deprecation headers set**: `Deprecation: true`, `Link: </api/payments/history>; rel="successor-version"`, `Sunset`
+- **Swagger**: marked `deprecated: true` in `backend/src/routes/wallet.js`
+- [ ] **Remove** `GET /api/wallet/transactions` route from `backend/src/routes/wallet.js`
+- [ ] **Remove** `getWalletTransactions` from `backend/src/controllers/walletController.js`
+- [ ] **Remove** `getWalletTransactions` export from `walletController.js`
+- [ ] Verify no frontend code references `/wallet/transactions`
+- [ ] Update this TODO entry to mark removal complete

--- a/backend/src/__tests__/walletTransactionsDeprecation.test.js
+++ b/backend/src/__tests__/walletTransactionsDeprecation.test.js
@@ -1,0 +1,83 @@
+'use strict';
+/**
+ * Tests for GET /api/wallet/transactions deprecation (issue #270)
+ *
+ * Verifies that the endpoint:
+ *  - Still returns data (backward-compatible)
+ *  - Sets Deprecation: true header
+ *  - Sets Link header pointing to /api/payments/history
+ */
+
+jest.mock('../db');
+jest.mock('../middleware/auth', () => (req, res, next) => {
+  req.user = { userId: 'user-test-id' };
+  next();
+});
+jest.mock('../services/stellar', () => ({}));
+
+const request = require('supertest');
+const express = require('express');
+const db = require('../db');
+
+// Build a minimal app with just the wallet router
+function buildApp() {
+  jest.resetModules();
+  jest.mock('../db');
+  jest.mock('../middleware/auth', () => (req, res, next) => {
+    req.user = { userId: 'user-test-id' };
+    next();
+  });
+  jest.mock('../services/stellar', () => ({}));
+  const walletRouter = require('../routes/wallet');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wallet', walletRouter);
+  app.use((err, req, res, next) => res.status(err.status || 500).json({ error: err.message }));
+  return { app, db: require('../db') };
+}
+
+describe('GET /api/wallet/transactions — deprecation', () => {
+  test('responds with Deprecation: true header', async () => {
+    const { app, db } = buildApp();
+    // resolveWallet queries wallets table
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: 'GPUBKEY', id: 'w-1', encrypted_secret_key: 'enc' }] })
+      .mockResolvedValueOnce({ rows: [] }); // transactions query
+
+    const res = await request(app)
+      .get('/api/wallet/transactions')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['deprecation']).toBe('true');
+  });
+
+  test('Link header points to /api/payments/history', async () => {
+    const { app, db } = buildApp();
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: 'GPUBKEY', id: 'w-1', encrypted_secret_key: 'enc' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/api/wallet/transactions')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.headers['link']).toMatch(/\/api\/payments\/history/);
+    expect(res.headers['link']).toMatch(/successor-version/);
+  });
+
+  test('still returns transactions array (backward-compatible)', async () => {
+    const { app, db } = buildApp();
+    const fakeTx = { id: 'tx-1', amount: '10', asset: 'XLM' };
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: 'GPUBKEY', id: 'w-1', encrypted_secret_key: 'enc' }] })
+      .mockResolvedValueOnce({ rows: [fakeTx] });
+
+    const res = await request(app)
+      .get('/api/wallet/transactions')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.transactions).toEqual([fakeTx]);
+  });
+});

--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -168,9 +168,14 @@ async function getQRCode(req, res, next) {
 
 // ---------------------------------------------------------------------------
 // GET /wallet/transactions  (optionally ?wallet_id=<uuid>)
+// DEPRECATED — use GET /api/payments/history instead
 // ---------------------------------------------------------------------------
 async function getWalletTransactions(req, res, next) {
   try {
+    res.set('Deprecation', 'true');
+    res.set('Link', '</api/payments/history>; rel="successor-version"');
+    res.set('Sunset', 'Sat, 01 Jan 2026 00:00:00 GMT');
+
     const wallet = await resolveWallet(req.user.userId, req.query.wallet_id || null);
     if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
 

--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -48,6 +48,26 @@ router.post(
 // Single-wallet endpoints (support optional ?wallet_id query param)
 router.get('/balance', getWallet);
 router.get('/qr', getQRCode);
+
+/**
+ * @swagger
+ * /api/wallet/transactions:
+ *   get:
+ *     summary: "[DEPRECATED] Get wallet transactions"
+ *     description: >
+ *       **Deprecated.** Use `GET /api/payments/history` instead, which
+ *       supports pagination, filtering, and a consistent response shape.
+ *       This endpoint will be removed in a future release.
+ *     deprecated: true
+ *     tags: [Wallet]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Transaction list (deprecated response shape)
+ *       401:
+ *         description: Unauthorized
+ */
 router.get('/transactions', getWalletTransactions);
 
 router.post(


### PR DESCRIPTION
## Summary

Deprecates `GET /api/wallet/transactions` in favour of `GET /api/payments/history` (issue #270).

The two endpoints return transaction history with different response shapes and pagination behaviour. `/api/wallet/transactions` is undocumented in the README API table and causes confusion.

## Changes

**`walletController.js`** — `getWalletTransactions`
Sets three deprecation headers on every response:
```
Deprecation: true
Link: </api/payments/history>; rel="successor-version"
Sunset: Sat, 01 Jan 2026 00:00:00 GMT
```

**`routes/wallet.js`**
Added `@swagger` JSDoc with `deprecated: true` so the endpoint is visually marked in Swagger UI.

**Frontend**
`TransactionHistory.jsx` already calls `/api/payments/history` — no change needed.

**`TODO.md`**
Added a removal checklist under a new _Deprecation Removal TODO_ section with sunset date 2026-01-01.

**`walletTransactionsDeprecation.test.js`** (new)
3 tests: `Deprecation: true` header present, `Link` header points to `/api/payments/history`, response is backward-compatible.

## Testing

```
npx jest src/__tests__/walletTransactionsDeprecation.test.js
# 3 passed
```

Closes #270