### PR TITLE
Add 2FA verification to wallet export endpoint

### DIFF
--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -22,6 +22,7 @@ const {
 const QRCode = require('qrcode');
 const cache = require('../utils/cache');
 const audit = require('../services/audit');
+const { verifyToken } = require('../services/twofa');
 
 
 const MAX_WALLETS_PER_USER = 5;
@@ -197,14 +198,21 @@ async function getWalletTransactions(req, res, next) {
 // ---------------------------------------------------------------------------
 async function exportKey(req, res, next) {
   try {
-    const { password, wallet_id } = req.body;
+    const { password, wallet_id, totp_code } = req.body;
     if (!password) return res.status(400).json({ error: 'Password is required' });
 
-    const userResult = await db.query('SELECT password_hash FROM users WHERE id = $1', [req.user.userId]);
+    const userResult = await db.query('SELECT password_hash, totp_enabled, totp_secret FROM users WHERE id = $1', [req.user.userId]);
     if (!userResult.rows[0]) return res.status(404).json({ error: 'User not found' });
 
     const valid = await bcrypt.compare(password, userResult.rows[0].password_hash);
     if (!valid) return res.status(401).json({ error: 'Incorrect password' });
+
+    // Check 2FA if enabled
+    if (userResult.rows[0].totp_enabled) {
+      if (!totp_code) return res.status(403).json({ error: '2FA verification required' });
+      const isValidTotp = verifyToken(userResult.rows[0].totp_secret, totp_code);
+      if (!isValidTotp) return res.status(403).json({ error: '2FA verification required' });
+    }
 
     const wallet = await resolveWallet(req.user.userId, wallet_id || null);
     if (!wallet) return res.status(404).json({ error: 'Wallet not found' });

--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -75,6 +75,7 @@ router.post(
   [
     body('password').notEmpty().withMessage('Password is required'),
     body('wallet_id').optional().isUUID().withMessage('wallet_id must be a valid UUID'),
+    body('totp_code').optional().trim().isLength({ min: 6, max: 6 }).withMessage('TOTP code must be 6 digits'),
   ],
   validate,
   exportKey,

--- a/backend/tests/wallet-export.test.js
+++ b/backend/tests/wallet-export.test.js
@@ -1,0 +1,153 @@
+jest.mock('../src/db');
+jest.mock('../src/services/stellar');
+jest.mock('../src/services/audit', () => ({ log: jest.fn() }));
+jest.mock('../src/services/twofa');
+
+const bcrypt = require('bcryptjs');
+const db = require('../src/db');
+const { decryptPrivateKey } = require('../src/services/stellar');
+const audit = require('../src/services/audit');
+const { verifyToken } = require('../src/services/twofa');
+const { exportKey } = require('../src/controllers/walletController');
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.ENCRYPTION_KEY = 'test_key';
+});
+
+test('returns 400 when password is missing', async () => {
+  const req = {
+    user: { userId: 1 },
+    body: { wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Password is required' });
+});
+
+test('returns 404 when user not found', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+
+  const req = {
+    user: { userId: 1 },
+    body: { password: 'test', wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(res.status).toHaveBeenCalledWith(404);
+  expect(res.json).toHaveBeenCalledWith({ error: 'User not found' });
+});
+
+test('returns 401 when password is incorrect', async () => {
+  const hashedPassword = await bcrypt.hash('correct_password', 10);
+  db.query.mockResolvedValueOnce({ rows: [{ password_hash: hashedPassword, totp_enabled: false }] });
+
+  const req = {
+    user: { userId: 1 },
+    body: { password: 'wrong_password', wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Incorrect password' });
+});
+
+test('returns 403 when 2FA is enabled but totp_code is missing', async () => {
+  const hashedPassword = await bcrypt.hash('test_password', 10);
+  db.query.mockResolvedValueOnce({ rows: [{ password_hash: hashedPassword, totp_enabled: true, totp_secret: 'secret123' }] });
+
+  const req = {
+    user: { userId: 1 },
+    body: { password: 'test_password', wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: '2FA verification required' });
+});
+
+test('returns 403 when 2FA is enabled but totp_code is invalid', async () => {
+  const hashedPassword = await bcrypt.hash('test_password', 10);
+  db.query.mockResolvedValueOnce({ rows: [{ password_hash: hashedPassword, totp_enabled: true, totp_secret: 'secret123' }] });
+  verifyToken.mockReturnValue(false);
+
+  const req = {
+    user: { userId: 1 },
+    body: { password: 'test_password', totp_code: '000000', wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: '2FA verification required' });
+});
+
+test('exports key successfully when 2FA is enabled and valid totp_code is provided', async () => {
+  const hashedPassword = await bcrypt.hash('test_password', 10);
+  db.query.mockResolvedValueOnce({ rows: [{ password_hash: hashedPassword, totp_enabled: true, totp_secret: 'secret123' }] });
+  db.query.mockResolvedValueOnce({ rows: [{ id: 'wallet1', public_key: 'GPUB', encrypted_secret_key: 'enc_key', is_default: true }] });
+  verifyToken.mockReturnValue(true);
+  decryptPrivateKey.mockReturnValue('GPRIV');
+
+  const req = {
+    user: { userId: 1 },
+    body: { password: 'test_password', totp_code: '123456', wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(verifyToken).toHaveBeenCalledWith('secret123', '123456');
+  expect(audit.log).toHaveBeenCalledWith(1, 'wallet_export', '127.0.0.1', 'test', { wallet_id: 'wallet1' });
+  expect(res.json).toHaveBeenCalledWith({ secret_key: 'GPRIV' });
+});
+
+test('exports key successfully when 2FA is disabled (no totp_code required)', async () => {
+  const hashedPassword = await bcrypt.hash('test_password', 10);
+  db.query.mockResolvedValueOnce({ rows: [{ password_hash: hashedPassword, totp_enabled: false }] });
+  db.query.mockResolvedValueOnce({ rows: [{ id: 'wallet1', public_key: 'GPUB', encrypted_secret_key: 'enc_key', is_default: true }] });
+  decryptPrivateKey.mockReturnValue('GPRIV');
+
+  const req = {
+    user: { userId: 1 },
+    body: { password: 'test_password', wallet_id: null },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test' }
+  };
+  const res = mockRes();
+
+  await exportKey(req, res, jest.fn());
+
+  expect(verifyToken).not.toHaveBeenCalled();
+  expect(audit.log).toHaveBeenCalledWith(1, 'wallet_export', '127.0.0.1', 'test', { wallet_id: 'wallet1' });
+  expect(res.json).toHaveBeenCalledWith({ secret_key: 'GPRIV' });
+});


### PR DESCRIPTION
closes #279 
- Require TOTP code when 2FA is enabled for POST /api/wallet/export-key
- Return 403 with '2FA verification required' if code is missing or invalid
- Audit log includes wallet_export event with IP and user agent
- Add comprehensive test coverage for 2FA scenarios