### PR TITLE
feat: expose POST /api/assets/issue under admin auth with issuer keyp…

### DIFF
--- a/backend/src/routes/assets.js
+++ b/backend/src/routes/assets.js
@@ -1,6 +1,68 @@
 const router = require('express').Router();
-const { getAssetMetadata } = require('../controllers/assetController');
+const { body, validationResult } = require('express-validator');
+const auth = require('../middleware/auth');
+const isAdmin = require('../middleware/isAdmin');
+const { issueTokens, getAssetMetadata } = require('../controllers/assetController');
 
 router.get('/AFRI/info', getAssetMetadata);
+
+/**
+ * @openapi
+ * /api/assets/issue:
+ *   post:
+ *     summary: Issue AFRI tokens to a recipient (admin only)
+ *     tags: [Assets]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [recipient, amount]
+ *             properties:
+ *               recipient:
+ *                 type: string
+ *                 description: Stellar public key of the recipient
+ *               amount:
+ *                 type: number
+ *                 description: Amount of AFRI tokens to issue (must be > 0)
+ *     responses:
+ *       200:
+ *         description: Tokens issued successfully
+ *       400:
+ *         description: Validation error or issuer keypair not configured
+ *       403:
+ *         description: Admin access required
+ */
+router.post(
+  '/issue',
+  auth,
+  isAdmin,
+  [
+    body('recipient')
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage('recipient is required'),
+    body('amount')
+      .isFloat({ gt: 0 })
+      .withMessage('amount must be a number greater than 0'),
+  ],
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    if (!process.env.AFRI_ISSUER_PUBLIC || !process.env.AFRI_ISSUER_SECRET) {
+      return res.status(400).json({ error: 'AFRI issuer keypair is not configured' });
+    }
+
+    next();
+  },
+  issueTokens
+);
 
 module.exports = router;

--- a/backend/src/utils/validateEnv.js
+++ b/backend/src/utils/validateEnv.js
@@ -55,6 +55,12 @@ function validateEnv() {
     );
   }
 
+  if (!isSet(process.env.AFRI_ISSUER_PUBLIC) || !isSet(process.env.AFRI_ISSUER_SECRET)) {
+    console.warn(
+      '\x1b[33m[CONFIG WARNING] AFRI_ISSUER_PUBLIC and/or AFRI_ISSUER_SECRET are not set. POST /api/assets/issue will be unavailable.\x1b[0m'
+    );
+  }
+
   const network = process.env.STELLAR_NETWORK.trim();
   const horizonUrl = process.env.STELLAR_HORIZON_URL.trim().replace(/\/$/, '');
   const expectedHorizon = EXPECTED_HORIZON_URLS[network];


### PR DESCRIPTION
Expose POST /api/assets/issue under admin auth
  
  Wires up the existing issueTokens controller to a new admin-only endpoint.
  
  Changes:
  
  - routes/assets.js — adds POST /issue protected by auth + isAdmin middleware, with
  express-validator input validation (recipient non-empty string, amount > 0) and a runtime guard
  that returns HTTP 400 if AFRI_ISSUER_PUBLIC or AFRI_ISSUER_SECRET are not configured
  - utils/validateEnv.js — adds a startup warning when either AFRI issuer key is missing, so
  misconfiguration is surfaced at boot rather than at first request
  
  Testing:
  
  - POST /api/assets/issue with a valid admin JWT, recipient address, and amount → 200 with
  transaction hash
  - Missing/invalid fields → 400 with validation errors
  - Non-admin JWT → 403
  - Missing AFRI_ISSUER_PUBLIC/AFRI_ISSUER_SECRET in env → 400 with config error message
closes #511