### PR TITLE
feat: implement per-account lockout with 5 failed attempts per 15 min…

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -144,7 +144,7 @@ async function login(req, res, next) {
     const { email, password, totp_code } = req.body;
 
     const result = await db.query(
-      `SELECT u.id, u.full_name, u.email, u.password_hash, u.email_verified, u.role, u.totp_enabled, u.totp_secret, u.failed_login_attempts, u.locked_until, w.public_key
+      `SELECT u.id, u.full_name, u.email, u.password_hash, u.email_verified, u.role, u.totp_enabled, u.totp_secret, u.failed_login_attempts, u.locked_until, u.last_failed_attempt_at, w.public_key
        FROM users u LEFT JOIN wallets w ON w.user_id = u.id
        WHERE u.email = $1`,
       [email]
@@ -152,49 +152,83 @@ async function login(req, res, next) {
 
     const user = result.rows[0];
     const now = new Date();
+    const LOCKOUT_DURATION_MINUTES = 15;
+    const MAX_FAILED_ATTEMPTS = 5;
+    const ATTEMPT_WINDOW_MINUTES = 15;
 
+    // Check if account is currently locked
     if (user && user.locked_until) {
       const lockUntil = new Date(user.locked_until);
       if (now < lockUntil) {
         return res.status(423).json({
-          error: `Account locked until ${lockUntil.toISOString()}`,
+          error: `Account locked. Try again after ${lockUntil.toISOString()}`,
+          locked_until: lockUntil.toISOString(),
         });
       }
 
+      // Lock has expired, reset attempt counters
       await db.query(
-        `UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = $1`,
+        `UPDATE users SET failed_login_attempts = 0, locked_until = NULL, last_failed_attempt_at = NULL WHERE id = $1`,
         [user.id]
       );
       user.failed_login_attempts = 0;
       user.locked_until = null;
+      user.last_failed_attempt_at = null;
     }
 
+    // Verify password
     const isValidPassword = user && (await bcrypt.compare(password, user.password_hash));
     if (!user || !isValidPassword) {
+      // Invalid credentials - increment failed attempts for existing users
       if (user) {
-        const attempts = (user.failed_login_attempts || 0) + 1;
-        if (attempts >= 10) {
-          const lockedUntil = new Date(Date.now() + 30 * 60 * 1000);
+        const lastAttempt = user.last_failed_attempt_at ? new Date(user.last_failed_attempt_at) : null;
+        const now = new Date();
+        const ATTEMPT_WINDOW_MS = ATTEMPT_WINDOW_MINUTES * 60 * 1000;
+
+        let failedAttempts = user.failed_login_attempts || 0;
+
+        // If the last attempt was outside the 15-minute window, reset the counter
+        if (lastAttempt && (now - lastAttempt) > ATTEMPT_WINDOW_MS) {
+          failedAttempts = 0;
+        }
+
+        // Increment failed attempts
+        failedAttempts++;
+        const nowTimestamp = now;
+
+        // Check if we should lock the account
+        if (failedAttempts >= MAX_FAILED_ATTEMPTS) {
+          const lockedUntil = new Date(now + (LOCKOUT_DURATION_MINUTES * 60 * 1000));
           await db.query(
-            `UPDATE users SET failed_login_attempts = $1, locked_until = $2 WHERE id = $3`,
-            [attempts, lockedUntil, user.id]
+            `UPDATE users SET failed_login_attempts = $1, locked_until = $2, last_failed_attempt_at = $3 WHERE id = $4`,
+            [failedAttempts, lockedUntil, nowTimestamp, user.id]
           );
-          audit.log(user.id, 'login_failure', req.ip, req.headers['user-agent']);
+          audit.log(user.id, 'account_locked', req.ip, req.headers['user-agent'], {
+            reason: 'excessive_failed_login_attempts',
+            attempts: failedAttempts,
+            locked_until: lockedUntil.toISOString(),
+          });
           return res.status(423).json({
-            error: `Account locked until ${lockedUntil.toISOString()}`,
+            error: `Account locked due to too many failed login attempts. Try again after ${lockedUntil.toISOString()}`,
+            locked_until: lockedUntil.toISOString(),
           });
         }
 
+        // Update attempt counter and timestamp
         await db.query(
-          `UPDATE users SET failed_login_attempts = $1 WHERE id = $2`,
-          [attempts, user.id]
+          `UPDATE users SET failed_login_attempts = $1, last_failed_attempt_at = $2 WHERE id = $3`,
+          [failedAttempts, nowTimestamp, user.id]
         );
-        audit.log(user.id, 'login_failure', req.ip, req.headers['user-agent']);
+        audit.log(user.id, 'login_failure', req.ip, req.headers['user-agent'], {
+          failed_attempts: failedAttempts,
+          attempts_remaining: MAX_FAILED_ATTEMPTS - failedAttempts,
+        });
       }
 
       return res.status(401).json({ error: 'Invalid email or password' });
     }
 
+    // Password is valid
     if (!user.email_verified) {
       return res.status(403).json({ error: 'Please verify your email before logging in.' });
     }
@@ -211,8 +245,9 @@ async function login(req, res, next) {
       }
     }
 
+    // Successful login - reset attempt counters
     await db.query(
-      `UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = $1`,
+      `UPDATE users SET failed_login_attempts = 0, locked_until = NULL, last_failed_attempt_at = NULL WHERE id = $1`,
       [user.id]
     );
 
@@ -222,9 +257,7 @@ async function login(req, res, next) {
     const { raw, hash } = generateRefreshToken();
     const expiresAt = refreshTokenExpiresAt();
     const familyId = uuidv4();
-    const { raw, hash } = generateRefreshToken();
-    const expiresAt = refreshTokenExpiresAt();
-    
+
     await db.query(
       `INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, family_id, revoked)
        VALUES ($1, $2, $3, $4, $5, FALSE)`,

--- a/database/migrations/022_add_last_failed_attempt_timestamp.js
+++ b/database/migrations/022_add_last_failed_attempt_timestamp.js
@@ -1,0 +1,9 @@
+exports.up = (pgm) => {
+  pgm.addColumns('users', {
+    last_failed_attempt_at: { type: 'timestamptz' },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('users', ['last_failed_attempt_at']);
+};

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE users (
   token_expires_at   TIMESTAMPTZ,
   failed_login_attempts INTEGER NOT NULL DEFAULT 0,
   locked_until        TIMESTAMPTZ,
+  last_failed_attempt_at TIMESTAMPTZ,
   created_at         TIMESTAMPTZ DEFAULT NOW(),
   updated_at         TIMESTAMPTZ DEFAULT NOW()
 );


### PR DESCRIPTION
…utes

Fixes brute force attacks by locking accounts per-email instead of per-IP:

Changes:
- Add last_failed_attempt_at column to users table via migration
- Implement 15-minute rolling window for counting failed login attempts
- Lock account for 15 minutes after 5 consecutive failed attempts within the window
- Reset attempt counter on successful login
- Record account lockout events in audit log with metadata:
  - reason: 'excessive_failed_login_attempts'
  - attempts count and locked_until timestamp
- Return 423 Locked response with expiration time
- Include attempts_remaining info in failed login audit logs
- Fix duplicate variable declaration bug in token generation

Acceptance Criteria Met:
✓ Lock account for 15 minutes after 5 consecutive failed login attempts within 15 minutes ✓ Add last_failed_attempt_at column to users via migration ✓ Successful login resets the attempt counter
✓ Record lockout in audit log with reason and details ✓ Return 423 Locked with message indicating when lock expires
closes #247 