### PR TITLE
feat: 2FA state fix, PIN setup prompt, push notification opt-in, contact picker confirmation

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -63,8 +63,10 @@ export function AuthProvider({ children }) {
     Sentry.setUser(null);
   };
 
+  const updateUser = (fields) => setUser((prev) => (prev ? { ...prev, ...fields } : prev));
+
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, updateUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Send, Download, RefreshCw, Copy, CheckCheck, FlaskConical, Plus, Minus, WifiOff, Wallet, ChevronDown, PiggyBank, Eye, EyeOff, Clock } from 'lucide-react';
+import { Send, Download, RefreshCw, Copy, CheckCheck, FlaskConical, Plus, Minus, WifiOff, Wallet, ChevronDown, PiggyBank, Eye, EyeOff, Clock, Bell, X } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { BalanceCardSkeleton, TransactionRowSkeleton } from '../components/Skeleton';
 import api from '../utils/api';
@@ -13,6 +13,8 @@ import { setCacheEntry, getCacheEntry } from '../utils/offlineDB';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { usePullToRefresh } from '../hooks/usePullToRefresh';
+import PINSetupModal from '../components/PINSetupModal';
+import { usePushNotifications } from '../hooks/usePushNotifications';
 
 const IS_TESTNET = process.env.REACT_APP_STELLAR_NETWORK !== 'mainnet';
 const MAX_WALLETS = 5;
@@ -29,9 +31,28 @@ function BalanceDisplay({ balance }) {
 }
 
 export default function Dashboard() {
-  const { user } = useAuth();
+  const { user, updateUser } = useAuth();
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  // Issue #454: PIN setup prompt on first login
+  const [showPINSetup, setShowPINSetup] = useState(false);
+  useEffect(() => {
+    if (user && user.pin_setup_completed === false) {
+      setShowPINSetup(true);
+    }
+  }, [user]);
+
+  // Issue #455: Push notification opt-in banner
+  const { supported: pushSupported, subscribed: pushSubscribed, loading: pushLoading, subscribe: pushSubscribe } = usePushNotifications();
+  const [pushDismissed, setPushDismissed] = useState(
+    () => localStorage.getItem('afripay_push_dismissed') === 'true'
+  );
+  const showPushBanner = pushSupported && !pushSubscribed && !pushDismissed;
+  const dismissPushBanner = () => {
+    localStorage.setItem('afripay_push_dismissed', 'true');
+    setPushDismissed(true);
+  };
 
   // Admin Contract State Viewer
   const [adminContractId, setAdminContractId] = useState('');
@@ -354,6 +375,33 @@ export default function Dashboard() {
             className="text-xs bg-red-500/20 hover:bg-red-500/30 px-3 py-1 rounded-lg transition-colors"
           >
             Refresh
+          </button>
+        </div>
+      )}
+
+      {/* Issue #455: Push notification opt-in banner */}
+      {showPushBanner && (
+        <div className="flex items-center gap-3 bg-primary-500/10 border border-primary-500/30 rounded-xl px-4 py-3">
+          <Bell size={18} className="text-primary-400 shrink-0" />
+          <div className="flex-1">
+            <p className="text-primary-300 text-sm font-medium">Enable push notifications</p>
+            <p className="text-primary-400/70 text-xs mt-0.5">
+              Get alerted instantly when you receive a payment.
+            </p>
+          </div>
+          <button
+            onClick={pushSubscribe}
+            disabled={pushLoading}
+            className="text-xs bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold px-3 py-1.5 rounded-lg transition-colors shrink-0"
+          >
+            {pushLoading ? 'Enabling…' : 'Enable'}
+          </button>
+          <button
+            onClick={dismissPushBanner}
+            className="text-gray-500 hover:text-white shrink-0"
+            aria-label="Dismiss notification prompt"
+          >
+            <X size={16} />
           </button>
         </div>
       )}
@@ -768,6 +816,13 @@ export default function Dashboard() {
           )}
         </div>
       )}
+
+      {/* Issue #454: PIN setup modal on first login */}
+      <PINSetupModal
+        isOpen={showPINSetup}
+        onClose={() => setShowPINSetup(false)}
+        onSuccess={() => updateUser({ pin_setup_completed: true })}
+      />
 
       {/* Recent transactions */}
       <div>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -38,7 +38,7 @@ const LANGUAGES = [
 ];
 
 export default function Profile() {
-  const { user, logout } = useAuth();
+  const { user, logout, updateUser } = useAuth();
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
   const [copied, setCopied] = useState(false);
@@ -158,8 +158,7 @@ export default function Profile() {
       setTwoFAStep(null);
       setTwoFAData(null);
       setTwoFACode('');
-      // Update local user state
-      user.totp_enabled = true;
+      updateUser({ totp_enabled: true });
     } catch (err) {
       toast.error(err.response?.data?.error || 'Invalid code');
     } finally {
@@ -175,7 +174,7 @@ export default function Profile() {
       toast.success('2FA disabled');
       setTwoFAStep(null);
       setTwoFAPassword('');
-      user.totp_enabled = false;
+      updateUser({ totp_enabled: false });
     } catch (err) {
       toast.error(err.response?.data?.error || 'Failed to disable 2FA');
     } finally {


### PR DESCRIPTION
## Summary


### #453 — 2FA setup flow in Profile security settings

**Root cause:** After enabling or disabling 2FA, `handleVerify2FA` and `handleDisable2FA` wrote directly to `user.totp_enabled` (e.g. `user.totp_enabled = true`). Mutating a prop object does not trigger a React re-render, so the Enable/Disable button never updated until a page reload.

**Fix:**
- Added `updateUser(fields)` to `AuthContext` — it merges the supplied fields into the current user state via `setUser`.
- Replaced both direct mutations in `Profile.jsx` with `updateUser({ totp_enabled: true/false })`.

The QR code display, backup-code acknowledgement, 6-digit TOTP verification, and disable-with-password flow were already fully built; this change makes the post-action UI state correct.

---

### #454 — PIN setup prompt after first login

**Root cause:** `PINSetupModal` was implemented but never mounted anywhere in the app.

**Fix:**
- Imported `PINSetupModal` into `Dashboard.jsx`.
- Added a `useEffect` that sets `showPINSetup = true` when `user.pin_setup_completed === false` (the field is returned by `/auth/me` and `/auth/login`).
- On `onSuccess`, calls `updateUser({ pin_setup_completed: true })` so the modal does not reappear for the remainder of the session.

---

### #455 — Push notification opt-in prompt on Dashboard

**Root cause:** `usePushNotifications` was only consumed in `Layout.jsx` with no user-facing prompt; users had no way to opt in from the Dashboard.

**Fix:**
- Imported `usePushNotifications` and the `Bell` / `X` icons into `Dashboard.jsx`.
- Added a dismissible banner above the greeting that renders when `supported && !subscribed && !dismissed`.
- "Enable" calls `subscribe()` from the hook (registers the service worker and POSTs to `/notifications/subscribe`).
- Dismissal is persisted in `localStorage` (`afripay_push_dismissed`) so the banner does not reappear after a page reload.

---

### #456 — Contact picker in SendMoney recipient field

The contact picker was already fully implemented in `SendMoney.jsx`:
- Contacts fetched from `/wallet/contacts` on mount.
- Searchable dropdown with keyboard navigation (↑ ↓ Enter Escape) and click-outside dismissal.
- Selecting a contact fills the recipient address and pre-populates the default memo.
- The "Contacts" button is visible whenever the user has at least one saved contact.

Closes #453, closes #454, closes #455, closes #456

---

## Files changed

| File | Change |
|------|--------|
| `frontend/src/context/AuthContext.jsx` | Add `updateUser` helper and expose it on context |
| `frontend/src/pages/Profile.jsx` | Use `updateUser` for 2FA enable/disable (fixes re-render bug) |
| `frontend/src/pages/Dashboard.jsx` | Add PINSetupModal trigger (#454) + push notification banner (#455) |

## Test plan

- [ ] Log in as a new user (`pin_setup_completed = false`) — PINSetupModal should appear automatically on Dashboard load
- [ ] Complete PIN setup — modal should close and not reappear on the same session
- [ ] Log in as a user with `pin_setup_completed = true` — modal should not appear
- [ ] On a supported browser, the push notification banner should be visible; clicking "Enable" should request permission and call `/notifications/subscribe`
- [ ] Clicking ✕ on the banner should dismiss it persistently (survives page reload)
- [ ] In Profile → Two-Factor Authentication: enable 2FA (scan QR, enter code) — the button should switch to "Disable" immediately without a reload
- [ ] Disable 2FA — the button should switch back to "Enable" immediately
- [ ] In SendMoney: add at least one contact in Profile, then open the Send page — the Contacts button should appear and the picker should filter, navigate with keyboard, and fill the address field

