### PR TITLE
fix: replace hardcoded USD→fiat multipliers with live exchange rates

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,6 +68,12 @@ DAILY_SEND_LIMIT=50000
 PHONE_VERIFICATION_THRESHOLD_USD=100
 XLM_USD_RATE=0.11
 
+# Exchange rate API key (optional)
+# Used by priceOracle to fetch live USD→NGN/GHS/KES rates.
+# Without a key the free open.er-api.com endpoint is used (1500 req/month).
+# Get a free key at https://www.exchangerate-api.com/ for higher limits.
+# EXCHANGE_RATE_API_KEY=your_key_here
+
 # SMS Configuration
 # SMS_PROVIDER: 'twilio', 'africastalking', or leave empty for mock
 SMS_PROVIDER=

--- a/backend/src/services/priceOracle.js
+++ b/backend/src/services/priceOracle.js
@@ -2,71 +2,111 @@ const StellarSdk = require('@stellar/stellar-sdk');
 const { withFallback } = require('./stellar');
 const logger = require('../utils/logger');
 
-const CACHE_TTL_MS = 60_000;
+const SDEX_CACHE_TTL_MS = 60_000;        // XLM/USD refreshes every 60 s
+const FIAT_CACHE_TTL_MS = 60 * 60_000;  // USD→fiat refreshes every 60 min
 
-// Fiat multipliers relative to USD (static — SDEX only gives XLM/USDC)
-const USD_TO_FIAT = {
-  NGN: 1550,
+// Fallback multipliers used when the exchange-rate API is unreachable
+const FALLBACK_USD_TO_FIAT = {
+  NGN: 1600,
   GHS: 15.5,
-  KES: 130,
+  KES: 129,
 };
 
-let cache = { price: null, fetchedAt: 0 };
+let sdexCache = { price: null, fetchedAt: 0 };
+let fiatCache = { rates: null, fetchedAt: 0 };
 
-/**
- * Fetch XLM/USDC mid-price from the SDEX order book.
- * Returns price in USD (1 XLM = X USD).
- */
+// ---------------------------------------------------------------------------
+// XLM/USD — Stellar SDEX order book
+// ---------------------------------------------------------------------------
+
 async function fetchSdexPrice() {
   const usdcIssuer = process.env.USDC_ISSUER;
   if (!usdcIssuer) throw new Error('USDC_ISSUER is not configured');
 
   const xlm = StellarSdk.Asset.native();
   const usdc = new StellarSdk.Asset('USDC', usdcIssuer);
-
   const book = await withFallback(s => s.orderbook(xlm, usdc).call());
 
   const bestBid = parseFloat(book.bids?.[0]?.price ?? '0');
   const bestAsk = parseFloat(book.asks?.[0]?.price ?? '0');
 
   if (!bestBid && !bestAsk) throw new Error('Empty SDEX order book');
-
-  // mid-price; fall back to whichever side is available
   if (bestBid && bestAsk) return (bestBid + bestAsk) / 2;
   return bestBid || bestAsk;
 }
 
-/**
- * Returns cached XLM/USD price, refreshing if stale.
- * Falls back to last known price on SDEX failure.
- */
 async function getXlmPrice() {
   const now = Date.now();
-  if (cache.price !== null && now - cache.fetchedAt < CACHE_TTL_MS) {
-    return cache.price;
+  if (sdexCache.price !== null && now - sdexCache.fetchedAt < SDEX_CACHE_TTL_MS) {
+    return sdexCache.price;
   }
-
   try {
     const price = await fetchSdexPrice();
-    cache = { price, fetchedAt: now };
+    sdexCache = { price, fetchedAt: now };
     return price;
   } catch (err) {
     logger.warn('SDEX price fetch failed, using last known price', { error: err.message });
-    if (cache.price !== null) return cache.price;
+    if (sdexCache.price !== null) return sdexCache.price;
     throw err;
   }
 }
 
+// ---------------------------------------------------------------------------
+// USD → fiat — open.er-api.com (free, no key required)
+// Set EXCHANGE_RATE_API_KEY for the authenticated tier (higher rate limits).
+// ---------------------------------------------------------------------------
+
+async function fetchFiatRates() {
+  const apiKey = process.env.EXCHANGE_RATE_API_KEY;
+  const url = apiKey
+    ? `https://v6.exchangerate-api.com/v6/${apiKey}/latest/USD`
+    : 'https://open.er-api.com/v6/latest/USD';
+
+  const res = await fetch(url, { signal: AbortSignal.timeout(8_000) });
+  if (!res.ok) throw new Error(`Exchange rate API HTTP ${res.status}`);
+
+  const data = await res.json();
+  const r = data?.rates;
+  if (!r || typeof r.NGN !== 'number') throw new Error('Invalid exchange rate payload');
+
+  return {
+    NGN: r.NGN,
+    GHS: r.GHS ?? FALLBACK_USD_TO_FIAT.GHS,
+    KES: r.KES ?? FALLBACK_USD_TO_FIAT.KES,
+  };
+}
+
+async function getUsdToFiat() {
+  const now = Date.now();
+  if (fiatCache.rates !== null && now - fiatCache.fetchedAt < FIAT_CACHE_TTL_MS) {
+    return fiatCache.rates;
+  }
+  try {
+    const rates = await fetchFiatRates();
+    fiatCache = { rates, fetchedAt: now };
+    logger.info('Fiat rates refreshed', { NGN: rates.NGN, GHS: rates.GHS, KES: rates.KES });
+    return rates;
+  } catch (err) {
+    logger.warn('Fiat rate fetch failed, using fallback', { error: err.message });
+    return fiatCache.rates ?? FALLBACK_USD_TO_FIAT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /**
  * Returns XLM price in USD, NGN, GHS, KES.
+ * XLM/USD comes from the SDEX; USD→fiat comes from open.er-api.com.
  */
 async function getXlmRates() {
-  const usd = await getXlmPrice();
+  const [usd, fiat] = await Promise.all([getXlmPrice(), getUsdToFiat()]);
   return {
-    USD: usd,
-    NGN: parseFloat((usd * USD_TO_FIAT.NGN).toFixed(4)),
-    GHS: parseFloat((usd * USD_TO_FIAT.GHS).toFixed(4)),
-    KES: parseFloat((usd * USD_TO_FIAT.KES).toFixed(4)),
+    USD: parseFloat(usd.toFixed(6)),
+    NGN: parseFloat((usd * fiat.NGN).toFixed(4)),
+    GHS: parseFloat((usd * fiat.GHS).toFixed(4)),
+    KES: parseFloat((usd * fiat.KES).toFixed(4)),
   };
 }
 

--- a/frontend/src/utils/currency.js
+++ b/frontend/src/utils/currency.js
@@ -2,9 +2,9 @@
 
 export const FALLBACK_XLM_FIAT_RATES = {
   USD: 0.11,
-  NGN: 170,
-  GHS: 1.35,
-  KES: 14.5,
+  NGN: 176,   // ~1600 NGN/USD × 0.11 USD/XLM
+  GHS: 1.70,  // ~15.5 GHS/USD × 0.11 USD/XLM
+  KES: 14.2,  // ~129 KES/USD × 0.11 USD/XLM
 };
 
 const FIAT_META = [


### PR DESCRIPTION
Closes #318 

priceOracle.js previously multiplied the live XLM/USD SDEX price by static NGN/GHS/KES constants that quickly became stale.

Changes:
- priceOracle.js: add fetchFiatRates() which calls open.er-api.com/v6/latest/USD (free, no key required). If EXCHANGE_RATE_API_KEY is set, uses the authenticated v6.exchangerate-api.com endpoint for higher rate limits. Fiat rates are cached for 60 min (separate from the 60 s SDEX cache) and fall back to FALLBACK_USD_TO_FIAT on network error. getXlmRates() now fetches both prices in parallel via Promise.all.
- .env.example: document EXCHANGE_RATE_API_KEY as an optional variable.
- currency.js: update FALLBACK_XLM_FIAT_RATES to current approximate values (NGN 176, GHS 1.70, KES 14.2) so the fallback is less misleading.