### PR TITLE
fix: enforce 28-byte limit on text memos (#259)

### DIFF
--- a/backend/src/validators/paymentSendValidators.js
+++ b/backend/src/validators/paymentSendValidators.js
@@ -35,8 +35,8 @@ module.exports = [
       return true;
     }
 
-    if (mt === 'text' && memo.length > 28) {
-      throw new Error('Text memo must be at most 28 characters');
+    if (mt === 'text' && Buffer.byteLength(memo, 'utf8') > 28) {
+      throw new Error('Text memo must be at most 28 bytes');
     }
     if (mt === 'id') {
       if (!/^\d+$/.test(memo)) throw new Error('Memo ID must be a numeric string');


### PR DESCRIPTION
Closes #259

## Summary
The Stellar protocol limits text memos to 28 **bytes**, not 28 characters. Multi-byte UTF-8 characters (e.g. emoji, Arabic, Chinese) could previously slip through the validator and get silently truncated on-chain by `buildStellarMemo`.

## Changes
- `backend/src/validators/paymentSendValidators.js`: changed `memo.length > 28` to `Buffer.byteLength(memo, 'utf8') > 28` for `memo_type = text`

The `id` (u64 numeric string) and `hash`/`return` (64 hex chars) validators were already correct.

## Testing
- Text memo with 28 ASCII chars → passes
- Text memo with 10 emoji (>28 bytes) → 400 `Text memo must be at most 28 bytes`
- Memo ID `18446744073709551615` (u64 max) → passes
- Memo ID `18446744073709551616` (overflow) → 400
- Hash memo with 64 hex chars → passes
- Hash memo with 63 chars → 400