### PR TITLE
feat: make wallet balance cache TTL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ STELLAR_NETWORK=testnet  # or mainnet
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://localhost:5000
 
+# Cache Configuration
+BALANCE_CACHE_TTL_SECONDS=30
+
 # SMS Configuration
 SMS_PROVIDER=
 TWILIO_ACCOUNT_SID=

--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # AES-256 encryption key for private key storage (must be exactly 32 characters)
 ENCRYPTION_KEY=your_32_character_encryption_key_
 
+# Cache Configuration
+# Balance cache TTL in seconds (default: 30)
+# Time-To-Live for cached wallet balance data. Lower values ensure fresher data but increase load on Horizon.
+# Higher values reduce load but may show stale balances after recent transactions.
+# Cache is automatically invalidated after send, sendBatch, and sendPath operations.
+BALANCE_CACHE_TTL_SECONDS=30
+
 # CORS
 FRONTEND_URL=http://localhost:3000
 ```
@@ -341,6 +348,24 @@ FRONTEND_URL=http://localhost:3000
 - Fraud protection: blocks wallets exceeding 5 transactions in 10 minutes
 - Input validation on all endpoints via `express-validator`
 - CORS restricted to configured frontend origin
+
+---
+
+## Performance & Caching
+
+**Balance Caching with Redis**
+
+Wallet balances are cached in Redis to reduce load on the Stellar Horizon API. The cache behavior is configurable:
+
+- **Configurable TTL**: Set `BALANCE_CACHE_TTL_SECONDS` in your environment (default: 30 seconds)
+- **Automatic Invalidation**: Cache is cleared immediately after:
+  - Standard payments (`POST /api/payments`)
+  - Batch payments (`POST /api/payments/batch`)
+  - Path payments (`POST /api/payments/send-path`)
+- **Fallback Behavior**: If Redis is not configured, balances are fetched live from Horizon on every request
+- **Stale Balance Risk**: In production, ensure the TTL is low enough (15-30 seconds recommended) to prevent users from seeing significantly stale balances after receiving payments
+
+To adjust the cache TTL in production, update the `BALANCE_CACHE_TTL_SECONDS` environment variable without restarting (if using a process manager with hot-reload support).
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -94,6 +94,11 @@ DAILY_SEND_LIMIT=50000
 # Redis (optional) — if not set, balance caching is disabled and live Horizon calls are used
 # REDIS_URL=redis://localhost:6379
 
+# Balance cache TTL in seconds (default: 30)
+# Time-To-Live for cached wallet balance data. Lower values ensure fresher data but increase load on Horizon.
+# Higher values reduce load but may show stale balances after recent transactions.
+BALANCE_CACHE_TTL_SECONDS=30
+
 # Web Push (VAPID) — generate with: npx web-push generate-vapid-keys
 VAPID_EMAIL=admin@afripay.app
 VAPID_PUBLIC_KEY=your_vapid_public_key_here

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -1,7 +1,8 @@
 const Redis = require('ioredis');
 const logger = require('./logger');
 
-const BALANCE_TTL = 30; // seconds
+// Read balance cache TTL from environment, default to 30 seconds
+const BALANCE_TTL = parseInt(process.env.BALANCE_CACHE_TTL_SECONDS || '30', 10);
 
 let client = null;
 


### PR DESCRIPTION
- Add BALANCE_CACHE_TTL_SECONDS to .env.example and backend/.env.example with default of 30 seconds
- Update cache.js to read TTL from process.env with fallback to 30 seconds
- Cache is automatically invalidated after send, sendBatch, and sendPath operations
- Add documentation to README about cache behavior and configuration
- Verify cache invalidation in sendPath (already implemented)
closes #246