### PR TITLE
feat(520): add POST /api/referrals/award and wire referral credit to wallet

### DIFF
--- a/backend/src/controllers/referralController.js
+++ b/backend/src/controllers/referralController.js
@@ -71,3 +71,23 @@ async function awardReferralCredit(referredUserId) {
 }
 
 module.exports = { getStats, awardReferralCredit };
+
+/**
+ * POST /api/referrals/award
+ * Admin/internal endpoint — awards referral credit for a given referred user.
+ * Body: { referred_user_id: string }
+ */
+async function awardReferralCreditHandler(req, res, next) {
+  try {
+    const { referred_user_id } = req.body;
+    if (!referred_user_id) {
+      return res.status(400).json({ error: 'referred_user_id is required' });
+    }
+    await awardReferralCredit(referred_user_id);
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { getStats, awardReferralCredit, awardReferralCreditHandler };

--- a/backend/src/routes/referrals.js
+++ b/backend/src/routes/referrals.js
@@ -1,9 +1,68 @@
 const router = require('express').Router();
+const { body, validationResult } = require('express-validator');
 const authMiddleware = require('../middleware/auth');
-const { getStats } = require('../controllers/referralController');
+const isAdmin = require('../middleware/isAdmin');
+const { getStats, awardReferralCreditHandler } = require('../controllers/referralController');
+
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  next();
+};
 
 router.use(authMiddleware);
 
+/**
+ * @swagger
+ * /api/referrals/stats:
+ *   get:
+ *     summary: Get referral stats for the authenticated user
+ *     tags: [Referrals]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Referral code, count, and credit summary
+ */
 router.get('/stats', getStats);
+
+/**
+ * @swagger
+ * /api/referrals/award:
+ *   post:
+ *     summary: Award referral credit for a referred user's first transaction (admin only)
+ *     tags: [Referrals]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [referred_user_id]
+ *             properties:
+ *               referred_user_id:
+ *                 type: string
+ *                 description: UUID of the user whose referrer should receive credit
+ *     responses:
+ *       200:
+ *         description: Credit awarded (or silently skipped if already awarded)
+ *       400:
+ *         description: Missing referred_user_id
+ *       403:
+ *         description: Admin access required
+ */
+router.post(
+  '/award',
+  isAdmin,
+  [
+    body('referred_user_id')
+      .notEmpty().withMessage('referred_user_id is required')
+      .isUUID().withMessage('referred_user_id must be a valid UUID'),
+  ],
+  validate,
+  awardReferralCreditHandler,
+);
 
 module.exports = router;


### PR DESCRIPTION
Adds `awardReferralCreditHandler` wrapper in referralController.js and wires `POST /api/referrals/award` behind authMiddleware + isAdmin with UUID validation. `GET /api/referrals/stats` unchanged.

Closes #520