### PR TITLE
fix: escrow address validation, fee guard, deploy network arg, error messages

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -12,11 +12,38 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Configuration
+# Parse arguments
 NETWORK="${STELLAR_NETWORK:-testnet}"
-CONTRACT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Default to escrow for backwards compatibility; override with CONTRACT=recurring-payments
+CONFIRM_MAINNET=false
 TARGET_CONTRACT="${CONTRACT:-escrow}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --network)
+            NETWORK="$2"
+            shift 2
+            ;;
+        --confirm-mainnet)
+            CONFIRM_MAINNET=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ "$NETWORK" != "testnet" && "$NETWORK" != "mainnet" ]]; then
+    echo -e "${RED}Error: --network must be 'testnet' or 'mainnet'${NC}"
+    exit 1
+fi
+
+if [[ "$NETWORK" == "mainnet" && "$CONFIRM_MAINNET" != "true" ]]; then
+    echo -e "${RED}Error: Mainnet deployment requires --confirm-mainnet flag to prevent accidental production deployments.${NC}"
+    exit 1
+fi
+
+CONTRACT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$TARGET_CONTRACT" in
   escrow)
@@ -48,7 +75,7 @@ esac
 BUILTIN_CONTRACT_DIR="$HOME/.soroban"
 
 echo -e "${YELLOW}=== Soroban ${TARGET_CONTRACT} Contract Deployment ===${NC}"
-echo "Network: $NETWORK"
+echo -e "${YELLOW}>>> DEPLOYING TO NETWORK: ${NETWORK} <<<${NC}"
 echo "Contract Directory: $CONTRACT_DIR"
 
 # Step 1: Check prerequisites

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -51,7 +51,6 @@ pub enum EscrowStatus {
     Cancelled,
 }
 
-// Storage keys
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -61,7 +60,6 @@ pub enum DataKey {
     Escrow(u64),
 }
 
-// 30 days in seconds
 const DEFAULT_EXPIRY_SECS: u64 = 30 * 24 * 60 * 60;
 
 #[contract]
@@ -95,6 +93,9 @@ impl EscrowContract {
         }
         if release_fee_bps > 10000 {
             panic!("Fee percentage cannot exceed 100%");
+        }
+        if sender == recipient || sender == agent || recipient == agent {
+            panic!("Sender, recipient, and agent must be distinct addresses");
         }
 
         sender.require_auth();
@@ -152,7 +153,6 @@ impl EscrowContract {
         next_id
     }
 
-    /// Top up an existing pending escrow. Panics if the escrow has expired.
     pub fn deposit(env: Env, sender: Address, escrow_id: u64, amount: i128) {
         if amount <= 0 {
             panic!("Amount must be positive");
@@ -164,13 +164,12 @@ impl EscrowContract {
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found");
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id));
 
         if escrow.status != EscrowStatus::Pending {
             panic!("Escrow is not in pending state");
         }
 
-        // Block deposits into expired escrows (#7 AlreadyReleased equivalent)
         if env.ledger().timestamp() >= escrow.expires_at {
             panic!("Escrow has expired");
         }
@@ -179,7 +178,7 @@ impl EscrowContract {
             .storage()
             .persistent()
             .get(&DataKey::UsdcAddress)
-            .unwrap();
+            .expect("Contract not initialized");
 
         token::Client::new(&env, &usdc_address).transfer(
             &sender,
@@ -200,7 +199,7 @@ impl EscrowContract {
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found");
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id));
 
         if agent != escrow.agent {
             panic!("Only the agent can release escrow");
@@ -211,241 +210,6 @@ impl EscrowContract {
 
         let fee_amount = (escrow.amount * escrow.release_fee_bps as i128) / 10000;
         let agent_amount = escrow.amount - fee_amount;
-
-        let usdc_address: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::UsdcAddress)
-            .unwrap();
-
-        token::Client::new(&env, &usdc_address).transfer(
-            &env.current_contract_address(),
-            &escrow.agent,
-            &agent_amount,
-        );
-
-        let current_fees: i128 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::AccumulatedFees)
-            .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&DataKey::AccumulatedFees, &(current_fees + fee_amount));
-
-        escrow.status = EscrowStatus::Released;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Escrow(escrow_id), &escrow);
-
-        env.events().publish(
-            (Symbol::new(&env, "EscrowReleased"),),
-            EscrowReleased {
-                escrow_id,
-                agent_amount,
-                fee_amount,
-            },
-        );
-    }
-
-    pub fn cancel_escrow(env: Env, sender: Address, escrow_id: u64) {
-        sender.require_auth();
-
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found");
-
-        if sender != escrow.sender {
-            panic!("Only the sender can cancel escrow");
-        }
-        if escrow.status != EscrowStatus::Pending {
-            panic!("Escrow is not in pending state");
-        }
-
-        let usdc_address: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::UsdcAddress)
-            .unwrap();
-
-        token::Client::new(&env, &usdc_address).transfer(
-            &env.current_contract_address(),
-            &escrow.sender,
-            &escrow.amount,
-        );
-
-        escrow.status = EscrowStatus::Cancelled;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Escrow(escrow_id), &escrow);
-
-        env.events().publish(
-            (Symbol::new(&env, "EscrowCancelled"),),
-            EscrowCancelled {
-                escrow_id,
-                refund_amount: escrow.amount,
-            },
-        );
-    }
-
-    pub fn get_escrow(env: Env, escrow_id: u64) -> Escrow {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found")
-    }
-
-    pub fn get_accumulated_fees(env: Env) -> i128 {
-        env.storage()
-            .persistent()
-            .get(&DataKey::AccumulatedFees)
-            .unwrap_or(0)
-    }
-
-    pub fn withdraw_fees(env: Env, admin: Address, amount: i128) {
-        admin.require_auth();
-
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Admin)
-            .unwrap();
-
-        if admin != stored_admin {
-            panic!("Only admin can withdraw fees");
-        }
-
-        let current_fees: i128 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::AccumulatedFees)
-            .unwrap_or(0);
-
-        if amount > current_fees {
-            panic!("Insufficient accumulated fees");
-        }
-
-        let usdc_address: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::UsdcAddress)
-            .unwrap();
-
-        token::Client::new(&env, &usdc_address).transfer(
-            &env.current_contract_address(),
-            &admin,
-            &amount,
-        );
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::AccumulatedFees, &(current_fees - amount));
-    }
-
-    pub fn get_metadata(env: Env) -> (Address, Address) {
-        let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
-        let usdc_address: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::UsdcAddress)
-            .unwrap();
-        (admin, usdc_address)
-    }
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct EscrowCreated {
-    pub escrow_id: u64,
-    pub sender: Address,
-    pub recipient: Address,
-    pub agent: Address,
-    pub amount: i128,
-    pub release_fee_bps: u32,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct EscrowReleased {
-    pub escrow_id: u64,
-    pub agent_amount: i128,
-    pub fee_amount: i128,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct EscrowCancelled {
-    pub escrow_id: u64,
-    pub refund_amount: i128,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct Escrow {
-    pub id: u64,
-    pub sender: Address,
-    pub recipient: Address,
-    pub agent: Address,
-    pub amount: i128,
-    pub release_fee_bps: u32,
-    pub status: EscrowStatus,
-    pub created_at: u64,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-#[contracttype]
-pub enum EscrowStatus {
-    Pending,
-    Released,
-    Cancelled,
-}
-
-// Storage keys
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    UsdcAddress,
-    EscrowCounter,
-    AccumulatedFees,
-    Escrow(u64),
-}
-
-#[contract]
-pub struct EscrowContract;
-
-#[contractimpl]
-impl EscrowContract {
-    pub fn initialize(env: Env, admin: Address, usdc_address: Address) {
-        if env.storage().persistent().has(&DataKey::Admin) {
-            panic!("Contract already initialized");
-        }
-        env.storage().persistent().set(&DataKey::Admin, &admin);
-        env.storage().persistent().set(&DataKey::UsdcAddress, &usdc_address);
-        env.storage().persistent().set(&DataKey::EscrowCounter, &0u64);
-        env.events().publish(
-            (Symbol::new(&env, "EscrowInitialized"),),
-            (env.current_contract_address(), admin, usdc_address),
-        );
-    }
-
-    pub fn create_escrow(
-        env: Env,
-        sender: Address,
-        recipient: Address,
-        agent: Address,
-        amount: i128,
-        release_fee_bps: u32,
-    ) -> u64 {
-        if amount <= 0 {
-            panic!("Amount must be positive");
-        }
-        if release_fee_bps > 10000 {
-            panic!("Fee percentage cannot exceed 100%");
-        }
-
-        sender.require_auth();
 
         let usdc_address: Address = env
             .storage()
@@ -454,76 +218,6 @@ impl EscrowContract {
             .expect("Contract not initialized");
 
         token::Client::new(&env, &usdc_address).transfer(
-            &sender,
-            &env.current_contract_address(),
-            &amount,
-        );
-
-        let current_id: u64 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::EscrowCounter)
-            .unwrap_or(0);
-        let next_id = current_id + 1;
-        env.storage()
-            .persistent()
-            .set(&DataKey::EscrowCounter, &next_id);
-
-        let escrow = Escrow {
-            id: next_id,
-            sender: sender.clone(),
-            recipient: recipient.clone(),
-            agent: agent.clone(),
-            amount,
-            release_fee_bps,
-            status: EscrowStatus::Pending,
-            created_at: env.ledger().timestamp(),
-        };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Escrow(next_id), &escrow);
-
-        env.events().publish(
-            (Symbol::new(&env, "EscrowCreated"),),
-            EscrowCreated {
-                escrow_id: next_id,
-                sender,
-                recipient,
-                agent,
-                amount,
-                release_fee_bps,
-            },
-        );
-
-        next_id
-    }
-
-    pub fn release_escrow(env: Env, agent: Address, escrow_id: u64) {
-        agent.require_auth();
-
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found");
-
-        if agent != escrow.agent {
-            panic!("Only the agent can release escrow");
-        }
-        if escrow.status != EscrowStatus::Pending {
-            panic!("Escrow is not in pending state");
-        }
-
-        let fee_amount = (escrow.amount * escrow.release_fee_bps as i128) / 10000;
-        let agent_amount = escrow.amount - fee_amount;
-
-        let usdc_address: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::UsdcAddress)
-            .unwrap();
-
-        token::Client::new(&env, &usdc_address).transfer(
             &env.current_contract_address(),
             &escrow.agent,
             &agent_amount,
@@ -560,7 +254,7 @@ impl EscrowContract {
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found");
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id));
 
         if sender != escrow.sender {
             panic!("Only the sender can cancel escrow");
@@ -573,7 +267,7 @@ impl EscrowContract {
             .storage()
             .persistent()
             .get(&DataKey::UsdcAddress)
-            .unwrap();
+            .expect("Contract not initialized");
 
         token::Client::new(&env, &usdc_address).transfer(
             &env.current_contract_address(),
@@ -599,7 +293,7 @@ impl EscrowContract {
         env.storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
-            .expect("Escrow not found")
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id))
     }
 
     pub fn get_accumulated_fees(env: Env) -> i128 {
@@ -612,11 +306,15 @@ impl EscrowContract {
     pub fn withdraw_fees(env: Env, admin: Address, amount: i128) {
         admin.require_auth();
 
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+
         let stored_admin: Address = env
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .unwrap();
+            .expect("Contract not initialized");
 
         if admin != stored_admin {
             panic!("Only admin can withdraw fees");
@@ -636,7 +334,7 @@ impl EscrowContract {
             .storage()
             .persistent()
             .get(&DataKey::UsdcAddress)
-            .unwrap();
+            .expect("Contract not initialized");
 
         token::Client::new(&env, &usdc_address).transfer(
             &env.current_contract_address(),
@@ -650,12 +348,16 @@ impl EscrowContract {
     }
 
     pub fn get_metadata(env: Env) -> (Address, Address) {
-        let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
         let usdc_address: Address = env
             .storage()
             .persistent()
             .get(&DataKey::UsdcAddress)
-            .unwrap();
+            .expect("Contract not initialized");
         (admin, usdc_address)
     }
 }

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -249,10 +249,57 @@ fn test_withdraw_fees_wrong_caller() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow not found")]
+#[should_panic(expected = "Escrow 999 not found")]
 fn test_get_nonexistent_escrow() {
     let (_, client, _, _) = setup();
     client.get_escrow(&999);
+}
+
+// ── #346: distinct addresses ──────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Sender, recipient, and agent must be distinct addresses")]
+fn test_create_escrow_sender_equals_agent() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint_usdc(&env, &usdc_id, &admin, &sender, 1_000_0000000);
+    client.create_escrow(&sender, &recipient, &sender, &1_000_0000000, &250);
+}
+
+#[test]
+#[should_panic(expected = "Sender, recipient, and agent must be distinct addresses")]
+fn test_create_escrow_sender_equals_recipient() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let agent = Address::generate(&env);
+    mint_usdc(&env, &usdc_id, &admin, &sender, 1_000_0000000);
+    client.create_escrow(&sender, &sender, &agent, &1_000_0000000, &250);
+}
+
+#[test]
+#[should_panic(expected = "Sender, recipient, and agent must be distinct addresses")]
+fn test_create_escrow_agent_equals_recipient() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint_usdc(&env, &usdc_id, &admin, &sender, 1_000_0000000);
+    client.create_escrow(&sender, &recipient, &recipient, &1_000_0000000, &250);
+}
+
+// ── #347: withdraw_fees amount > 0 ───────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_withdraw_fees_zero_amount_panics() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    mint_usdc(&env, &usdc_id, &admin, &sender, 1_000_0000000);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &1_000_0000000, &500);
+    client.release_escrow(&agent, &escrow_id);
+    client.withdraw_fees(&admin, &0);
 }
 
 #[test]


### PR DESCRIPTION

Escrow contract does not validate that sender, recipient, and agent are distinct addresses Fixes #346

Escrow contract withdraw_fees does not validate that amount > 0 Fixes #347

contracts/deploy.sh hardcodes testnet RPC URL — does not support mainnet deployment Fixes #348

Escrow contract get_escrow panics with unhelpful message when escrow ID does not exist Fixes #349