### PR TITLE
Escrow cleanup and partial release enhancements

### DIFF
--- a/backend/src/services/agentEscrow.js
+++ b/backend/src/services/agentEscrow.js
@@ -60,74 +60,8 @@ function decryptSecret(encryptedKey) {
   return decipher.update(encrypted, "hex", "utf8") + decipher.final("utf8");
 }
 
-async function invokeContract(encryptedSecretKey, method, args) {
-  if (!CONTRACT_ID) {
-    throw Object.assign(new Error("AGENT_ESCROW_CONTRACT_ID is not configured"), { status: 500 });
-  }
-
-  const secretKey = decryptSecret(encryptedSecretKey);
-  const keypair = StellarSdk.Keypair.fromSecret(secretKey);
-  const rpc = getRpc();
-
-  const account = await rpc.getAccount(keypair.publicKey());
-  const contract = new StellarSdk.Contract(CONTRACT_ID);
-  const fee = await getRecommendedFee(rpc);
-
-  const tx = new StellarSdk.TransactionBuilder(account, {
-    fee,
-    networkPassphrase,
-  })
-    .addOperation(contract.call(method, ...args))
-    .setTimeout(30)
-    .build();
-
-  const prepared = await rpc.prepareTransaction(tx);
-  prepared.sign(keypair);
-
-  const result = await rpc.sendTransaction(prepared);
-  if (result.status === "ERROR") {
-    throw Object.assign(new Error(`Contract call failed: ${result.errorResult}`), { status: 400 });
-  }
-
-  // Poll for confirmation
-  let response = result;
-  let iterations = 0;
-  while (response.status === "PENDING" || response.status === "NOT_FOUND") {
-    if (iterations >= MAX_POLL_ITERATIONS) {
-      throw Object.assign(new Error("Transaction confirmation timeout after 30s"), { status: 504 });
-    }
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    response = await rpc.getTransaction(result.hash);
-    iterations++;
-  }
-
-  if (response.status !== "SUCCESS") {
-    throw Object.assign(new Error(`Transaction failed: ${response.status}`), { status: 400 });
-  }
-
-  return { hash: result.hash, returnValue: response.returnValue };
-}
-
-/**
- * Create an agent escrow on-chain.
- * Returns { escrowId, txHash }.
- */
-async function createEscrow({ encryptedSecretKey, recipient, agent, amount, feeBps }) {
-  const { hash, returnValue } = await invokeContract(
-    encryptedSecretKey,
-    "create_escrow",
-    [
-      // sender is derived from the keypair inside invokeContract — pass as arg
-      // The contract requires sender address; we pass it via the keypair public key
-      // resolved inside the helper below
-    ]
-  );
-  // Delegate to the full helper that has access to the keypair public key
-  return _createEscrow({ encryptedSecretKey, recipient, agent, amount, feeBps });
-}
-
 // Internal implementation with full arg list
-async function _createEscrow({ encryptedSecretKey, recipient, agent, amount, feeBps }) {
+async function createEscrow({ encryptedSecretKey, recipient, agent, amount, feeBps }) {
   const secretKey = decryptSecret(encryptedSecretKey);
   const keypair = StellarSdk.Keypair.fromSecret(secretKey);
   const sender = keypair.publicKey();
@@ -203,7 +137,7 @@ async function confirmPayout({ encryptedSecretKey, escrowId }) {
     fee,
     networkPassphrase,
   })
-    .addOperation(contract.call("confirm_payout", ...args))
+    .addOperation(contract.call("confirm_delivery", ...args))
     .setTimeout(30)
     .build();
 
@@ -212,7 +146,7 @@ async function confirmPayout({ encryptedSecretKey, escrowId }) {
 
   const result = await rpc.sendTransaction(prepared);
   if (result.status === "ERROR") {
-    throw Object.assign(new Error(`confirm_payout failed: ${result.errorResult}`), { status: 400 });
+    throw Object.assign(new Error(`confirm_delivery failed: ${result.errorResult}`), { status: 400 });
   }
 
   let response = result;
@@ -286,4 +220,4 @@ async function cancelEscrow({ encryptedSecretKey, escrowId }) {
   return { txHash: result.hash };
 }
 
-module.exports = { createEscrow: _createEscrow, confirmPayout, cancelEscrow };
+module.exports = { createEscrow, confirmPayout, cancelEscrow };

--- a/contracts/escrow/README.md
+++ b/contracts/escrow/README.md
@@ -24,8 +24,10 @@ This contract supports a three-party escrow flow:
 
 The escrow lifecycle is:
 
-- `Pending` → `Released` when the assigned agent calls `release_escrow`
+- `Pending` → `Released` when the assigned agent calls `release_escrow` or fully settles the escrow with `partial_release`
 - `Pending` → `Cancelled` when the original sender calls `cancel_escrow`
+
+Completed or cancelled escrow records may be archived after a configurable retention period to limit persistent storage growth.
 
 Fees are calculated in basis points and stored separately as `AccumulatedFees`.
 
@@ -238,6 +240,139 @@ Events:
 
 ---
 
+### `confirm_delivery`
+
+Signature:
+```rust
+fn confirm_delivery(env: Env, agent: Address, escrow_id: u64)
+```
+
+Description:
+- Marks an escrow as having had off-chain payout confirmed by the agent.
+- Prevents the sender from cancelling the escrow after confirmation.
+
+Parameters:
+- `agent` (`Address`) - must authorize the confirmation.
+- `escrow_id` (`u64`) - the escrow to confirm.
+
+Returns:
+- `void`
+
+Authorization:
+- `agent.require_auth()` is required.
+- The caller must match `escrow.agent`.
+
+Panics / Errors:
+- `Escrow {id} not found` if the escrow does not exist.
+- `Only the agent can confirm delivery` if the caller is not the assigned agent.
+- `Escrow is not in pending state` if the escrow is already released or cancelled.
+- `Delivery has already been confirmed` if confirmation has already been submitted.
+
+Events:
+- `DeliveryConfirmed`
+
+---
+
+### `partial_release`
+
+Signature:
+```rust
+fn partial_release(env: Env, agent: Address, escrow_id: u64, amount: i128)
+```
+
+Description:
+- Releases a portion of the escrow amount to the agent with proportional fee calculation.
+- Keeps the escrow in `Pending` state until the remaining amount reaches zero.
+
+Parameters:
+- `agent` (`Address`) - must authorize the release.
+- `escrow_id` (`u64`) - the escrow to partially release.
+- `amount` (`i128`) - the amount to release in stroops.
+
+Returns:
+- `void`
+
+Authorization:
+- `agent.require_auth()` is required.
+- The caller must match `escrow.agent`.
+
+Panics / Errors:
+- `Escrow {id} not found` if the escrow does not exist.
+- `Only the agent can release escrow` if the caller is not the assigned agent.
+- `Escrow is not in pending state` if the escrow is already released or cancelled.
+- `Amount must be positive` if the release amount is zero or negative.
+- `Release amount exceeds escrow balance` if the requested amount is larger than the remaining escrow amount.
+
+Behavior:
+- Calculates `fee_amount = (amount * release_fee_bps) / 10000`.
+- Sends `amount - fee_amount` to the assigned agent.
+- Adds `fee_amount` to `AccumulatedFees` storage.
+- Reduces `escrow.amount` by the released amount.
+- Sets `status = Released` only when the full escrow amount has been paid out.
+
+Events:
+- `PartialRelease`
+
+---
+
+### `set_retention_period`
+
+Signature:
+```rust
+fn set_retention_period(env: Env, admin: Address, retention_secs: u64)
+```
+
+Description:
+- Configures the number of seconds after which completed or cancelled escrow records are eligible for cleanup.
+
+Parameters:
+- `admin` (`Address`) - must authorize the change.
+- `retention_secs` (`u64`) - the retention period in seconds.
+
+Returns:
+- `void`
+
+Authorization:
+- `admin.require_auth()` is required.
+- The caller must match the stored admin.
+
+Panics / Errors:
+- `Retention period must be positive` if zero is passed.
+- `Only admin can perform this action` if the caller is not the stored admin.
+
+---
+
+### `cleanup_escrow`
+
+Signature:
+```rust
+fn cleanup_escrow(env: Env, admin: Address, escrow_id: u64)
+```
+
+Description:
+- Removes a completed or cancelled escrow record from persistent storage once the configured retention period has elapsed.
+
+Parameters:
+- `admin` (`Address`) - must authorize the cleanup.
+- `escrow_id` (`u64`) - the escrow to archive.
+
+Returns:
+- `void`
+
+Authorization:
+- `admin.require_auth()` is required.
+- The caller must match the stored admin.
+
+Panics / Errors:
+- `Escrow {id} not found` if the escrow does not exist.
+- `Only released or cancelled escrows can be cleaned up` if the escrow is still pending.
+- `Escrow retention period has not elapsed` if the configured TTL has not passed since `updated_at`.
+
+Events:
+- `EscrowArchived`
+
+---
+
 ### `get_escrow`
 
 Signature:
@@ -376,6 +511,31 @@ Fields:
 - `escrow_id` (`u64`) - cancelled escrow identifier.
 - `refund_amount` (`i128`) - refunded amount returned to the sender.
 
+### `DeliveryConfirmed`
+
+Emitted by `confirm_delivery`.
+
+Fields:
+- `escrow_id` (`u64`) - escrow identifier.
+- `agent` (`Address`) - agent that confirmed delivery.
+
+### `PartialRelease`
+
+Emitted by `partial_release`.
+
+Fields:
+- `escrow_id` (`u64`) - escrow identifier.
+- `released_amount` (`i128`) - amount released to the agent.
+- `remaining_amount` (`i128`) - amount remaining in escrow.
+- `fee_amount` (`i128`) - release fee for this partial payout.
+
+### `EscrowArchived`
+
+Emitted by `cleanup_escrow`.
+
+Fields:
+- `escrow_id` (`u64`) - archived escrow identifier.
+
 ## Storage Layout
 
 This contract stores state under the following `DataKey` variants in persistent storage:
@@ -384,6 +544,7 @@ This contract stores state under the following `DataKey` variants in persistent 
 - `DataKey::UsdcAddress` -> `Address`
 - `DataKey::EscrowCounter` -> `u64`
 - `DataKey::AccumulatedFees` -> `i128`
+- `DataKey::RetentionPeriodSecs` -> `u64`
 - `DataKey::Escrow(u64)` -> `Escrow`
 
 ### `Escrow` struct layout
@@ -397,10 +558,16 @@ struct Escrow {
     amount: i128,
     release_fee_bps: u32,
     status: EscrowStatus,
+    payout_confirmed: bool,
     created_at: u64,
+    updated_at: u64,
     expires_at: u64,
 }
 ```
+
+### Storage TTL strategy
+
+Completed or cancelled escrows are eligible for cleanup after a configurable retention period. The admin can set the retention TTL via `set_retention_period`, and then manually archive old records with `cleanup_escrow` once the escrow's `updated_at` timestamp is older than the retention threshold.
 
 ### `EscrowStatus` enum
 
@@ -472,9 +639,10 @@ async function createEscrow(senderKeypair, recipientAddress, agentAddress, amoun
 1. Deploy and initialize the contract with `initialize(admin, usdc_address)`.
 2. Call `create_escrow(sender, recipient, agent, amount, release_fee_bps)`.
 3. Optionally call `deposit(sender, escrow_id, amount)` to add funds.
-4. Call `release_escrow(agent, escrow_id)` when payout is confirmed.
-5. Call `cancel_escrow(sender, escrow_id)` to refund pending escrow.
-6. Admin calls `withdraw_fees(admin, amount)` to collect fees.
+4. Call `confirm_delivery(agent, escrow_id)` after the agent confirms off-chain payout.
+5. Call `partial_release(agent, escrow_id, amount)` to release funds in installments, or `release_escrow(agent, escrow_id)` to release the remaining balance.
+6. Call `cancel_escrow(sender, escrow_id)` to refund pending escrow before delivery confirmation.
+7. Admin calls `withdraw_fees(admin, amount)` to collect fees.
 
 ## Deployment
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -31,6 +31,28 @@ pub struct EscrowCancelled {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct DeliveryConfirmed {
+    pub escrow_id: u64,
+    pub agent: Address,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct PartialRelease {
+    pub escrow_id: u64,
+    pub released_amount: i128,
+    pub remaining_amount: i128,
+    pub fee_amount: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowArchived {
+    pub escrow_id: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub struct Upgraded {
     pub new_wasm_hash: BytesN<32>,
 }
@@ -52,7 +74,9 @@ pub struct Escrow {
     pub amount: i128,
     pub release_fee_bps: u32,
     pub status: EscrowStatus,
+    pub payout_confirmed: bool,
     pub created_at: u64,
+    pub updated_at: u64,
     pub expires_at: u64,
 }
 
@@ -70,16 +94,37 @@ pub enum DataKey {
     UsdcAddress,
     EscrowCounter,
     AccumulatedFees,
+    RetentionPeriodSecs,
     Escrow(u64),
 }
 
 const DEFAULT_EXPIRY_SECS: u64 = 30 * 24 * 60 * 60;
+const DEFAULT_RETENTION_SECS: u64 = 90 * 24 * 60 * 60;
 
 /// Maximum allowed fee: 50% (5000 bps). Configurable by admin via contract upgrade.
 const MAX_FEE_BPS: u32 = 5000;
 
 /// Minimum escrow amount in stroops to prevent integer-division rounding to zero fee.
 const MIN_ESCROW_AMOUNT: i128 = 100;
+
+fn require_admin(env: &Env, admin: &Address) {
+    admin.require_auth();
+    let stored_admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .expect("Contract not initialized");
+    if admin != &stored_admin {
+        panic!("Only admin can perform this action");
+    }
+}
+
+fn retention_period(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RetentionPeriodSecs)
+        .unwrap_or(DEFAULT_RETENTION_SECS)
+}
 
 #[contract]
 pub struct EscrowContract;
@@ -182,7 +227,9 @@ impl EscrowContract {
             amount,
             release_fee_bps,
             status: EscrowStatus::Pending,
+            payout_confirmed: false,
             created_at: now,
+            updated_at: now,
             expires_at: now + DEFAULT_EXPIRY_SECS,
         };
         env.storage()
@@ -284,6 +331,7 @@ impl EscrowContract {
             .set(&DataKey::AccumulatedFees, &(current_fees + fee_amount));
 
         escrow.status = EscrowStatus::Released;
+        escrow.updated_at = env.ledger().timestamp();
         env.storage()
             .persistent()
             .set(&DataKey::Escrow(escrow_id), &escrow);
@@ -295,6 +343,144 @@ impl EscrowContract {
                 agent_amount,
                 fee_amount,
             },
+        );
+    }
+
+    pub fn confirm_delivery(env: Env, agent: Address, escrow_id: u64) {
+        agent.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id));
+
+        if agent != escrow.agent {
+            panic!("Only the agent can confirm delivery");
+        }
+        if escrow.status != EscrowStatus::Pending {
+            panic!("Escrow is not in pending state");
+        }
+        if escrow.payout_confirmed {
+            panic!("Delivery has already been confirmed");
+        }
+
+        escrow.payout_confirmed = true;
+        escrow.updated_at = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        env.events().publish(
+            (Symbol::new(&env, "DeliveryConfirmed"),),
+            DeliveryConfirmed {
+                escrow_id,
+                agent,
+            },
+        );
+    }
+
+    pub fn partial_release(env: Env, agent: Address, escrow_id: u64, amount: i128) {
+        agent.require_auth();
+
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id));
+
+        if agent != escrow.agent {
+            panic!("Only the agent can release escrow");
+        }
+        if escrow.status != EscrowStatus::Pending {
+            panic!("Escrow is not in pending state");
+        }
+        if amount > escrow.amount {
+            panic!("Release amount exceeds escrow balance");
+        }
+
+        let fee_amount = (amount * escrow.release_fee_bps as i128) / 10000;
+        let agent_amount = amount - fee_amount;
+
+        let usdc_address: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UsdcAddress)
+            .expect("Contract not initialized");
+
+        token::Client::new(&env, &usdc_address).transfer(
+            &env.current_contract_address(),
+            &escrow.agent,
+            &agent_amount,
+        );
+
+        let current_fees: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AccumulatedFees)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AccumulatedFees, &(current_fees + fee_amount));
+
+        escrow.amount -= amount;
+        if escrow.amount == 0 {
+            escrow.status = EscrowStatus::Released;
+        }
+        escrow.updated_at = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        env.events().publish(
+            (Symbol::new(&env, "PartialRelease"),),
+            PartialRelease {
+                escrow_id,
+                released_amount: amount,
+                remaining_amount: escrow.amount,
+                fee_amount,
+            },
+        );
+    }
+
+    pub fn set_retention_period(env: Env, admin: Address, retention_secs: u64) {
+        require_admin(&env, &admin);
+        if retention_secs == 0 {
+            panic!("Retention period must be positive");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::RetentionPeriodSecs, &retention_secs);
+    }
+
+    pub fn cleanup_escrow(env: Env, admin: Address, escrow_id: u64) {
+        require_admin(&env, &admin);
+
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic!("Escrow {} not found", escrow_id));
+
+        if escrow.status != EscrowStatus::Released && escrow.status != EscrowStatus::Cancelled {
+            panic!("Only released or cancelled escrows can be cleaned up");
+        }
+
+        let retention = retention_period(&env);
+        let now = env.ledger().timestamp();
+        if now < escrow.updated_at + retention {
+            panic!("Escrow retention period has not elapsed");
+        }
+
+        env.storage().persistent().remove(&DataKey::Escrow(escrow_id));
+
+        env.events().publish(
+            (Symbol::new(&env, "EscrowArchived"),),
+            EscrowArchived { escrow_id },
         );
     }
 
@@ -313,6 +499,9 @@ impl EscrowContract {
         if escrow.status != EscrowStatus::Pending {
             panic!("Escrow is not in pending state");
         }
+        if escrow.payout_confirmed {
+            panic!("Cannot cancel: agent has confirmed delivery");
+        }
 
         let usdc_address: Address = env
             .storage()
@@ -327,6 +516,7 @@ impl EscrowContract {
         );
 
         escrow.status = EscrowStatus::Cancelled;
+        escrow.updated_at = env.ledger().timestamp();
         env.storage()
             .persistent()
             .set(&DataKey::Escrow(escrow_id), &escrow);

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -207,6 +207,106 @@ fn test_cancel_escrow() {
 }
 
 #[test]
+fn test_confirm_delivery_prevents_cancel() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, amount);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &amount, &250);
+    client.confirm_delivery(&agent, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert!(escrow.payout_confirmed);
+
+    let result = std::panic::catch_unwind(|| {
+        client.cancel_escrow(&sender, &escrow_id);
+    });
+    assert!(result.is_err());
+    let error_message = format!("{:?}", result.err().unwrap());
+    assert!(error_message.contains("Cannot cancel: agent has confirmed delivery"));
+}
+
+#[test]
+fn test_partial_release_keeps_pending_until_fully_released() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, amount);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &amount, &250);
+
+    client.partial_release(&agent, &escrow_id, &500_000000i128);
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Pending);
+    assert_eq!(escrow.amount, 500_000000i128);
+    assert_eq!(TokenClient::new(&env, &usdc_id).balance(&agent), 500_000000i128 - 12_500000i128);
+}
+
+#[test]
+fn test_multiple_partial_releases_release_remaining_amount() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, amount);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &amount, &250);
+
+    client.partial_release(&agent, &escrow_id, &300_000000i128);
+    client.partial_release(&agent, &escrow_id, &200_000000i128);
+    client.partial_release(&agent, &escrow_id, &500_000000i128);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(escrow.amount, 0);
+}
+
+#[test]
+#[should_panic(expected = "Release amount exceeds escrow balance")]
+fn test_partial_release_over_release_panics() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, 1_000_0000000);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &1_000_0000000, &250);
+    client.partial_release(&agent, &escrow_id, &1_000_000001i128);
+}
+
+#[test]
+fn test_cleanup_escrow_after_retention() {
+    let (env, client, admin, usdc_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let agent = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+
+    mint_usdc(&env, &usdc_id, &admin, &sender, amount);
+    let escrow_id = client.create_escrow(&sender, &recipient, &agent, &amount, &250);
+    client.cancel_escrow(&sender, &escrow_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp += 90 * 24 * 60 * 60 + 1;
+    });
+
+    client.cleanup_escrow(&admin, &escrow_id);
+
+    let result = std::panic::catch_unwind(|| {
+        client.get_escrow(&escrow_id);
+    });
+    assert!(result.is_err());
+    let err_str = format!("{:?}", result.err().unwrap());
+    assert!(err_str.contains("Escrow 1 not found"));
+}
+
+#[test]
 #[should_panic(expected = "Only the agent can release escrow")]
 fn test_release_wrong_caller() {
     let (env, client, admin, usdc_id) = setup();


### PR DESCRIPTION
closes #337 
closes #338 
closes #339 
closes #340 

- Add payout_confirmed and confirm_delivery to escrow contract
- Add partial_release with proportional fee handling
- Add configurable retention TTL and cleanup_escrow admin cleanup function
- Remove dead backend createEscrow wrapper and export actual helper
- Document TTL strategy, new contract lifecycle events, and cleanup behavior
- Add contract tests for delivery confirmation, partial releases, and archive cleanup