### PR TITLE
fix: validate execute_at is in the future for scheduled payments (#263)

### DIFF
--- a/backend/src/controllers/scheduledPaymentController.js
+++ b/backend/src/controllers/scheduledPaymentController.js
@@ -3,7 +3,7 @@ const db = require('../db');
 
 async function create(req, res, next) {
   try {
-    const { recipient_wallet, amount, asset = 'XLM', frequency, memo } = req.body;
+    const { recipient_wallet, amount, asset = 'XLM', frequency, memo, execute_at } = req.body;
     const userId = req.user.userId;
 
     if (!amount || parseFloat(amount) <= 0) {
@@ -14,7 +14,7 @@ async function create(req, res, next) {
     }
 
     const id = uuidv4();
-    const nextRunAt = new Date();
+    const nextRunAt = new Date(execute_at);
 
     await db.query(
       `INSERT INTO scheduled_payments (id, user_id, recipient_wallet, amount, asset, frequency, next_run_at, memo)

--- a/backend/src/routes/scheduledPayments.js
+++ b/backend/src/routes/scheduledPayments.js
@@ -1,10 +1,80 @@
 const express = require('express');
+const { body, validationResult } = require('express-validator');
 const auth = require('../middleware/auth');
 const { create, list, update, delete: delete_ } = require('../controllers/scheduledPaymentController');
 
 const router = express.Router();
 
-router.post('/', auth, create);
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  next();
+};
+
+const ONE_MINUTE_MS = 60 * 1000;
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * @swagger
+ * /api/scheduled-payments:
+ *   post:
+ *     summary: Create a scheduled payment
+ *     tags: [Scheduled Payments]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [recipient_wallet, amount, frequency, execute_at]
+ *             properties:
+ *               recipient_wallet:
+ *                 type: string
+ *               amount:
+ *                 type: number
+ *               asset:
+ *                 type: string
+ *                 enum: [XLM, USDC, NGN, GHS, KES]
+ *               frequency:
+ *                 type: string
+ *                 enum: [daily, weekly, monthly]
+ *               execute_at:
+ *                 type: string
+ *                 format: date-time
+ *                 description: Must be at least 1 minute in the future and within 1 year
+ *               memo:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Scheduled payment created
+ *       400:
+ *         description: Validation error
+ */
+router.post(
+  '/',
+  auth,
+  [
+    body('execute_at')
+      .notEmpty().withMessage('execute_at is required')
+      .isISO8601().withMessage('execute_at must be a valid ISO 8601 timestamp')
+      .custom((value) => {
+        const executeAt = new Date(value);
+        const now = Date.now();
+        if (executeAt.getTime() < now + ONE_MINUTE_MS) {
+          throw new Error('execute_at must be a future timestamp');
+        }
+        if (executeAt.getTime() > now + ONE_YEAR_MS) {
+          throw new Error('execute_at must be within 1 year from now');
+        }
+        return true;
+      }),
+  ],
+  validate,
+  create,
+);
+
 router.get('/', auth, list);
 router.put('/:id', auth, update);
 router.delete('/:id', auth, delete_);


### PR DESCRIPTION
Closes #263

## Summary
`POST /api/scheduled-payments` accepted any `execute_at` (or none at all), defaulting to `new Date()` — meaning a past timestamp would either fire immediately on the next job run or never fire.

## Changes
- **`routes/scheduledPayments.js`** — added `express-validator` rule requiring `execute_at` to be:
  - a valid ISO 8601 timestamp
  - at least 1 minute in the future (returns 400 `execute_at must be a future timestamp`)
  - within 1 year from now
  - Added Swagger docs for the endpoint
- **`controllers/scheduledPaymentController.js`** — `create()` now reads `execute_at` from the body and uses it as `next_run_at` instead of `new Date()`

## Testing
- Past timestamp → 400 `execute_at must be a future timestamp`
- Timestamp 30 seconds from now → 400 (less than 1 minute)
- Timestamp 2 minutes from now → 200
- Timestamp 2 years from now → 400 `execute_at must be within 1 year from now`