### PR TITLE
fix: emit payment.failed webhook for policy rejections, dynamic escro…

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -217,6 +217,7 @@ async function send(req, res, next) {
       }
 
       if (kycStatus !== "verified" && estimatedUSD >= KYC_THRESHOLD_USD) {
+        webhook.deliver("payment.failed", { code: "KYC_REQUIRED", error: "KYC verification required for transactions above $" + KYC_THRESHOLD_USD + " USD equivalent." }).catch(() => {});
         return res.status(403).json({
           error: "KYC verification required for transactions above $" + KYC_THRESHOLD_USD + " USD equivalent.",
           kyc_status: kycStatus,
@@ -250,6 +251,7 @@ async function send(req, res, next) {
 
     const overLimit = await dailyLimitExceeded(public_key, amount);
     if (overLimit) {
+      webhook.deliver("payment.failed", { code: "DAILY_LIMIT_EXCEEDED", error: `Daily send limit of ${DAILY_SEND_LIMIT} reached. Try again tomorrow.` }).catch(() => {});
       return res.status(400).json({
         error: `Daily send limit of ${DAILY_SEND_LIMIT} reached. Try again tomorrow.`,
         code: "DAILY_LIMIT_EXCEEDED",
@@ -262,13 +264,15 @@ async function send(req, res, next) {
       checkDailyLimit(public_key, amount, asset),
     ]);
     if (isSuspicious) {
+      webhook.deliver("payment.failed", { code: "FRAUD_BLOCKED", error: "Transaction limit reached. Please wait before sending again." }).catch(() => {});
       return res
         .status(429)
         .json({ error: "Transaction limit reached. Please wait before sending again." });
-    // Fraud protection
+    }
     const fraudCheck = await checkFraud(public_key, amount, asset);
     if (fraudCheck.blocked) {
       await logFraudBlock(public_key, fraudCheck.reason, amount, asset);
+      webhook.deliver("payment.failed", { code: "FRAUD_BLOCKED", error: fraudCheck.reason }).catch(() => {});
       return res.status(429).json({ error: fraudCheck.reason });
     }
 
@@ -279,6 +283,7 @@ async function send(req, res, next) {
       });
     }
     if (limitExceeded) {
+      webhook.deliver("payment.failed", { code: "DAILY_LIMIT_EXCEEDED", error: "Daily send limit reached. Try again later." }).catch(() => {});
       return res
         .status(429)
         .json({ error: "Daily send limit reached. Try again later.", code: "DAILY_LIMIT_EXCEEDED" });
@@ -302,11 +307,6 @@ async function send(req, res, next) {
     const ledger_close_time = await fetchLedgerCloseTime(ledger);
 
     // Save to DB
-    const feeAmount = calculateFee(amount);
-    await db.query(
-      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status, fee_amount)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,'completed',$8)`,
-      [txId, public_key, recipient_address, amount, asset, memo || null, transactionHash, feeAmount],
     const txStatus = type === "claimable_balance" ? "pending_claim" : "confirming";
     await db.query(
       `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, claimable_balance_id, request_id, is_encrypted, encrypted_memo, ledger_close_time)
@@ -372,7 +372,9 @@ async function send(req, res, next) {
     }
 
     if (err.status) {
-      webhook.deliver("payment.failed", { error: err.message }).catch(() => {});
+      const failedPayload = { error: err.message };
+      if (err.payload?.code) failedPayload.code = err.payload.code;
+      webhook.deliver("payment.failed", failedPayload).catch(() => {});
       return res.status(err.status).json({ error: err.message, ...(err.payload || {}) });
     }
     if (err.response?.data) {

--- a/backend/src/services/agentEscrow.js
+++ b/backend/src/services/agentEscrow.js
@@ -36,6 +36,19 @@ function getRpc() {
   return new StellarSdk.SorobanRpc.Server(rpcUrl);
 }
 
+async function getRecommendedFee(rpc) {
+  try {
+    const stats = await rpc.getFeeStats();
+    const p90 = stats?.sorobanInclusionFee?.p90;
+    if (p90 != null) {
+      return String(p90);
+    }
+    return String(StellarSdk.BASE_FEE * 10);
+  } catch {
+    return String(StellarSdk.BASE_FEE * 10);
+  }
+}
+
 function decryptSecret(encryptedKey) {
   const [ivHex, encrypted] = encryptedKey.split(":");
   const iv = Buffer.from(ivHex, "hex");
@@ -58,9 +71,10 @@ async function invokeContract(encryptedSecretKey, method, args) {
 
   const account = await rpc.getAccount(keypair.publicKey());
   const contract = new StellarSdk.Contract(CONTRACT_ID);
+  const fee = await getRecommendedFee(rpc);
 
   const tx = new StellarSdk.TransactionBuilder(account, {
-    fee: StellarSdk.BASE_FEE,
+    fee,
     networkPassphrase,
   })
     .addOperation(contract.call(method, ...args))
@@ -121,6 +135,7 @@ async function _createEscrow({ encryptedSecretKey, recipient, agent, amount, fee
 
   const account = await rpc.getAccount(sender);
   const contract = new StellarSdk.Contract(CONTRACT_ID);
+  const fee = await getRecommendedFee(rpc);
 
   const args = [
     StellarSdk.nativeToScVal(sender, { type: "address" }),
@@ -131,7 +146,7 @@ async function _createEscrow({ encryptedSecretKey, recipient, agent, amount, fee
   ];
 
   const tx = new StellarSdk.TransactionBuilder(account, {
-    fee: StellarSdk.BASE_FEE,
+    fee,
     networkPassphrase,
   })
     .addOperation(contract.call("create_escrow", ...args))
@@ -177,6 +192,7 @@ async function confirmPayout({ encryptedSecretKey, escrowId }) {
 
   const account = await rpc.getAccount(agent);
   const contract = new StellarSdk.Contract(CONTRACT_ID);
+  const fee = await getRecommendedFee(rpc);
 
   const args = [
     StellarSdk.nativeToScVal(agent, { type: "address" }),
@@ -184,7 +200,7 @@ async function confirmPayout({ encryptedSecretKey, escrowId }) {
   ];
 
   const tx = new StellarSdk.TransactionBuilder(account, {
-    fee: StellarSdk.BASE_FEE,
+    fee,
     networkPassphrase,
   })
     .addOperation(contract.call("confirm_payout", ...args))
@@ -229,6 +245,7 @@ async function cancelEscrow({ encryptedSecretKey, escrowId }) {
 
   const account = await rpc.getAccount(sender);
   const contract = new StellarSdk.Contract(CONTRACT_ID);
+  const fee = await getRecommendedFee(rpc);
 
   const args = [
     StellarSdk.nativeToScVal(sender, { type: "address" }),
@@ -236,7 +253,7 @@ async function cancelEscrow({ encryptedSecretKey, escrowId }) {
   ];
 
   const tx = new StellarSdk.TransactionBuilder(account, {
-    fee: StellarSdk.BASE_FEE,
+    fee,
     networkPassphrase,
   })
     .addOperation(contract.call("cancel_escrow", ...args))

--- a/backend/tests/send.policyRejection.webhook.test.js
+++ b/backend/tests/send.policyRejection.webhook.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for issue #255:
+ * POST /api/payments/send must emit payment.failed webhook for all
+ * application-level policy rejections with a matching code field.
+ */
+jest.mock('../src/db');
+jest.mock('../src/services/stellar');
+jest.mock('../src/services/webhook', () => ({ deliver: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/utils/cache', () => ({ del: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/fraudDetection', () => ({
+  checkVelocity: jest.fn().mockResolvedValue(false),
+  checkDailyLimit: jest.fn().mockResolvedValue(false),
+  checkFraud: jest.fn().mockResolvedValue({ blocked: false }),
+  logFraudBlock: jest.fn(),
+}));
+jest.mock('../src/services/memoRequired', () => ({ isMemoRequired: jest.fn().mockResolvedValue(false) }));
+jest.mock('../src/controllers/referralController', () => ({ awardReferralCredit: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/loyaltyToken', () => ({ mintPoints: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/feeDistributor', () => ({ depositFee: jest.fn().mockResolvedValue(undefined) }));
+
+const db = require('../src/db');
+const webhook = require('../src/services/webhook');
+const { checkFraud, checkVelocity } = require('../src/services/fraudDetection');
+const { send } = require('../src/controllers/paymentController');
+
+const SENDER = 'GABC1234SENDERKEY000000000000000000000000000000000000000';
+const RECIPIENT = 'GDIFFERENTRECIPIENTKEY0000000000000000000000000000000000';
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function makeReq(overrides = {}) {
+  return {
+    user: { userId: 1 },
+    body: { recipient_address: RECIPIENT, amount: '10', asset: 'XLM', ...overrides },
+    logger: { warn: jest.fn(), info: jest.fn() },
+    requestId: 'test-req-id',
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('#255 payment.failed webhook for policy rejections', () => {
+  test('emits payment.failed with code KYC_REQUIRED when KYC is not verified for large transaction', async () => {
+    // amount=200 USDC → estimatedUSD=200 ≥ KYC_THRESHOLD_USD (100) — ensureKycIfNeeded throws
+    db.query.mockResolvedValueOnce({ rows: [{ kyc_status: 'unverified' }] });
+
+    const req = makeReq({ amount: '200', asset: 'USDC' });
+    const res = mockRes();
+    await send(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(webhook.deliver).toHaveBeenCalledWith(
+      'payment.failed',
+      expect.objectContaining({ code: 'KYC_REQUIRED' }),
+    );
+  });
+
+  test('emits payment.failed with code DAILY_LIMIT_EXCEEDED when daily sum exceeds limit', async () => {
+    // Low-value XLM: no KYC/phone checks. Wallet lookup then dailyLimitExceeded.
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: SENDER, encrypted_secret_key: 'enc' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '50000' }] }); // 50000 + 10 > DAILY_SEND_LIMIT
+
+    const req = makeReq({ amount: '10', asset: 'XLM' });
+    const res = mockRes();
+    await send(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(webhook.deliver).toHaveBeenCalledWith(
+      'payment.failed',
+      expect.objectContaining({ code: 'DAILY_LIMIT_EXCEEDED' }),
+    );
+  });
+
+  test('emits payment.failed with code FRAUD_BLOCKED when velocity check flags the sender', async () => {
+    checkVelocity.mockResolvedValueOnce(true);
+
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: SENDER, encrypted_secret_key: 'enc' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] });
+
+    const req = makeReq({ amount: '10', asset: 'XLM' });
+    const res = mockRes();
+    await send(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(webhook.deliver).toHaveBeenCalledWith(
+      'payment.failed',
+      expect.objectContaining({ code: 'FRAUD_BLOCKED' }),
+    );
+  });
+
+  test('emits payment.failed with code FRAUD_BLOCKED when fraud check blocks the transaction', async () => {
+    checkFraud.mockResolvedValueOnce({ blocked: true, reason: 'Suspicious activity detected' });
+
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: SENDER, encrypted_secret_key: 'enc' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] });
+
+    const req = makeReq({ amount: '10', asset: 'XLM' });
+    const res = mockRes();
+    await send(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(webhook.deliver).toHaveBeenCalledWith(
+      'payment.failed',
+      expect.objectContaining({ code: 'FRAUD_BLOCKED' }),
+    );
+  });
+});

--- a/contracts/agent-escrow/src/lib.rs
+++ b/contracts/agent-escrow/src/lib.rs
@@ -153,12 +153,14 @@ impl AgentEscrowContract {
             &amount,
         );
 
-        let id: u64 = env
+        let current_count: u64 = env
             .storage()
             .persistent()
             .get(&DataKey::Counter)
-            .unwrap_or(0)
-            + 1;
+            .unwrap_or(0);
+        // u64::MAX is 18,446,744,073,709,551,615. At one escrow per second,
+        // exhausting the counter would take ~584 billion years.
+        let id = current_count.checked_add(1).expect("Escrow counter overflow");
         env.storage().persistent().set(&DataKey::Counter, &id);
 
         let now = env.ledger().timestamp();

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -159,7 +159,9 @@ impl EscrowContract {
             .persistent()
             .get(&DataKey::EscrowCounter)
             .unwrap_or(0);
-        let next_id = current_id + 1;
+        // u64::MAX is 18,446,744,073,709,551,615. At one escrow per second,
+        // exhausting the counter would take ~584 billion years.
+        let next_id = current_id.checked_add(1).expect("Escrow counter overflow");
         env.storage()
             .persistent()
             .set(&DataKey::EscrowCounter, &next_id);

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -377,6 +377,43 @@ fn test_deposit_into_active_escrow() {
     assert_eq!(client.get_escrow(&escrow_id).amount, amount * 2);
 }
 
+// release_escrow does not enforce expiry — agent may release after the 30-day window.
+#[test]
+fn test_release_escrow_after_expiry_succeeds() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, amount);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &amount, &250);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += 30 * 24 * 60 * 60 + 1;
+    });
+
+    client.release_escrow(&agent, &escrow_id);
+    assert_eq!(client.get_escrow(&escrow_id).status, EscrowStatus::Released);
+}
+
+#[test]
+#[should_panic(expected = "Insufficient accumulated fees")]
+fn test_withdraw_fees_exceeds_accumulated_panics() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, amount);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &amount, &250);
+    client.release_escrow(&agent, &escrow_id);
+
+    let accumulated = client.get_accumulated_fees();
+    client.withdraw_fees(&admin, &(accumulated + 1));
+}
+
 #[test]
 #[should_panic(expected = "Escrow has expired")]
 fn test_deposit_into_expired_escrow_is_rejected() {


### PR DESCRIPTION
…w fees, overflow protection, and edge-case test coverage

POST /api/payments/send does not emit payment.failed webhook for policy rejections Fixes #255

Escrow contract test coverage for edge cases is unknown — financial contract requires comprehensive tests Fixes #350

agentEscrow.js uses hardcoded BASE_FEE instead of fetching current network fee recommendation Fixes #355

Escrow contract EscrowCounter increment does not protect against overflow Fixes #356