### PR TITLE
feat: add page transition animation to eliminate white flash

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Outlet, NavLink, useNavigate } from 'react-router-dom';
+import { Outlet, NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { LayoutDashboard, Send, Download, Clock, Upload, User, LogOut, Sun, Moon, Bell, BellOff, AlertTriangle, ArrowUpDown } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
@@ -22,6 +22,7 @@ const isTestnet = process.env.REACT_APP_STELLAR_NETWORK !== 'mainnet';
 export default function Layout() {
   const { logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const { theme, toggleTheme } = useTheme();
   const { supported, subscribed, loading, subscribe, unsubscribe } = usePushNotifications();
   const { isDegraded, status } = useStellarStatus();
@@ -80,7 +81,9 @@ export default function Layout() {
 
       {/* Page content */}
       <main className="flex-1 overflow-y-auto pb-20">
-        <Outlet />
+        <div key={location.pathname} className="page-transition">
+          <Outlet />
+        </div>
       </main>
 
       {/* Bottom nav (mobile-first) */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,16 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Page transition */
+@keyframes page-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.page-transition {
+  animation: page-fade-in 0.18s ease-out both;
+}
+
 /* Skeleton shimmer */
 @keyframes shimmer {
   0%   { background-position: -400px 0; }


### PR DESCRIPTION
Closes #325

---

## Summary
Eliminates the blank white flash users see when navigating between pages, especially noticeable on slow connections.

## Changes
- **`frontend/src/index.css`** — Added `@keyframes page-fade-in` (opacity 0→1 + 6px upward slide, 0.18s ease-out) and a `.page-transition` utility class.
- **`frontend/src/components/Layout.jsx`** — Imported `useLocation` from react-router-dom; wrapped `<Outlet />` in a `<div key={location.pathname} className="page-transition">` so the animation re-triggers on every route change.

## What was tested
- `ErrorBoundary.test.jsx` — PASS
- `useStellarStatus.test.js` — PASS
- 7 other test suites fail with pre-existing issues (missing `@sentry/react`, ESM axios transform, `Profile.jsx` syntax error, missing `@stellar/stellar-sdk`) — none related to these changes.