### PR TITLE
feat: wire Analytics, Sessions, BusinessSettings pages and integrate LedgerSignModal (#465–#468)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,8 @@ import Register from "./pages/Register";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import Dashboard from "./pages/Dashboard";
+import SendMoney from "./pages/SendMoney";
+import ReceiveMoney from "./pages/ReceiveMoney";
 import SaveMoney from "./pages/SaveMoney";
 import RequestMoney from "./pages/RequestMoney";
 import ScheduledPayments from "./pages/ScheduledPayments";

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -14,7 +14,7 @@ export default function Analytics() {
   useEffect(() => {
     const fetchAnalytics = async () => {
       try {
-        const res = await api.get('/analytics/summary');
+        const res = await api.get('/payments/analytics');
         setData(res.data);
       } catch (err) {
         toast.error(t('analytics.error') || 'Failed to load analytics');

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -22,6 +22,7 @@ import {
   Shield,
   Key,
   AlertCircle,
+  Monitor,
 } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { truncateAddress } from '../utils/currency';
@@ -1095,6 +1096,18 @@ export default function Profile() {
             {signersLoading ? 'Loading…' : signers === null ? 'Load' : 'Refresh'}
           </button>
         </div>
+
+        {/* Active sessions link (#466) */}
+        <Link
+          to="/sessions"
+          className="flex items-center justify-between bg-gray-800 hover:bg-gray-700 rounded-xl px-4 py-3 mb-4 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            <Monitor size={15} className="text-gray-400" />
+            <span className="text-sm text-white">Active Sessions</span>
+          </div>
+          <span className="text-gray-500 text-lg">›</span>
+        </Link>
 
         {signersError && <p className="text-red-400 text-xs mb-3">{signersError}</p>}
 


### PR DESCRIPTION
## Summary


### #465 — Analytics dashboard page
**File:** `frontend/src/pages/Analytics.jsx`

`Analytics.jsx` was calling `GET /analytics/summary`, which is mounted under `/api/analytics` with `isAdmin` middleware — inaccessible to regular users. The same controller (`analyticsController.summary`) is also mounted at `GET /api/payments/analytics` without the admin guard. Changed the fetch call to `/payments/analytics` so any authenticated user can load their own transaction volume, fee spend, and currency breakdown. The `/analytics` route in `App.jsx` was already present.

closes #465 

### #466 — Sessions management page linked from Profile
**File:** `frontend/src/pages/Profile.jsx`

`Sessions.jsx` existed and was routed at `/sessions`, but the Profile page had no entry point to it. Added an **Active Sessions** row inside the existing Security section, using the same card style as the Business Account button. Tapping it navigates to `/sessions` where users can view and revoke active login sessions. Also added the `Monitor` icon import from `lucide-react`.

closes #466 

### #467 — BusinessSettings page for multi-sig accounts
No code changes required. `BusinessSettings.jsx` was already routed at `/business` in `App.jsx` and already linked from the Profile page via the **Business Account** button. The page fully implements co-signer management and upgrade-to-business flow against `/wallet/signers`.

closes #467 

### #468 — Ledger hardware wallet signing modal in SendMoney
No code changes required. `LedgerSignModal` was already imported in `SendMoney.jsx`, with `handleSignWithLedger`, `handleLedgerSigned`, and `showLedgerModal` state wired up. The **Sign with Ledger** button is rendered at the confirmation step and the modal is mounted at the bottom of the form.

closes #468 

### Bonus fix — missing imports in App.jsx
**File:** `frontend/src/App.jsx`

`SendMoney` and `ReceiveMoney` were used in `<Route>` elements but never imported, which would cause a runtime crash on those routes. Added the two missing import statements.

---

## Files changed
| File | Change |
|------|--------|
| `frontend/src/App.jsx` | Add missing `SendMoney` and `ReceiveMoney` imports |
| `frontend/src/pages/Analytics.jsx` | Fix API endpoint: `/analytics/summary` → `/payments/analytics` |
| `frontend/src/pages/Profile.jsx` | Add Active Sessions link in Security section; add `Monitor` import |

---

## Testing
- Navigate to `/analytics` as a regular user — data loads without a 403.
- Open Profile → Security section — **Active Sessions** row is visible and navigates to `/sessions`.
- `/sessions` lists active sessions with per-session revoke and bulk logout.
- `/business` loads BusinessSettings; upgrade and signer management work as before.
- `/send` confirmation step shows **Sign with Ledger** button; clicking it opens `LedgerSignModal`.