### PR TITLE
feat-pattern: fix ILIKE injection in getUsers search

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -30,7 +30,15 @@ async function getUsers(req, res, next) {
     const page = Math.max(1, parseInt(req.query.page) || 1);
     const limit = Math.min(100, parseInt(req.query.limit) || 20);
     const offset = (page - 1) * limit;
-    const search = req.query.search ? `%${req.query.search}%` : null;
+    let search = req.query.search || null;
+    if (search) {
+      if (search.length > 100) {
+        return res.status(400).json({ error: 'Search string exceeds maximum length of 100 characters' });
+      }
+      // Escape PostgreSQL special pattern characters
+      search = search.replace(/[%_\\]/g, '\\$&');
+      search = `%${search}%`;
+    }
 
     const params = search ? [search, search, limit, offset] : [limit, offset];
     const where = search ? `WHERE u.full_name ILIKE $1 OR u.email ILIKE $2` : '';
@@ -96,7 +104,7 @@ async function getTransactions(req, res, next) {
   }
 }
 
-module.exports = { getStats, getUsers, getTransactions, getStellarNetworkStats };
+
 
 async function getStellarNetworkStats(req, res, next) {
   try {
@@ -115,7 +123,10 @@ async function getStellarNetworkStats(req, res, next) {
     stellarStatsCacheTime = now;
 
     res.json(stats);
-module.exports = { getStats, getUsers, getTransactions, clawback };
+  } catch (err) {
+    next(err);
+  }
+}
 
 /**
  * POST /api/admin/clawback
@@ -267,7 +278,7 @@ async function revokeKYC(req, res, next) {
   }
 }
 
-module.exports = { getStats, getUsers, getTransactions, clawback, approveKYC, revokeKYC };
+
 
 const { getAccountFlags, setAccountFlags } = require('../services/stellar');
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -3,14 +3,12 @@ const { body, validationResult } = require('express-validator');
 const StellarSdk = require('@stellar/stellar-sdk');
 const authMiddleware = require('../middleware/auth');
 const isAdmin = require('../middleware/isAdmin');
-const { getStats, getUsers, getTransactions, getStellarNetworkStats } = require('../controllers/adminController');
 const { issueTokens } = require('../controllers/assetController');
-const { getStats, getUsers, getTransactions, clawback, approveKYC, revokeKYC } = require('../controllers/adminController');
-const { getStats, getUsers, getTransactions, clawback, approveKYC, revokeKYC, setWalletFlags } = require('../controllers/adminController');
 const {
   getStats,
   getUsers,
   getTransactions,
+  getStellarNetworkStats,
   clawback,
   approveKYC,
   revokeKYC,

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -340,19 +340,11 @@ async function createClaimableBalance({
   const assetObj = resolveAsset(asset);
   const secretKey = decryptPrivateKey(encryptedSecretKey);
   const senderKeypair = StellarSdk.Keypair.fromSecret(secretKey);
-  const senderAccount = await withRetry(() => withFallback(s => s.loadAccount(senderPublicKey), logger), { label: 'loadAccount(sender)' });
+  const rawAccount = await withRetry(() => withFallback(s => s.loadAccount(senderPublicKey), logger), { label: 'loadAccount(sender)' });
+  const senderAccount = validateHorizonResponse(AccountResponseSchema, rawAccount, 'loadAccount(sender)');
 
   const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
     fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), logger), { label: 'fetchBaseFee' }),
-  const senderAccount = validateHorizonResponse(
-    AccountResponseSchema,
-    await withRetry(() => withFallback(s => s.loadAccount(senderPublicKey)), { label: 'loadAccount(sender)' }),
-    'loadAccount(sender)'
-  );
-  const senderAccount = await withRetry(() => withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount'), { label: 'loadAccount(sender)' });
-
-  const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-    fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' }),
     networkPassphrase
   })
     .addOperation(StellarSdk.Operation.createClaimableBalance({
@@ -370,10 +362,8 @@ async function createClaimableBalance({
   const transaction = txBuilder.build();
   transaction.sign(senderKeypair);
 
-  const result = await withRetry(() => withFallback(s => s.submitTransaction(transaction), logger), { label: 'submitTransaction' });
-  const rawResult = await withRetry(() => withFallback(s => s.submitTransaction(transaction)), { label: 'submitTransaction' });
+  const rawResult = await withRetry(() => withFallback(s => s.submitTransaction(transaction), logger), { label: 'submitTransaction' });
   const result = validateHorizonResponse(TransactionSubmitResponseSchema, rawResult, 'submitTransaction(claimableBalance)');
-  const result = await withRetry(() => withFallback(s => s.submitTransaction(transaction), 'submitTransaction'), { label: 'submitTransaction' });
   return { transactionHash: result.hash, ledger: result.ledger };
 }
 
@@ -489,10 +479,8 @@ async function _sendPaymentOnce({
       const transaction = txBuilder.build();
       transaction.sign(senderKeypair);
 
-      const result = await withFallback(s => s.submitTransaction(transaction), logger);
-      const rawResult = await withFallback(s => s.submitTransaction(transaction));
+      const rawResult = await withFallback(s => s.submitTransaction(transaction), logger);
       const result = validateHorizonResponse(TransactionSubmitResponseSchema, rawResult, 'submitTransaction(payment)');
-      const result = await withFallback(s => s.submitTransaction(transaction), 'submitTransaction');
       return { transactionHash: result.hash, ledger: result.ledger, type: 'payment' };
     } catch (err) {
       if (isBadSeq(err) && attempt < MAX_SEQ_RETRIES - 1) {
@@ -695,6 +683,12 @@ async function issueAsset(recipientPublicKey, amount) {
       destination: recipientPublicKey,
       asset: afriAsset,
       amount: String(amount)
+    }))
+    .setTimeout(30)
+    .build();
+  transaction.sign(distributionKeypair);
+  return await server.submitTransaction(transaction);
+}
 // ---------------------------------------------------------------------------
 // Fee estimate
 // ---------------------------------------------------------------------------
@@ -1059,15 +1053,7 @@ async function getStellarStats() {
   }
 }
 
-module.exports = { 
-  createWallet, 
-  getBalance, 
-  sendPayment, 
-  getTransactions, 
-  decryptPrivateKey,
-  issueAsset,
-  getAssetInfo,
-  getStellarStats
+
   tx.sign(ownerKeypair);
   const rawResult = await withRetry(() => server.submitTransaction(tx), { label: 'submitTransaction(addSigner)' });
   const result = validateHorizonResponse(TransactionSubmitResponseSchema, rawResult, 'submitTransaction(addSigner)');
@@ -1119,14 +1105,8 @@ async function removeAccountSigner({ ownerPublicKey, encryptedSecretKey, signerP
 async function mergeAccount({ sourcePublicKey, encryptedSecretKey, destinationPublicKey }) {
   const secretKey = decryptPrivateKey(encryptedSecretKey);
   const sourceKeypair = StellarSdk.Keypair.fromSecret(secretKey);
-  const sourceAccount = validateHorizonResponse(
-    AccountResponseSchema,
-    await withRetry(() => withFallback(s => s.loadAccount(sourcePublicKey)), { label: 'loadAccount(merge)' }),
-    'loadAccount(merge)'
-  const sourceAccount = await withRetry(
-    () => withFallback(s => s.loadAccount(sourcePublicKey), 'loadAccount'),
-    { label: 'loadAccount(merge)' }
-  );
+  const rawAccount = await withRetry(() => withFallback(s => s.loadAccount(sourcePublicKey)), { label: 'loadAccount(merge)' });
+  const sourceAccount = validateHorizonResponse(AccountResponseSchema, rawAccount, 'loadAccount(merge)');
 
   const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
     fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' }),
@@ -1139,8 +1119,6 @@ async function mergeAccount({ sourcePublicKey, encryptedSecretKey, destinationPu
   tx.sign(sourceKeypair);
   const rawResult = await withRetry(
     () => withFallback(s => s.submitTransaction(tx)),
-  const result = await withRetry(
-    () => withFallback(s => s.submitTransaction(tx), 'submitTransaction'),
     { label: 'submitTransaction(merge)' }
   );
   const result = validateHorizonResponse(TransactionSubmitResponseSchema, rawResult, 'submitTransaction(merge)');
@@ -1157,14 +1135,8 @@ async function clawbackAsset({ issuerPublicKey, encryptedIssuerSecretKey, fromPu
   const assetObj = resolveAsset(asset);
   const secretKey = decryptPrivateKey(encryptedIssuerSecretKey);
   const issuerKeypair = StellarSdk.Keypair.fromSecret(secretKey);
-  const issuerAccount = validateHorizonResponse(
-    AccountResponseSchema,
-    await withRetry(() => withFallback(s => s.loadAccount(issuerPublicKey)), { label: 'loadAccount(clawback)' }),
-    'loadAccount(clawback)'
-  const issuerAccount = await withRetry(
-    () => withFallback(s => s.loadAccount(issuerPublicKey), 'loadAccount'),
-    { label: 'loadAccount(clawback)' }
-  );
+  const rawAccount = await withRetry(() => withFallback(s => s.loadAccount(issuerPublicKey)), { label: 'loadAccount(clawback)' });
+  const issuerAccount = validateHorizonResponse(AccountResponseSchema, rawAccount, 'loadAccount(clawback)');
 
   const tx = new StellarSdk.TransactionBuilder(issuerAccount, {
     fee: await withRetry(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee' }),
@@ -1181,8 +1153,6 @@ async function clawbackAsset({ issuerPublicKey, encryptedIssuerSecretKey, fromPu
   tx.sign(issuerKeypair);
   const rawResult = await withRetry(
     () => withFallback(s => s.submitTransaction(tx)),
-  const result = await withRetry(
-    () => withFallback(s => s.submitTransaction(tx), 'submitTransaction'),
     { label: 'submitTransaction(clawback)' }
   );
   const result = validateHorizonResponse(TransactionSubmitResponseSchema, rawResult, 'submitTransaction(clawback)');
@@ -1382,11 +1352,8 @@ module.exports = {
   setAccountFlags,
   findReceivePath,
   sendStrictReceivePathPayment,
-<<<<<<< feat/bump-sequence-recovery
   isBadSeq,
   recoverSequence,
   withSequenceRecovery,
-=======
   validateNetworkPassphrase,
->>>>>>> main
 };

--- a/backend/tests/adminController.search.test.js
+++ b/backend/tests/adminController.search.test.js
@@ -1,0 +1,81 @@
+const db = require('../src/db');
+const { getUsers } = require('../src/controllers/adminController');
+
+jest.mock('../src/db');
+jest.mock('../src/services/stellar', () => ({
+  getStellarStats: jest.fn(),
+  getAccountFlags: jest.fn(),
+  setAccountFlags: jest.fn(),
+  clawbackAsset: jest.fn()
+}));
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Admin Controller - getUsers', () => {
+  it('should return 400 if search string exceeds 100 characters', async () => {
+    const req = {
+      query: {
+        search: 'a'.repeat(101)
+      }
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await getUsers(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Search string exceeds maximum length of 100 characters' });
+  });
+
+  it('should escape PostgreSQL special characters in search string', async () => {
+    const req = {
+      query: {
+        search: '100%_sure\\'
+      }
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    db.query.mockResolvedValue({ rows: [], count: 0 });
+    // Mock the count query too
+    db.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+    await getUsers(req, res, next);
+
+    expect(db.query).toHaveBeenCalledTimes(2);
+    
+    // Check that the parameter used for search has the escaped characters
+    const firstCallParams = db.query.mock.calls[0][1];
+    expect(firstCallParams[0]).toBe('%100\\%\\_sure\\\\%');
+    expect(firstCallParams[1]).toBe('%100\\%\\_sure\\\\%');
+  });
+
+  it('should verify that a search for "%" does not return all users', async () => {
+    const req = {
+      query: {
+        search: '%'
+      }
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    db.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+    await getUsers(req, res, next);
+
+    expect(db.query).toHaveBeenCalledTimes(2);
+    
+    // The search term should be escaped
+    const firstCallParams = db.query.mock.calls[0][1];
+    expect(firstCallParams[0]).toBe('%\\%%');
+  });
+});


### PR DESCRIPTION
Closes #254

---

- Limit search query to 100 chars; return 400 for longer inputs
- Escape PostgreSQL special pattern chars before ILIKE
- Fix broken syntax and duplicate exports in adminController.js
- Fix merge conflict artifacts in stellar.js
- Clean up duplicate require calls in admin.js routes
- Add tests verifying 400 on long search, escaping, and percent safety