### PR TITLE
feat: show transaction summary and anti-phishing warning in PIN modal

### DIFF
--- a/frontend/src/components/PINVerificationModal.jsx
+++ b/frontend/src/components/PINVerificationModal.jsx
@@ -70,21 +70,35 @@ export default function PINVerificationModal({ isOpen, onClose, onSuccess, amoun
 
         {/* Content */}
         <div className="px-6 py-6">
-          {/* Transaction Details */}
-          <div className="bg-gray-800 rounded-lg p-4 mb-6">
-            <p className="text-xs text-gray-500 mb-3">{t('auth.confirming_transaction')}</p>
-            <div className="space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="text-gray-400 text-sm">{t('send.confirm_amount')}</span>
-                <span className="text-white font-semibold">{amount}</span>
-              </div>
-              {recipient && (
+          {/* Transaction Summary — only shown when amount is provided */}
+          {amount && (
+            <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 mb-4">
+              <p className="text-xs text-gray-500 uppercase tracking-wide mb-3">{t('auth.confirming_transaction')}</p>
+              <div className="space-y-2">
                 <div className="flex justify-between items-center">
-                  <span className="text-gray-400 text-sm">{t('send.confirm_to')}</span>
-                  <span className="text-gray-300 text-xs font-mono">{recipient.slice(0, 16)}...</span>
+                  <span className="text-gray-400 text-sm">{t('send.confirm_amount')}</span>
+                  <span className="text-white font-bold text-base">{amount}</span>
                 </div>
-              )}
+                {recipient && (
+                  <div className="flex justify-between items-start gap-4">
+                    <span className="text-gray-400 text-sm shrink-0">{t('send.confirm_to')}</span>
+                    <span className="text-gray-300 text-xs font-mono text-right break-all">
+                      {recipient.length > 24
+                        ? `${recipient.slice(0, 8)}…${recipient.slice(-8)}`
+                        : recipient}
+                    </span>
+                  </div>
+                )}
+              </div>
             </div>
+          )}
+
+          {/* Anti-phishing notice */}
+          <div className="flex items-start gap-2 bg-yellow-500/10 border border-yellow-500/30 rounded-xl px-3 py-2.5 mb-5">
+            <AlertCircle size={15} className="text-yellow-400 shrink-0 mt-0.5" />
+            <p className="text-yellow-300 text-xs leading-snug">
+              {t('auth.pin_phishing_warning') || 'Only enter your PIN if you initiated this action. AfriPay will never ask for your PIN via chat or email.'}
+            </p>
           </div>
 
           <form onSubmit={handleVerify} className="space-y-4">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -134,7 +134,8 @@
     "pin_max_attempts": "Too many failed attempts. Please try again later.",
     "pin_attempts_remaining": "{{remaining}} attempts remaining",
     "pin_verify_button": "Verify & Send",
-    "pin_security_note": "Your PIN is never sent to or stored on our servers"
+    "pin_security_note": "Your PIN is never sent to or stored on our servers",
+    "pin_phishing_warning": "Only enter your PIN if you initiated this action. AfriPay will never ask for your PIN via chat or email."
   },
   "receive": {
     "title": "Receive Money",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -134,7 +134,8 @@
     "pin_max_attempts": "Trop de tentatives échouées. Réessayez plus tard.",
     "pin_attempts_remaining": "{{remaining}} tentatives restantes",
     "pin_verify_button": "Vérifier et envoyer",
-    "pin_security_note": "Votre code PIN n'est jamais envoyé ni stocké sur nos serveurs"
+    "pin_security_note": "Votre code PIN n'est jamais envoyé ni stocké sur nos serveurs",
+    "pin_phishing_warning": "Saisissez votre code PIN uniquement si vous avez initié cette action. AfriPay ne vous demandera jamais votre code PIN par chat ou e-mail."
   },
   "receive": {
     "title": "Recevoir de l'argent",

--- a/frontend/src/locales/ha.json
+++ b/frontend/src/locales/ha.json
@@ -134,7 +134,8 @@
     "pin_max_attempts": "Kokarin da yawa ba su nasara ba. Sai batta sannan.",
     "pin_attempts_remaining": "{{remaining}} kokarin da suka rage",
     "pin_verify_button": "Tabbatar da Aika",
-    "pin_security_note": "Ba a aiko PIN nka ko ajiya shi a saerve namu ba"
+    "pin_security_note": "Ba a aiko PIN nka ko ajiya shi a saerve namu ba",
+    "pin_phishing_warning": "Shigar da PIN nka ne kawai idan kai ne ka fara wannan aiki. AfriPay ba zai taɓa neman PIN nka ta hanyar hira ko imel ba."
   },
   "receive": {
     "title": "Karɓi Kuɗi",

--- a/frontend/src/locales/sw.json
+++ b/frontend/src/locales/sw.json
@@ -134,7 +134,8 @@
     "pin_max_attempts": "Majaribio mengi yameshindwa. Jaribu baadaye.",
     "pin_attempts_remaining": "{{remaining}} majaribio yanayobasisa",
     "pin_verify_button": "Thibitisha na Tuma",
-    "pin_security_note": "PIN yako haisogezwi kwa au haikufikiwa kwenye seva yetu"
+    "pin_security_note": "PIN yako haisogezwi kwa au haikufikiwa kwenye seva yetu",
+    "pin_phishing_warning": "Ingiza PIN yako tu ikiwa wewe ulianzisha hatua hii. AfriPay haitakuomba PIN yako kupitia gumzo au barua pepe."
   },
   "receive": {
     "title": "Pokea Pesa",


### PR DESCRIPTION
Closes #327

---

## Problem
The `PINVerificationModal` received `amount` and `recipient` props but the transaction summary had three issues that left users vulnerable to PIN phishing:

1. The summary block rendered unconditionally — when the modal is used outside a payment context, it showed empty/broken rows.
2. Recipient was truncated with `slice(0,16) + '...'` — fragile on short addresses and showed no meaningful start/end of the address.
3. No anti-phishing warning — users had no prompt to verify they initiated the action before entering their PIN.

## Changes

**`PINVerificationModal.jsx`**
- Guard the transaction summary on `amount` being truthy
- Recipient now shows `first8…last8` (or full address if ≤24 chars), using `break-all` so long addresses wrap cleanly
- Amount is bold and larger — the most visually prominent element in the summary
- Added a persistent yellow anti-phishing banner above the PIN input: *"Only enter your PIN if you initiated this action. AfriPay will never ask for your PIN via chat or email."*

**Locale files (en / fr / sw / ha)**
- Added `auth.pin_phishing_warning` key with translated text in all 4 supported languages

## Testing
- 2 pre-existing passing tests still pass
- 7 pre-existing failures unchanged — unrelated to this change