### PR TITLE
feat: wire notification, WebSocket, dispute, and payment-claim endpoints

### DIFF
--- a/backend/src/controllers/paymentRequestController.js
+++ b/backend/src/controllers/paymentRequestController.js
@@ -71,11 +71,27 @@ async function markClaimed(req, res, next) {
   try {
     const { id } = req.params;
     const { txHash } = req.body;
+    const userId = req.user.userId;
+
+    const result = await db.query(
+      `SELECT requester_id, claimed FROM payment_requests WHERE id = $1 AND expires_at > NOW()`,
+      [id]
+    );
+
+    if (!result.rows[0]) {
+      return res.status(404).json({ error: 'Payment request not found or expired' });
+    }
+
+    if (result.rows[0].requester_id !== userId) {
+      return res.status(403).json({ error: 'Only the intended recipient can claim this payment request' });
+    }
+
+    if (result.rows[0].claimed) {
+      return res.status(409).json({ error: 'Payment request already claimed' });
+    }
 
     await db.query(
-      `UPDATE payment_requests
-       SET claimed = true, claimed_tx_hash = $1
-       WHERE id = $2`,
+      `UPDATE payment_requests SET claimed = true, claimed_tx_hash = $1 WHERE id = $2`,
       [txHash, id]
     );
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -102,6 +102,7 @@ io.on('connection', async (socket) => {
 });
 
 ledgerListener.setSocketIO(io);
+ledgerListener.initStreams();
 
 async function shutdown(signal) {
   logger.info(`${signal} received — shutting down gracefully`);

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -4,6 +4,39 @@ const { subscribe, unsubscribe } = require('../controllers/notificationControlle
 
 router.use(authMiddleware);
 
+/**
+ * @swagger
+ * /api/notifications/subscribe:
+ *   post:
+ *     summary: Subscribe to Web Push notifications
+ *     tags: [Notifications]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [subscription]
+ *             properties:
+ *               subscription:
+ *                 type: object
+ *                 description: PushSubscriptionJSON from the browser Push API
+ *     responses:
+ *       200:
+ *         description: Push subscription saved
+ *       400:
+ *         description: Invalid push subscription
+ *   delete:
+ *     summary: Unsubscribe from Web Push notifications
+ *     tags: [Notifications]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Push subscription removed
+ */
 router.post('/subscribe', subscribe);
 router.delete('/subscribe', unsubscribe);
 

--- a/backend/src/routes/paymentRequests.js
+++ b/backend/src/routes/paymentRequests.js
@@ -6,6 +6,6 @@ const router = express.Router();
 
 router.post('/', auth, create);
 router.get('/:id', getById);
-router.post('/:id/claim', markClaimed);
+router.post('/:id/claim', auth, markClaimed);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

Closes #521, closes #522, closes #523, closes #524

- **#521 – Push notification subscribe/unsubscribe**: `POST /api/notifications/subscribe` and `DELETE /api/notifications/subscribe` are routed through `notificationController` (already wired); added Swagger/JSDoc docs to the route file to make the API contract explicit.
- **#522 – Real-time payment streaming via WebSocket**: Socket.IO is initialised in `index.js` and scoped per authenticated user (JWT room = wallet public key). Added `ledgerListener.initStreams()` call after `setSocketIO(io)` so Horizon streams start at server boot for all email-verified users, not only on first socket connection — ensuring DB transaction confirmations and room emissions are active from startup.
- **#523 – Dispute resolution endpoints**: `open`, `submitEvidenceHandler`, `resolve`, `listDisputes`, `getDispute` are all routed in `routes/disputes.js` with correct role guards (`isAdmin` on resolve). No changes required.
- **#524 – Payment request mark-as-claimed**: Added `auth` middleware to `POST /api/payment-requests/:id/claim` so the endpoint is protected. Updated `markClaimed` to fetch the payment request, return 404 if not found/expired, 403 if the caller is not the `requester_id` (intended recipient), and 409 if already claimed.

## Test plan

- [ ] `POST /api/notifications/subscribe` with valid PushSubscriptionJSON saves subscription and starts Horizon stream for user's wallet
- [ ] `DELETE /api/notifications/subscribe` removes subscription and stops stream
- [ ] Socket connects → joins wallet room → receives `payment:confirmed` / `payment:received` events when Stellar transactions arrive
- [ ] Ledger streams start at server boot (verify logs show "Ledger streams initialized")
- [ ] `POST /api/disputes` / `POST /api/disputes/:id/evidence` / `POST /api/disputes/:id/resolve` / `GET /api/disputes` / `GET /api/disputes/:id` all return expected responses with proper auth/role enforcement
- [ ] `POST /api/payment-requests/:id/claim` returns 401 without token, 403 for non-requester, 409 if already claimed, 200 on success
