### PR TITLE
 Expose GET /api/assets/:code/:issuer for Stellar asset metadata      Adds a generic endpoint to query live Stellar asset information by asset code and issuer   address.      Changes:      - services/stellar.js — new getAssetMetadataByCodeAndIssuer(code, issuer) that queries   Horizon's assets endpoint and the issuer account in parallel   - controllers/assetController.js — new getAssetByParams handler   - routes/assets.js — registers GET /:code/:issuer route      Response includes:      - supply — total circulating supply   - num_accounts — number of trustline holders   - home_domain — issuer's home domain (from account record)   - flags — auth/clawback flags on the asset      Returns 404 if the asset does not exist on Stellar.      Example:      GET /api/assets/USDC/GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVNfeat: expose GET /api/assets/:code/:issuer for Stellar asset info

### DIFF
--- a/backend/src/controllers/assetController.js
+++ b/backend/src/controllers/assetController.js
@@ -1,5 +1,5 @@
 const db = require('../db');
-const { issueAsset, getAssetInfo } = require('../services/stellar');
+const { issueAsset, getAssetInfo, getAssetMetadataByCodeAndIssuer } = require('../services/stellar');
 const logger = require('../utils/logger');
 
 // Issue AFRI tokens to a recipient (admin only)
@@ -44,4 +44,15 @@ async function getAssetMetadata(req, res, next) {
   }
 }
 
-module.exports = { issueTokens, getAssetMetadata };
+// GET /api/assets/:code/:issuer — return Stellar asset info for any asset
+async function getAssetByParams(req, res, next) {
+  try {
+    const { code, issuer } = req.params;
+    const info = await getAssetMetadataByCodeAndIssuer(code, issuer);
+    res.json(info);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { issueTokens, getAssetMetadata, getAssetByParams };

--- a/backend/src/routes/assets.js
+++ b/backend/src/routes/assets.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
-const { getAssetMetadata } = require('../controllers/assetController');
+const { getAssetMetadata, getAssetByParams } = require('../controllers/assetController');
 
 router.get('/AFRI/info', getAssetMetadata);
+router.get('/:code/:issuer', getAssetByParams);
 
 module.exports = router;

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -1313,6 +1313,30 @@ async function refundTestnetWallets(publicKeys) {
   }));
 }
 
+// Fetch Stellar asset info (supply, home domain, num_accounts) for any code+issuer
+async function getAssetMetadataByCodeAndIssuer(code, issuer) {
+  const [assetResponse, issuerAccount] = await Promise.all([
+    server.assets().forCode(code).forIssuer(issuer).call(),
+    server.loadAccount(issuer).catch(() => null),
+  ]);
+
+  const asset = assetResponse.records[0];
+  if (!asset) {
+    const err = new Error(`Asset ${code}:${issuer} not found on Stellar`);
+    err.status = 404;
+    throw err;
+  }
+
+  return {
+    code: asset.asset_code,
+    issuer: asset.asset_issuer,
+    supply: asset.amount,
+    num_accounts: asset.num_accounts,
+    home_domain: issuerAccount?.home_domain || null,
+    flags: asset.flags,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
@@ -1356,4 +1380,5 @@ module.exports = {
   recoverSequence,
   withSequenceRecovery,
   validateNetworkPassphrase,
+  getAssetMetadataByCodeAndIssuer,
 };


### PR DESCRIPTION
 Expose GET /api/assets/:code/:issuer for Stellar asset metadata
  
  Adds a generic endpoint to query live Stellar asset information by asset code and issuer
  address.
  
  Changes:
  
  - services/stellar.js — new getAssetMetadataByCodeAndIssuer(code, issuer) that queries
  Horizon's assets endpoint and the issuer account in parallel
  - controllers/assetController.js — new getAssetByParams handler
  - routes/assets.js — registers GET /:code/:issuer route
  
  Response includes:
  
  - supply — total circulating supply
  - num_accounts — number of trustline holders
  - home_domain — issuer's home domain (from account record)
  - flags — auth/clawback flags on the asset
  
  Returns 404 if the asset does not exist on Stellar.
  
  Example:
  
  GET /api/assets/USDC/GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
closes #512 