### PR TITLE
feat: expose analytics fees, global contract events, and stellar stats endpoints

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -581,6 +581,70 @@ async function getContractEventsEndpoint(req, res, next) {
 }
 
 /**
+ * GET /api/admin/contracts/events
+ * Query contract events across all contracts with optional filtering.
+ * Query params: contractAddress, eventType, limit, offset, from, to
+ */
+async function getContractEventsGlobalEndpoint(req, res, next) {
+  try {
+    const { contractAddress, eventType, limit, offset, from, to } = req.query;
+
+    const maxLimit = Math.min(parseInt(limit) || 100, 500);
+    const offsetVal = parseInt(offset) || 0;
+
+    const params = [];
+    let query = 'SELECT * FROM contract_events WHERE 1=1';
+    let countQuery = 'SELECT COUNT(*) AS count FROM contract_events WHERE 1=1';
+
+    if (contractAddress) {
+      params.push(contractAddress);
+      const cond = ` AND contract_id = $${params.length}`;
+      query += cond;
+      countQuery += cond;
+    }
+
+    if (eventType) {
+      params.push(eventType);
+      const cond = ` AND event_type = $${params.length}`;
+      query += cond;
+      countQuery += cond;
+    }
+
+    if (from) {
+      params.push(new Date(from).toISOString());
+      const cond = ` AND created_at >= $${params.length}`;
+      query += cond;
+      countQuery += cond;
+    }
+
+    if (to) {
+      params.push(new Date(to).toISOString());
+      const cond = ` AND created_at <= $${params.length}`;
+      query += cond;
+      countQuery += cond;
+    }
+
+    const countParams = [...params];
+    params.push(maxLimit, offsetVal);
+    query += ` ORDER BY ledger_sequence DESC LIMIT $${params.length - 1} OFFSET $${params.length}`;
+
+    const [result, countResult] = await Promise.all([
+      db.query(query, params),
+      db.query(countQuery, countParams),
+    ]);
+
+    res.json({
+      events: result.rows,
+      total: parseInt(countResult.rows[0].count),
+      limit: maxLimit,
+      offset: offsetVal,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
  * POST /api/admin/contracts/:contractId/events/index
  * Manually trigger event indexing for a specific contract.
  */
@@ -617,5 +681,6 @@ module.exports = {
   executeContractUpgrade,
   getContractUpgradeStatus,
   getContractEventsEndpoint,
+  getContractEventsGlobalEndpoint,
   indexContractEventsEndpoint
 };

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -75,3 +75,51 @@ exports.summary = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
+
+exports.fees = async (req, res) => {
+  try {
+    const now = new Date();
+    const defaultFrom = new Date(now);
+    defaultFrom.setDate(defaultFrom.getDate() - 30);
+
+    const from = req.query.from ? new Date(req.query.from) : defaultFrom;
+    const to = req.query.to ? new Date(req.query.to) : now;
+
+    if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+      return res.status(400).json({ error: 'Invalid date format; use ISO 8601 (e.g. YYYY-MM-DD)' });
+    }
+    if (from > to) {
+      return res.status(400).json({ error: 'from must be before or equal to to' });
+    }
+
+    const [totals, byAsset] = await Promise.all([
+      db.query(
+        `SELECT COALESCE(SUM(fee_amount), 0) AS total_fees,
+                COUNT(*) AS transaction_count
+         FROM transactions
+         WHERE created_at >= $1 AND created_at <= $2 AND status = 'completed'`,
+        [from, to],
+      ),
+      db.query(
+        `SELECT asset,
+                COUNT(*) AS transaction_count,
+                COALESCE(SUM(fee_amount), 0) AS total_fees,
+                COALESCE(AVG(fee_amount), 0) AS avg_fee
+         FROM transactions
+         WHERE created_at >= $1 AND created_at <= $2 AND status = 'completed'
+         GROUP BY asset
+         ORDER BY total_fees DESC`,
+        [from, to],
+      ),
+    ]);
+
+    res.json({
+      period: { from: from.toISOString(), to: to.toISOString() },
+      total_fees: totals.rows[0].total_fees,
+      transaction_count: totals.rows[0].transaction_count,
+      by_asset: byAsset.rows,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -17,6 +17,7 @@ const {
   executeContractUpgrade,
   getContractUpgradeStatus,
   getContractEventsEndpoint,
+  getContractEventsGlobalEndpoint,
   indexContractEventsEndpoint
 } = require('../controllers/adminController');
 
@@ -160,8 +161,9 @@ router.post(
 router.get('/contracts/:contractId/upgrade/status', getContractUpgradeStatus);
 
 /**
- * Contract Events Routes (Issue #147)
+ * Contract Events Routes (Issue #147, #527)
  */
+router.get('/contracts/events', getContractEventsGlobalEndpoint);
 router.get('/contracts/:contractId/events', getContractEventsEndpoint);
 
 router.post(

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -2,11 +2,12 @@ const router = require('express').Router();
 const rateLimit = require('express-rate-limit');
 const authMiddleware = require('../middleware/auth');
 const isAdmin = require('../middleware/isAdmin');
-const { summary } = require('../controllers/analyticsController');
+const { summary, fees } = require('../controllers/analyticsController');
 
 // All analytics routes require authentication and admin role
 router.use(authMiddleware, isAdmin);
 
 router.get('/summary', summary);
+router.get('/fees', fees);
 
 module.exports = router;

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -1042,6 +1042,7 @@ async function getStellarStats() {
     return {
       latestLedger: ledger.sequence,
       baseFee: ledger.base_fee_in_stroops,
+      networkPassphrase,
       maxFee: ledger.max_tx_set_size,
       transactionCount: ledger.successful_transaction_count,
       operationCount: ledger.operation_count,


### PR DESCRIPTION
## Summary

- **Closes #525** — Added `GET /api/analytics/fees` to `analyticsController.js` and wired it in `analytics.js`. Returns total fees and a per-asset breakdown for a configurable date range (defaults to last 30 days).
- **Closes #526** — `announceContractUpgrade` and `executeContractUpgrade` were already implemented in `adminController.js` and routed under `/api/admin/contracts` with `authMiddleware` + `isAdmin`. No code changes needed.
- **Closes #527** — Added `GET /api/admin/contracts/events` (global endpoint) with optional query-param filtering by `contractAddress`, `eventType`, `from`, and `to`. Route is registered before `/:contractId/events` to prevent Express matching the literal string "events" as a `contractId`.
- **Closes #528** — Added `networkPassphrase` to the response of `GET /api/admin/stellar-stats` by including it in the `getStellarStats` return value in `stellar.js`.

## Changed files

| File | Change |
|------|--------|
| `controllers/analyticsController.js` | Added `fees` export |
| `routes/analytics.js` | Registered `GET /fees` |
| `controllers/adminController.js` | Added `getContractEventsGlobalEndpoint`, exported it |
| `routes/admin.js` | Imported and registered `GET /contracts/events` |
| `services/stellar.js` | Added `networkPassphrase` to `getStellarStats` return |

🤖 Generated with [Claude Code](https://claude.com/claude-code)