### PR TITLE
feat(518): expose POST /api/tools/decode-xdr with base64 XDR validation

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -103,7 +103,8 @@ app.use('/api/prices', pricesRoutes);
 app.use('/api/channels', channelsRoutes);
 app.use('/api/contracts', contractsRoutes);
 app.use('/api/webhooks', webhookRoutes);
-app.use('/api/dev', toolsRoutes);
+app.use('/api/tools', toolsRoutes);
+app.use('/api/dev', toolsRoutes); // legacy alias
 app.use('/api/assets', assetsRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/.well-known/stellar', sep10Routes);

--- a/backend/src/routes/tools.js
+++ b/backend/src/routes/tools.js
@@ -1,6 +1,57 @@
 const router = require('express').Router();
+const { body, validationResult } = require('express-validator');
+const authMiddleware = require('../middleware/auth');
 const { decodeXDR } = require('../controllers/toolsController');
 
-router.post('/decode-xdr', decodeXDR);
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  next();
+};
+
+/**
+ * @swagger
+ * /api/tools/decode-xdr:
+ *   post:
+ *     summary: Decode a Stellar XDR transaction envelope
+ *     tags: [Tools]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [xdr]
+ *             properties:
+ *               xdr:
+ *                 type: string
+ *                 description: Base64-encoded Stellar XDR transaction envelope
+ *     responses:
+ *       200:
+ *         description: Decoded transaction object
+ *       400:
+ *         description: Missing or invalid XDR
+ */
+router.post(
+  '/decode-xdr',
+  authMiddleware,
+  [
+    body('xdr')
+      .notEmpty().withMessage('xdr is required')
+      .isString().withMessage('xdr must be a string')
+      .custom((value) => {
+        // Validate it is a non-empty base64 string
+        const base64Re = /^[A-Za-z0-9+/]+={0,2}$/;
+        if (!base64Re.test(value.trim())) {
+          throw new Error('xdr must be a valid base64-encoded XDR string');
+        }
+        return true;
+      }),
+  ],
+  validate,
+  decodeXDR,
+);
 
 module.exports = router;


### PR DESCRIPTION
- Added express-validator check: xdr must be a non-empty, valid base64-encoded string before reaching the controller.
- Added authMiddleware so only authenticated users can call the endpoint.
- Mounted toolsRoutes at /api/tools in app.js (legacy /api/dev alias kept).
- Added JSDoc/Swagger annotation for the new route.

Closes #518