### PR TITLE
feat: Add email verification success screen with resend functionality

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -435,6 +435,46 @@ async function verifyEmail(req, res, next) {
   }
 }
 
+async function resendVerificationEmail(req, res, next) {
+  try {
+    const { email } = req.body;
+    if (!email) {
+      return res.status(400).json({ error: 'Email is required' });
+    }
+
+    const result = await db.query(
+      `SELECT id, email_verified, token_expires_at FROM users WHERE email = $1`,
+      [email]
+    );
+
+    const user = result.rows[0];
+    if (!user) {
+      // Return generic response for security (don't reveal if email exists)
+      return res.json({ message: 'If an account with this email exists, you will receive a verification email shortly.' });
+    }
+
+    // If email is already verified, no need to resend
+    if (user.email_verified) {
+      return res.json({ message: 'This email is already verified. You can log in now.' });
+    }
+
+    // Generate new verification token
+    const { raw, hashed } = generateVerificationToken();
+    const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
+
+    await db.query(
+      `UPDATE users SET verification_token = $1, token_expires_at = $2 WHERE id = $3`,
+      [hashed, expiresAt, user.id]
+    );
+
+    await sendVerificationEmail(email, raw);
+
+    res.json({ message: 'Verification email sent successfully' });
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function verifyPhone(req, res, next) {
   try {
     const { otp } = req.body;
@@ -928,6 +968,7 @@ module.exports = {
   refresh,
   logout,
   verifyEmail,
+  resendVerificationEmail,
   verifyPhone,
   getMe,
   updateProfile,

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -6,6 +6,7 @@ const {
   refresh,
   logout,
   verifyEmail,
+  resendVerificationEmail,
   getMe,
   setPIN,
   verifyPIN,
@@ -105,6 +106,12 @@ router.post('/refresh', refresh);
 router.post('/logout', logout);
 
 router.get('/verify-email', verifyEmail);
+router.post(
+  '/resend-verification-email',
+  [body('email').isEmail().normalizeEmail().withMessage('Valid email required')],
+  validate,
+  resendVerificationEmail
+);
 router.post(
   '/verify-phone',
   authMiddleware,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "./context/ThemeContext";
 import Welcome from "./pages/Welcome";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import RegistrationSuccess from "./pages/RegistrationSuccess";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import Dashboard from "./pages/Dashboard";
@@ -81,6 +82,14 @@ export default function App() {
                 element={
                   <PublicRoute>
                     <Register />
+                  </PublicRoute>
+                }
+              />
+              <Route
+                path="/verify-email-pending"
+                element={
+                  <PublicRoute>
+                    <RegistrationSuccess />
                   </PublicRoute>
                 }
               />

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -51,6 +51,11 @@ export function AuthProvider({ children }) {
     return res.data;
   };
 
+  const resendVerificationEmail = async (email) => {
+    const res = await api.post('/auth/resend-verification-email', { email });
+    return res.data;
+  };
+
   const logout = async () => {
     try {
       await api.post('/auth/logout');
@@ -64,7 +69,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, register, resendVerificationEmail, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -13,6 +13,8 @@
     "sign_out": "Sign Out",
     "no_transactions": "No transactions found",
     "see_all": "See all",
+    "or": "Or",
+    "error": "Error",
     "rates_disclaimer": "Exchange rates are approximate and may be cached. Live prices refresh about every minute."
   },
   "welcome": {
@@ -69,6 +71,20 @@
     "back_to_login": "Back to sign in",
     "missing_token": "This reset link is invalid or incomplete. Request a new one from the login page.",
     "error_generic": "Something went wrong. Please try again."
+  },
+  "verifyEmail": {
+    "success_title": "Check your email!",
+    "check_email": "We've sent a verification link to:",
+    "check_spam": "If you don't see it, check your spam folder.",
+    "description": "Click the link in the email to verify your address and unlock your account.",
+    "resend_button": "Resend verification email",
+    "sending": "Sending...",
+    "resent_sent": "Email sent!",
+    "resent_success": "Verification email sent successfully",
+    "resent_error": "Failed to resend verification email",
+    "go_to_login": "Already verified? Go to login",
+    "didnt_receive": "Didn't receive the email?",
+    "contact_support": "Contact support"
   },
   "dashboard": {
     "greeting": "Good day,",

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -52,9 +52,8 @@ export default function Register() {
       const refCode = searchParams.get('ref');
       if (refCode) payload.referral_code = refCode;
       await register(payload);
-      toast.success(t('register.success'));
-      setShowPINSetup(true);
-      navigate('/login');
+      // Navigate to verification success screen with email
+      navigate('/verify-email-pending', { state: { email: form.email } });
     } catch (err) {
       toast.error(err.response?.data?.error || t('register.error'));
     } finally {

--- a/frontend/src/pages/RegistrationSuccess.jsx
+++ b/frontend/src/pages/RegistrationSuccess.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import toast from 'react-hot-toast';
+import { Mail, ArrowLeft, CheckCircle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export default function RegistrationSuccess() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { t } = useTranslation();
+  const { resendVerificationEmail } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [resent, setResent] = useState(false);
+
+  // Get email from navigation state or URL
+  const email = location.state?.email || new URLSearchParams(location.search).get('email');
+
+  if (!email) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col items-center justify-center px-6">
+        <div className="text-center max-w-sm">
+          <p className="text-gray-600 dark:text-gray-400 mb-6">{t('common.error')}</p>
+          <button
+            onClick={() => navigate('/register')}
+            className="text-primary-500 hover:underline"
+          >
+            {t('common.back')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const handleResendEmail = async () => {
+    setLoading(true);
+    try {
+      await resendVerificationEmail(email);
+      setResent(true);
+      toast.success(t('verifyEmail.resent_success'));
+      setTimeout(() => setResent(false), 5000);
+    } catch (err) {
+      toast.error(err.response?.data?.error || t('verifyEmail.resent_error'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col px-6 py-8 transition-colors duration-200">
+      {/* Back button */}
+      <button
+        onClick={() => navigate('/')}
+        className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white mb-6 flex items-center gap-1 transition-colors"
+      >
+        <ArrowLeft size={18} /> {t('common.back')}
+      </button>
+
+      {/* Main content */}
+      <div className="flex-1 flex flex-col justify-center max-w-sm mx-auto w-full">
+        {/* Icon */}
+        <div className="flex justify-center mb-6">
+          <div className="w-16 h-16 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center">
+            <CheckCircle size={32} className="text-primary-500" />
+          </div>
+        </div>
+
+        {/* Heading */}
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white text-center mb-3">
+          {t('verifyEmail.success_title')}
+        </h1>
+
+        {/* Email verification message */}
+        <div className="bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 rounded-xl p-4 mb-6">
+          <div className="flex items-start gap-3">
+            <Mail size={20} className="text-primary-500 mt-0.5 flex-shrink-0" />
+            <div>
+              <p className="text-sm text-gray-700 dark:text-gray-300 mb-1">
+                {t('verifyEmail.check_email')}
+              </p>
+              <p className="text-sm font-medium text-primary-600 dark:text-primary-400 break-all">
+                {email}
+              </p>
+              <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
+                {t('verifyEmail.check_spam')}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Description */}
+        <p className="text-center text-gray-600 dark:text-gray-400 text-sm mb-8">
+          {t('verifyEmail.description')}
+        </p>
+
+        {/* Resend button */}
+        <button
+          onClick={handleResendEmail}
+          disabled={loading || resent}
+          className={`w-full py-3.5 rounded-xl font-semibold transition-colors mb-3 ${
+            resent
+              ? 'bg-green-500 text-white'
+              : 'bg-primary-500 hover:bg-primary-600 text-white disabled:opacity-50'
+          }`}
+        >
+          {loading ? t('verifyEmail.sending') : resent ? t('verifyEmail.resent_sent') : t('verifyEmail.resend_button')}
+        </button>
+
+        {/* Divider */}
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+          <span className="text-xs text-gray-500 dark:text-gray-400">{t('common.or')}</span>
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+        </div>
+
+        {/* Go to login button */}
+        <button
+          onClick={() => navigate('/login')}
+          className="w-full py-3.5 rounded-xl font-semibold text-primary-600 dark:text-primary-400 border border-primary-200 dark:border-primary-800 hover:bg-primary-50 dark:hover:bg-primary-900/20 transition-colors"
+        >
+          {t('verifyEmail.go_to_login')}
+        </button>
+
+        {/* Help text */}
+        <p className="text-center text-xs text-gray-500 dark:text-gray-500 mt-6">
+          {t('verifyEmail.didnt_receive')}{' '}
+          <a href="mailto:support@afripay.com" className="text-primary-500 hover:underline">
+            {t('verifyEmail.contact_support')}
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Close #328 


- Create RegistrationSuccess component showing verification email status
- Display user email and clear instructions for verification
- Add resend verification email button with loading states
- Add 'Already verified? Go to login' link
- Implement resendVerificationEmail endpoint in backend
- Add i18n translations for verification flow
- Update registration flow to navigate to success screen
- Add new route /verify-email-pending for post-registration state