### PR TITLE
feat: wire RequestMoney, ScheduledPayments, Referrals & Webhooks into Profile nav

### DIFF
--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -22,6 +22,9 @@ import {
   Shield,
   Key,
   AlertCircle,
+  Link2,
+  Calendar,
+  Webhook,
 } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { truncateAddress } from '../utils/currency';
@@ -584,6 +587,51 @@ export default function Profile() {
           <div>
             <p className="font-semibold text-white text-sm">Refer &amp; Earn</p>
             <p className="text-xs text-gray-400">Invite friends, earn fee credits</p>
+          </div>
+        </div>
+        <span className="text-gray-500 text-lg">›</span>
+      </Link>
+
+      {/* Request Money (#461) */}
+      <Link
+        to="/request"
+        className="bg-gray-900 rounded-2xl p-5 flex items-center justify-between hover:bg-gray-800 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <Link2 size={20} className="text-primary-500" />
+          <div>
+            <p className="font-semibold text-white text-sm">Request Money</p>
+            <p className="text-xs text-gray-400">Create a shareable payment link</p>
+          </div>
+        </div>
+        <span className="text-gray-500 text-lg">›</span>
+      </Link>
+
+      {/* Scheduled Payments (#462) */}
+      <Link
+        to="/scheduled"
+        className="bg-gray-900 rounded-2xl p-5 flex items-center justify-between hover:bg-gray-800 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <Calendar size={20} className="text-primary-500" />
+          <div>
+            <p className="font-semibold text-white text-sm">Scheduled Payments</p>
+            <p className="text-xs text-gray-400">View, create, and cancel recurring payments</p>
+          </div>
+        </div>
+        <span className="text-gray-500 text-lg">›</span>
+      </Link>
+
+      {/* Webhooks (#464) */}
+      <Link
+        to="/webhooks"
+        className="bg-gray-900 rounded-2xl p-5 flex items-center justify-between hover:bg-gray-800 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <Webhook size={20} className="text-primary-500" />
+          <div>
+            <p className="font-semibold text-white text-sm">Webhooks</p>
+            <p className="text-xs text-gray-400">Manage transaction event endpoints</p>
           </div>
         </div>
         <span className="text-gray-500 text-lg">›</span>


### PR DESCRIPTION
## Summary

**`frontend/src/pages/Profile.jsx`** — single file changed

- Added `Link2`, `Calendar`, and `Webhook` icon imports from `lucide-react`
- Added a **Request Money** nav card linking to `/request` (#461)
- Added a **Scheduled Payments** nav card linking to `/scheduled` (#462)
- Verified the existing **Refer & Earn** card linking to `/referrals` is present and correct (#463)
- Added a **Webhooks** nav card linking to `/webhooks` (#464)

All four cards follow the same visual pattern as the existing Referrals card (icon + title + subtitle + chevron).

## Feature details

| Issue | Page | Route | Key functionality |
|-------|------|-------|-------------------|
| #461 | RequestMoney | `/request` | Form to create a payment request; generates a shareable deep-link with amount & address; Copy + Share buttons |
| #462 | ScheduledPayments | `/scheduled` | List, create (daily/weekly/monthly), toggle active, and delete recurring payments |
| #463 | Referrals | `/referrals` | Displays referral link with one-click copy; shows friends-referred and active-credits stats |
| #464 | Webhooks | `/webhooks` | Register HTTPS endpoints, subscribe to `payment.*` events, reveal/copy signing secret |

## Testing

1. Log in and navigate to Profile
2. Confirm four new nav cards appear: Request Money, Scheduled Payments, Refer & Earn, Webhooks
3. Tap each card and verify the correct page loads
4. On Request Money: fill in amount, create request, verify Copy and Share buttons appear on the generated link
5. On Referrals: verify referral link is displayed with a working copy button and stats cards

closes #461
closes #462 
closes #463 
closes #464 