### PR TITLE
fix: validate KYC document upload — MIME type, size, UUID filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Thumbs.db
 # Editor
 .vscode/
 .idea/
+
+# KYC document uploads — keep directory, ignore contents
+uploads/kyc/*
+!uploads/kyc/.gitkeep

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,8 @@
         "helmet": "^8.0.0",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.2",
+        "multer": "1.4.5-lts.1",
+        "node-cron": "^3.0.3",
         "node-pg-migrate": "^7.0.0",
         "nodemailer": "^8.0.3",
         "pg": "^8.11.3",
@@ -142,6 +144,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1824,6 +1827,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2187,6 +2196,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2254,8 +2264,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2684,6 +2704,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2751,6 +2822,12 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -3265,6 +3342,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5228,6 +5306,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -5237,11 +5324,42 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -5273,6 +5391,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-int64": {
@@ -5826,6 +5965,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6037,6 +6177,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prom-client": {
       "version": "15.1.3",
@@ -6877,6 +7023,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7485,6 +7639,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "helmet": "^8.0.0",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",
+    "multer": "1.4.5-lts.1",
     "node-cron": "^3.0.3",
     "node-pg-migrate": "^7.0.0",
     "nodemailer": "^8.0.3",

--- a/backend/src/__tests__/kyc.test.js
+++ b/backend/src/__tests__/kyc.test.js
@@ -1,0 +1,115 @@
+const request = require("supertest");
+const express = require("express");
+const path = require("path");
+const fs = require("fs");
+
+jest.mock("../db");
+jest.mock("../middleware/auth", () => (req, res, next) => {
+  req.user = { userId: "user-test-1" };
+  next();
+});
+jest.mock("../services/stellar", () => ({}));
+
+const db = require("../db");
+const kycRouter = require("../routes/kyc");
+
+const app = express();
+app.use(express.json());
+app.use("/kyc", kycRouter);
+
+const VALID_BODY = {
+  id_type: "passport",
+  id_number: "AB1234567",
+  date_of_birth: "1990-01-15",
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// Clean up any files written during tests
+afterAll(() => {
+  const uploadDir = path.resolve(__dirname, "../../../uploads/kyc");
+  if (fs.existsSync(uploadDir)) {
+    fs.readdirSync(uploadDir)
+      .filter((f) => f !== ".gitkeep")
+      .forEach((f) => fs.unlinkSync(path.join(uploadDir, f)));
+  }
+});
+
+describe("POST /kyc/submit — file validation", () => {
+  test("rejects request with no file (400)", async () => {
+    const res = await request(app).post("/kyc/submit").field(VALID_BODY);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/document file is required/i);
+  });
+
+  test("rejects disallowed MIME type — text/plain (400)", async () => {
+    const res = await request(app)
+      .post("/kyc/submit")
+      .field(VALID_BODY)
+      .attach("document", Buffer.from("hello"), { filename: "doc.txt", contentType: "text/plain" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/jpeg|png|pdf/i);
+  });
+
+  test("rejects file exceeding 10 MB (400)", async () => {
+    const bigBuffer = Buffer.alloc(11 * 1024 * 1024, "a");
+    const res = await request(app)
+      .post("/kyc/submit")
+      .field(VALID_BODY)
+      .attach("document", bigBuffer, { filename: "big.pdf", contentType: "application/pdf" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/10 mb/i);
+  });
+
+  test("accepts valid JPEG under 10 MB and stores with UUID filename (200)", async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ kyc_status: "not_submitted" }] }) // status check
+      .mockResolvedValueOnce({ rows: [] }); // update
+
+    const res = await request(app)
+      .post("/kyc/submit")
+      .field(VALID_BODY)
+      .attach("document", Buffer.from("fake-jpeg-data"), {
+        filename: "id.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.kyc_status).toBe("pending");
+
+    // Verify the stored filename is UUID-based, not the original
+    const savedFilename = db.query.mock.calls[1][1][0]; // first param of UPDATE call
+    const kycData = JSON.parse(savedFilename);
+    expect(kycData.document_filename).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/,
+    );
+    expect(kycData.document_mimetype).toBe("image/jpeg");
+  });
+
+  test("accepts valid PDF under 10 MB (200)", async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ kyc_status: "not_submitted" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post("/kyc/submit")
+      .field(VALID_BODY)
+      .attach("document", Buffer.from("%PDF-fake"), {
+        filename: "passport.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects missing id_type field (400)", async () => {
+    const res = await request(app)
+      .post("/kyc/submit")
+      .field({ id_number: "AB123", date_of_birth: "1990-01-15" })
+      .attach("document", Buffer.from("data"), {
+        filename: "doc.jpg",
+        contentType: "image/jpeg",
+      });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/controllers/kycController.js
+++ b/backend/src/controllers/kycController.js
@@ -15,6 +15,9 @@ async function submitKYC(req, res, next) {
     if (!date_of_birth || isNaN(Date.parse(date_of_birth))) {
       return res.status(400).json({ error: "Invalid date of birth" });
     }
+    if (!req.file) {
+      return res.status(400).json({ error: "Document file is required" });
+    }
 
     // Check current status — do not allow resubmission if already verified or pending
     const userResult = await db.query("SELECT kyc_status FROM users WHERE id = $1", [
@@ -35,6 +38,8 @@ async function submitKYC(req, res, next) {
       id_type,
       id_number_last4: id_number.trim().slice(-4),
       date_of_birth,
+      document_filename: req.file.filename,
+      document_mimetype: req.file.mimetype,
       submitted_at: new Date().toISOString(),
     };
 

--- a/backend/src/middleware/kycUpload.js
+++ b/backend/src/middleware/kycUpload.js
@@ -1,0 +1,27 @@
+const multer = require("multer");
+const path = require("path");
+const { v4: uuidv4 } = require("uuid");
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf"];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+// Store outside web root: uploads/ at project root, not inside src/
+const storage = multer.diskStorage({
+  destination: path.resolve(__dirname, "../../../uploads/kyc"),
+  filename: (_req, _file, cb) => {
+    const ext = { "image/jpeg": ".jpg", "image/png": ".png", "application/pdf": ".pdf" };
+    cb(null, uuidv4() + ext[_file.mimetype]);
+  },
+});
+
+const fileFilter = (_req, file, cb) => {
+  if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(Object.assign(new Error("Only JPEG, PNG, and PDF files are allowed"), { status: 400 }));
+  }
+};
+
+module.exports = multer({ storage, fileFilter, limits: { fileSize: MAX_FILE_SIZE } }).single(
+  "document",
+);

--- a/backend/src/routes/kyc.js
+++ b/backend/src/routes/kyc.js
@@ -1,6 +1,8 @@
 const router = require("express").Router();
+const multer = require("multer");
 const { body, validationResult } = require("express-validator");
 const authMiddleware = require("../middleware/auth");
+const kycUpload = require("../middleware/kycUpload");
 const { submitKYC, getKYCStatus } = require("../controllers/kycController");
 
 const validate = (req, res, next) => {
@@ -9,12 +11,24 @@ const validate = (req, res, next) => {
   next();
 };
 
+// Wrap multer so its errors surface as 400 responses instead of 500s
+const upload = (req, res, next) => {
+  kycUpload(req, res, (err) => {
+    if (!err) return next();
+    if (err instanceof multer.MulterError && err.code === "LIMIT_FILE_SIZE") {
+      return res.status(400).json({ error: "File size must not exceed 10 MB" });
+    }
+    return res.status(400).json({ error: err.message || "File upload error" });
+  });
+};
+
 router.use(authMiddleware);
 
 router.get("/status", getKYCStatus);
 
 router.post(
   "/submit",
+  upload,
   [
     body("id_type").notEmpty().withMessage("ID type is required"),
     body("id_number").notEmpty().withMessage("ID number is required"),


### PR DESCRIPTION
close #251 


Branch: fix/kyc-document-upload-validation

Files changed:

- backend/src/middleware/kycUpload.js (new) — multer middleware that:
  - Allows only image/jpeg, image/png, application/pdf
  - Enforces 10 MB max file size
  - Stores files as <uuid>.<ext> in uploads/kyc/ (outside the web root / src/)

- backend/src/routes/kyc.js — wires the upload middleware into POST /kyc/submit with a custom error handler that converts multer errors to 400 responses

- backend/src/controllers/kycController.js — requires req.file to be present (400 if missing), and records document_filename + document_mimetype in the stored kyc_data

- uploads/kyc/.gitkeep — directory tracked, contents gitignored

- backend/src/__tests__/kyc.test.js (new) — 6 tests covering all acceptance criteria: missing file, wrong MIME type, oversized file, valid JPEG, valid PDF, missing body field

CI check: The 29 pre-existing failures on this branch are all syntax errors in paymentController.js, authController.js, stellar.js, and index.js that exist on main too (main has 30 failing suites vs 29 here — the KYC suite 
was already failing on main before this fix).
