### PR TITLE
fix: dynamic CSV filename for export endpoint (#268)

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -1074,7 +1074,18 @@ async function exportCSV(req, res, next) {
     }));
 
     res.setHeader("Content-Type", "text/csv");
-    res.setHeader("Content-Disposition", 'attachment; filename="transactions.csv"');
+    // Build dynamic filename based on date range params; sanitize to prevent header injection
+    const sanitize = (s) => s.replace(/[^0-9a-zA-Z_\-]/g, "");
+    let filename;
+    if (req.query.from || req.query.to) {
+      const from = sanitize((req.query.from || "").slice(0, 10));
+      const to = sanitize((req.query.to || "").slice(0, 10));
+      filename = `transactions_${from}_to_${to}.csv`;
+    } else {
+      const today = new Date().toISOString().slice(0, 10);
+      filename = `transactions_exported_${today}.csv`;
+    }
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
 
     const output = stringify(rows, {
       header: true,


### PR DESCRIPTION
Closes #268

## Summary
`GET /api/payments/export` always set `Content-Disposition: attachment; filename="transactions.csv"`. Exporting multiple date ranges produced identically named files.

## Changes
- **`controllers/paymentController.js`** — `exportCSV()` now generates the filename dynamically:
  - With `from`/`to` params: `transactions_YYYY-MM-DD_to_YYYY-MM-DD.csv`
  - Without date range: `transactions_exported_YYYY-MM-DD.csv`
  - Filename is sanitized (only `[0-9a-zA-Z_-]` allowed) to prevent header injection

## Testing
- `GET /api/payments/export?from=2024-01-01&to=2024-03-31` → `transactions_2024-01-01_to_2024-03-31.csv`
- `GET /api/payments/export` → `transactions_exported_2026-04-27.csv`
- Params with special chars are stripped before use in the header