### PR TITLE
Fix/UI issues

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -89,14 +89,21 @@ export default function Layout() {
           <NavLink
             key={to}
             to={to}
+            aria-current={({ isActive }) => isActive ? 'page' : undefined}
             className={({ isActive }) =>
               `flex flex-col items-center gap-0.5 px-3 py-1 rounded-lg transition-colors text-xs ${
-                isActive ? 'text-primary-500' : 'text-gray-500 hover:text-gray-300'
+                isActive
+                  ? 'text-primary-500 font-semibold'
+                  : 'text-gray-500 hover:text-gray-300'
               }`
             }
           >
-            <Icon size={20} />
-            <span>{label}</span>
+            {({ isActive }) => (
+              <>
+                <Icon size={20} strokeWidth={isActive ? 2.5 : 1.75} />
+                <span>{label}</span>
+              </>
+            )}
           </NavLink>
         ))}
       </nav>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -180,12 +180,14 @@ export default function Dashboard() {
   };
 
   const handleAnchorAction = async (action) => {
+    const win = window.open('', 'anchor', 'width=500,height=600');
     try {
       const asset = 'USDC';
       const endpoint = action === 'deposit' ? '/anchor/deposit' : '/anchor/withdraw';
       const res = await api.post(endpoint, { asset });
-      window.open(res.data.url, 'anchor', 'width=500,height=600');
+      win.location.href = res.data.url;
     } catch (err) {
+      win.close();
       toast.error(err.response?.data?.error || `Failed to ${action}`);
     }
   };

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,9 +1,24 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import toast from 'react-hot-toast';
-import { Eye, EyeOff, ArrowLeft, ChevronDown, ChevronUp } from 'lucide-react';
+import { Eye, EyeOff, ArrowLeft, ChevronDown, ChevronUp, Check, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+
+function getPasswordStrength(password) {
+  const checks = {
+    length: password.length >= 8,
+    uppercase: /[A-Z]/.test(password),
+    number: /[0-9]/.test(password),
+    special: /[^A-Za-z0-9]/.test(password),
+  };
+  const score = Object.values(checks).filter(Boolean).length;
+  const levels = ['', 'weak', 'fair', 'strong', 'very strong'];
+  const colors = ['', 'bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-green-500'];
+  const textColors = ['', 'text-red-500', 'text-orange-500', 'text-yellow-500', 'text-green-500'];
+  return { checks, score, label: levels[score], barColor: colors[score], textColor: textColors[score] };
+}
+
 export default function Register() {
   const { register } = useAuth();
   const navigate = useNavigate();
@@ -15,6 +30,8 @@ export default function Register() {
   const [showPINSetup, setShowPINSetup] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [secretKey, setSecretKey] = useState('');
+
+  const strength = useMemo(() => getPasswordStrength(form.password), [form.password]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -95,11 +112,33 @@ export default function Register() {
                 {showPass ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>
             </div>
+            {form.password && (
+              <div className="mt-2 space-y-2">
+                <div className="flex gap-1">
+                  {[1, 2, 3, 4].map(i => (
+                    <div key={i} className={`h-1 flex-1 rounded-full transition-colors ${i <= strength.score ? strength.barColor : 'bg-gray-200 dark:bg-gray-700'}`} />
+                  ))}
+                </div>
+                <p className={`text-xs font-medium capitalize ${strength.textColor}`}>{strength.label}</p>
+                <ul className="space-y-1">
+                  {[
+                    { key: 'length', label: 'At least 8 characters' },
+                    { key: 'uppercase', label: 'One uppercase letter' },
+                    { key: 'number', label: 'One number' },
+                    { key: 'special', label: 'One special character' },
+                  ].map(({ key, label }) => (
+                    <li key={key} className={`flex items-center gap-1.5 text-xs ${strength.checks[key] ? 'text-green-500' : 'text-gray-400 dark:text-gray-500'}`}>
+                      {strength.checks[key] ? <Check size={12} /> : <X size={12} />} {label}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || strength.score < 2}
             className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold py-3.5 rounded-xl transition-colors mt-2"
           >
             {loading ? t('register.submitting') : t('register.submit')}

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -55,6 +55,8 @@ export default function SendMoney() {
   const [pathResult, setPathResult] = useState(null);
   const [pathLoading, setPathLoading] = useState(false);
   const [memoRequired, setMemoRequired] = useState(false);
+  const [memoError, setMemoError] = useState(false);
+  const memoRef = useRef(null);
   // 'send' = strict send (sender specifies exact amount), 'receive' = strict receive (recipient gets exact amount)
   const [sendMode, setSendMode] = useState('send');
 
@@ -88,6 +90,7 @@ export default function SendMoney() {
     setFeeXLM(null);
     setPathResult(null);
     setMemoRequired(false);
+    setMemoError(false);
     setContractSimData(null);
   };
 
@@ -488,9 +491,19 @@ export default function SendMoney() {
       resetForm();
       navigate('/dashboard');
     } catch (err) {
-      toast.error(err.response?.data?.error || t('send.error'));
-      setConfirmed(false);
-      setShowPINVerification(false);
+      if (err.response?.data?.code === 'MEMO_REQUIRED') {
+        setMemoError(true);
+        setConfirmed(false);
+        setShowPINVerification(false);
+        setTimeout(() => {
+          memoRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          memoRef.current?.focus();
+        }, 50);
+      } else {
+        toast.error(err.response?.data?.error || t('send.error'));
+        setConfirmed(false);
+        setShowPINVerification(false);
+      }
     } finally {
       setLoading(false);
     }
@@ -872,13 +885,19 @@ export default function SendMoney() {
         <div>
           <label className="text-sm text-gray-400 mb-1 block">{t('send.memo')}</label>
           <input
+            ref={memoRef}
             type="text"
             maxLength={memoMaxLen}
             placeholder={t('send.memo_placeholder')}
             value={form.memo}
-            onChange={e => setForm({ ...form, memo: e.target.value })}
-            className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors font-mono text-sm"
+            onChange={e => { setForm({ ...form, memo: e.target.value }); setMemoError(false); }}
+            className={`w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 focus:outline-none transition-colors font-mono text-sm border ${
+              memoError ? 'border-red-500 focus:border-red-400' : 'border-gray-700 focus:border-primary-500'
+            }`}
           />
+          {memoError && (
+            <p className="mt-1 text-xs text-red-400">A memo is required for this recipient. Please add one before sending.</p>
+          )}
           {memoTrimmed ? (
             <div className="mt-2">
               <label className="text-sm text-gray-400 mb-1 block" htmlFor="memo-type">


### PR DESCRIPTION
closes #297 
closes #298 
closes #299 
closes #300 

## Fix four frontend UX issues

**Branch:** `fix/ui-issues` → `main`

---

### Overview

This PR addresses four independent frontend issues across the registration
flow, navigation bar, anchor integration, and payment form error handling.

---

### Changes

#### 1. `feat(register)` — Password strength meter with checklist and submit guard
> `frontend/src/pages/Register.jsx` · commit `8d52c059`

The registration form gave no feedback on password quality, leading users
to set weak passwords that were only rejected at the backend with a
confusing error.

**What changed:**
- Added a `getPasswordStrength` helper that scores the password against
  four criteria: length ≥ 8, uppercase letter, number, special character.
- A 4-segment color-coded bar renders below the password field as the user
  types: 🔴 weak → 🟠 fair → 🟡 strong → 🟢 very strong.
- A live checklist shows which criteria are met/unmet with ✓/✗ icons.
- The submit button is **disabled** until the password reaches at least
  **fair** (score ≥ 2).

---

#### 2. `fix(nav)` — Highlight active bottom nav item and add `aria-current`
> `frontend/src/components/Layout.jsx` · commit `495b0c1a`

The bottom navigation bar rendered all items identically regardless of the
current route. Users had no visual indication of which section they were in.

**What changed:**
- Switched `NavLink` children to the render-prop form to access `isActive`
  inside the child element.
- Active icon gets a heavier `strokeWidth` (2.5 vs 1.75) for a "filled"
  appearance.
- Active label gets `font-semibold` for additional visual weight.
- `aria-current="page"` is set on the active link for screen reader
  accessibility.

---

#### 3. `fix(anchor)` — Open popup synchronously to prevent mobile browser blocking
> `frontend/src/pages/Dashboard.jsx` · commit `9fc74d3c`

`handleAnchorAction` called `window.open` **after** an `await`, breaking
the user-gesture chain. iOS Safari and Android Chrome silently blocked the
popup because it was no longer directly triggered by the click event.

**What changed:**
- `window.open('', 'anchor', 'width=500,height=600')` is now called
  **synchronously** on click, before any async work, to obtain a window
  reference within the gesture boundary.
- `win.location.href` is assigned once the API returns the URL.
- On API error, `win.close()` is called to avoid leaving a blank orphan
  tab open.

---

#### 4. `fix(send)` — Handle `MEMO_REQUIRED` error with scroll-to-field and inline highlight
> `frontend/src/pages/SendMoney.jsx` · commit `cd028f6c`

When the backend returned `{ "code": "MEMO_REQUIRED" }` (HTTP 422), the
UI showed a generic error toast and left the user with no clear path
forward.

**What changed:**
- Added a `memoRef` (attached to the memo `<input>`) and a `memoError`
  boolean state.
- When `err.response?.data?.code === 'MEMO_REQUIRED'` is detected in the
  payment error handler:
  - `confirmed` is reset so the user can re-submit after editing.
  - The memo input is scrolled into view and focused via `memoRef`.
  - A red border (`border-red-500`) and an inline error message are applied
    to the memo field.
- `memoError` is cleared on input change and on full form reset.

---

### Testing Checklist

- [x] **Register** — type a password and confirm the bar/checklist update
  in real time; verify submit stays disabled until score ≥ 2.
- [x] **Navigation** — tap each bottom nav item and confirm the active one
  shows a bolder icon and semibold label.
- [x] **Anchor deposit/withdraw** — test on iOS Safari and Android Chrome;
  popup should open without being blocked.
- [x] **Send money** — mock a `422 { "code": "MEMO_REQUIRED" }` response
  and confirm the memo field is highlighted, focused, and the confirmation
  state is reset.

---

### Commits

| Hash | Message |
|------|---------|
| `8d52c059` | feat(register): add password strength meter with checklist and submit guard |
| `495b0c1a` | fix(nav): highlight active bottom nav item and add aria-current |
| `9fc74d3c` | fix(anchor): open popup synchronously to prevent mobile browser blocking |
| `cd028f6c` | fix(send): handle MEMO_REQUIRED error with scroll-to-field and inline highlight |
