### PR TITLE
fix: direction SQL filter and composite indexes for history (#260)

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -636,7 +636,17 @@ async function history(req, res, next) {
 
     const { public_key } = walletResult.rows[0];
 
-    const conditions = ["(sender_wallet = $1 OR recipient_wallet = $1)"];
+    const direction = req.query.direction || "all";
+    let directionCondition;
+    if (direction === "sent") {
+      directionCondition = "sender_wallet = $1";
+    } else if (direction === "received") {
+      directionCondition = "recipient_wallet = $1";
+    } else {
+      directionCondition = "(sender_wallet = $1 OR recipient_wallet = $1)";
+    }
+
+    const conditions = [directionCondition];
     const baseParams = [public_key];
 
     if (cursor) {

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -131,35 +131,72 @@ router.post('/send',
   send,
 );
 
+/**
+ * @swagger
+ * /api/payments/history:
+ *   get:
+ *     summary: Get transaction history
+ *     tags: [Payments]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: direction
+ *         schema:
+ *           type: string
+ *           enum: [sent, received, all]
+ *           default: all
+ *         description: Filter by transaction direction. Translated to a SQL WHERE clause on sender_wallet or recipient_wallet.
+ *       - in: query
+ *         name: from
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Start date (ISO 8601)
+ *       - in: query
+ *         name: to
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: End date (ISO 8601)
+ *       - in: query
+ *         name: asset
+ *         schema:
+ *           type: string
+ *           enum: [XLM, USDC, NGN, GHS, KES]
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: integer
+ *         description: Pagination cursor (last transaction id)
+ *     responses:
+ *       200:
+ *         description: List of transactions
+ *       400:
+ *         description: Invalid query parameters
+ */
 router.get(
   "/history",
   [
-    query("page").optional().isInt({ min: 1 }).withMessage("page must be a positive integer"),
-    query("limit")
-      .optional()
-      .isInt({ min: 1, max: 100 })
-      .withMessage("limit must be between 1 and 100"),
-    query("from")
-      .optional({ values: "falsy" })
-      .trim()
-      .isISO8601()
-      .withMessage("from must be a valid ISO 8601 date"),
-    query("to")
-      .optional({ values: "falsy" })
-      .trim()
-      .isISO8601()
-      .withMessage("to must be a valid ISO 8601 date"),
+    query("limit").optional().isInt({ min: 1, max: 100 }).withMessage("limit must be between 1 and 100"),
+    query("from").optional({ values: "falsy" }).trim().isISO8601().withMessage("from must be a valid ISO 8601 date"),
+    query("to").optional({ values: "falsy" }).trim().isISO8601().withMessage("to must be a valid ISO 8601 date"),
     query("asset")
       .optional({ values: "falsy" })
-    query('page').optional().isInt({ min: 1 }).withMessage('page must be a positive integer'),
-    query('limit').optional().isInt({ min: 1, max: 100 }).withMessage('limit must be between 1 and 100'),
-    query('from').optional({ values: 'falsy' }).trim().isISO8601().withMessage('from must be a valid ISO 8601 date'),
-    query('to').optional({ values: 'falsy' }).trim().isISO8601().withMessage('to must be a valid ISO 8601 date'),
-    query('asset')
-      .optional({ values: 'falsy' })
       .trim()
       .isIn(ALLOWED_HISTORY_ASSETS)
       .withMessage(`asset must be one of: ${ALLOWED_HISTORY_ASSETS.join(", ")}`),
+    query("direction")
+      .optional({ values: "falsy" })
+      .isIn(["sent", "received", "all"])
+      .withMessage("direction must be sent, received, or all"),
   ],
   validate,
   history,

--- a/database/migrations/021_add_direction_indexes.js
+++ b/database/migrations/021_add_direction_indexes.js
@@ -1,0 +1,16 @@
+exports.up = (pgm) => {
+  // Composite indexes to support direction-filtered history queries efficiently
+  pgm.createIndex('transactions', ['sender_wallet', 'created_at'], {
+    name: 'idx_transactions_sender_created',
+    ifNotExists: true,
+  });
+  pgm.createIndex('transactions', ['recipient_wallet', 'created_at'], {
+    name: 'idx_transactions_recipient_created',
+    ifNotExists: true,
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('transactions', ['sender_wallet', 'created_at'], { name: 'idx_transactions_sender_created' });
+  pgm.dropIndex('transactions', ['recipient_wallet', 'created_at'], { name: 'idx_transactions_recipient_created' });
+};


### PR DESCRIPTION
Closes #260

## Summary
The `direction` field was computed in JavaScript after fetching all rows, causing full table scans even when the user only wanted sent or received transactions.

## Changes
- **`paymentController.js`** — `history()` now translates `direction=sent|received|all` to a SQL `WHERE` clause (`sender_wallet = $1` / `recipient_wallet = $1` / `OR`) before querying
- **`routes/payments.js`** — added `direction` query param validator (`sent | received | all`) and Swagger JSDoc for `GET /api/payments/history`
- **`database/migrations/021_add_direction_indexes.js`** — composite indexes on `(sender_wallet, created_at)` and `(recipient_wallet, created_at)`

## Testing
- `GET /api/payments/history?direction=sent` → only sent transactions
- `GET /api/payments/history?direction=received` → only received transactions
- `GET /api/payments/history?direction=all` (default) → all transactions
- `GET /api/payments/history?direction=invalid` → 400