### PR TITLE
feat: add trustline issuer validation and wire multisig-approval cont…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -179,6 +179,10 @@ ADMIN_ENCRYPTED_SECRET_KEY=your_encrypted_admin_secret_key_here
 # Soroban Fee Distributor Contract
 # Deploy with: CONTRACT=fee-distributor ./contracts/deploy.sh
 FEE_DISTRIBUTOR_CONTRACT_ID=your_deployed_contract_id_here
+
+# Soroban Multisig Approval Contract
+# Deploy with: CONTRACT=multisig-approval ./contracts/deploy.sh
+MULTISIG_APPROVAL_CONTRACT_ID=your_multisig_approval_contract_id_here
 # AES-256 encrypted secret key for the service wallet that holds USDC for fee deposits
 SERVICE_ENCRYPTED_SECRET_KEY=your_encrypted_service_secret_key_here
 # Anchor URL allowlist (comma-separated hostnames for SEP-6/SEP-24 anchor responses)

--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -18,6 +18,7 @@ const {
   getDataEntries,
   getAccountFlags,
   setAccountFlags,
+  initMultisigApproval,
 } = require('../services/stellar');
 const QRCode = require('qrcode');
 const cache = require('../utils/cache');
@@ -230,8 +231,22 @@ async function exportKey(req, res, next) {
 // ---------------------------------------------------------------------------
 async function upgradeToBusinessAccount(req, res, next) {
   try {
+    const wallet = await resolveWallet(req.user.userId, req.body.wallet_id || null);
+    if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
+
+    const { transactionHash } = await initMultisigApproval({
+      publicKey: wallet.public_key,
+      encryptedSecretKey: wallet.encrypted_secret_key,
+    });
+
     await db.query(`UPDATE users SET account_type = 'business' WHERE id = $1`, [req.user.userId]);
-    res.json({ message: 'Account upgraded to business' });
+
+    audit.log(req.user.userId, 'upgrade_to_business', req.ip, req.headers['user-agent'], {
+      wallet_id: wallet.id,
+      transaction_hash: transactionHash,
+    });
+
+    res.json({ message: 'Account upgraded to business', transaction_hash: transactionHash });
   } catch (err) {
     next(err);
   }
@@ -333,13 +348,14 @@ async function listTrustlines(req, res, next) {
 
 async function addTrustlineHandler(req, res, next) {
   try {
-    const { asset, limit, wallet_id } = req.body;
+    const { asset, asset_issuer, limit, wallet_id } = req.body;
     const wallet = await resolveWallet(req.user.userId, wallet_id || null);
     if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
     const { transactionHash } = await addTrustline({
       publicKey: wallet.public_key,
       encryptedSecretKey: wallet.encrypted_secret_key,
       asset,
+      issuer: asset_issuer || undefined,
       limit,
     });
     res.status(201).json({ message: 'Trustline added', transaction_hash: transactionHash });
@@ -351,12 +367,14 @@ async function addTrustlineHandler(req, res, next) {
 async function removeTrustlineHandler(req, res, next) {
   try {
     const { asset } = req.params;
-    const wallet = await resolveWallet(req.user.userId, req.query.wallet_id || null);
+    const { wallet_id, asset_issuer } = req.query;
+    const wallet = await resolveWallet(req.user.userId, wallet_id || null);
     if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
     const { transactionHash } = await removeTrustline({
       publicKey: wallet.public_key,
       encryptedSecretKey: wallet.encrypted_secret_key,
       asset,
+      issuer: asset_issuer || undefined,
     });
     res.json({ message: 'Trustline removed', transaction_hash: transactionHash });
   } catch (err) {

--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -121,6 +121,13 @@ router.post(
   '/trustline',
   [
     body('asset').trim().notEmpty().withMessage('asset is required').isAlphanumeric().isLength({ max: 12 }).withMessage('Invalid asset code'),
+    body('asset_issuer')
+      .if(body('asset').not().equals('XLM'))
+      .notEmpty().withMessage('asset_issuer is required for non-XLM assets')
+      .custom((v) => {
+        if (!StellarSdk.StrKey.isValidEd25519PublicKey(v)) throw new Error('asset_issuer must be a valid Stellar public key');
+        return true;
+      }),
     body('limit').optional().isFloat({ min: 0 }).withMessage('limit must be a non-negative number'),
     body('wallet_id').optional().isUUID().withMessage('wallet_id must be a valid UUID'),
   ],
@@ -129,7 +136,16 @@ router.post(
 );
 router.delete(
   '/trustline/:asset',
-  [param('asset').isAlphanumeric().isLength({ max: 12 }).withMessage('Invalid asset code')],
+  [
+    param('asset').isAlphanumeric().isLength({ max: 12 }).withMessage('Invalid asset code'),
+    query('asset_issuer')
+      .optional()
+      .custom((v) => {
+        if (!StellarSdk.StrKey.isValidEd25519PublicKey(v)) throw new Error('asset_issuer must be a valid Stellar public key');
+        return true;
+      }),
+    query('wallet_id').optional().isUUID().withMessage('wallet_id must be a valid UUID'),
+  ],
   validate,
   removeTrustlineHandler,
 );
@@ -153,7 +169,12 @@ router.post(
 );
 
 // Multisig / business account routes
-router.post('/upgrade-business', upgradeToBusinessAccount);
+router.post(
+  '/upgrade-business',
+  [body('wallet_id').optional().isUUID().withMessage('wallet_id must be a valid UUID')],
+  validate,
+  upgradeToBusinessAccount,
+);
 router.get('/signers', listSigners);
 router.get('/signers/horizon', getSignersFromHorizon);
 router.post('/clear-inflation-destination', clearInflationDestinationHandler);

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -903,8 +903,8 @@ async function sendStrictReceivePathPayment({
  * Add (or update limit on) a trustline for a non-native asset.
  * limit defaults to the Stellar max if not provided.
  */
-async function addTrustline({ publicKey, encryptedSecretKey, asset, limit }) {
-  const assetObj = resolveAsset(asset);
+async function addTrustline({ publicKey, encryptedSecretKey, asset, limit, issuer }) {
+  const assetObj = issuer ? new StellarSdk.Asset(asset, issuer) : resolveAsset(asset);
   const secretKey = decryptPrivateKey(encryptedSecretKey);
   const keypair = StellarSdk.Keypair.fromSecret(secretKey);
 
@@ -939,8 +939,8 @@ async function addTrustline({ publicKey, encryptedSecretKey, asset, limit }) {
  * Remove a trustline by setting limit=0.
  * Stellar will reject this if the account still holds a balance of that asset.
  */
-async function removeTrustline({ publicKey, encryptedSecretKey, asset }) {
-  return addTrustline({ publicKey, encryptedSecretKey, asset, limit: '0' });
+async function removeTrustline({ publicKey, encryptedSecretKey, asset, issuer }) {
+  return addTrustline({ publicKey, encryptedSecretKey, asset, limit: '0', issuer });
 }
 
 /**
@@ -1339,6 +1339,74 @@ async function getAssetMetadataByCodeAndIssuer(code, issuer) {
 }
 
 // ---------------------------------------------------------------------------
+// Multisig approval contract — registers a wallet as a business multisig account.
+// Requires MULTISIG_APPROVAL_CONTRACT_ID env var pointing to the deployed Soroban contract.
+// ---------------------------------------------------------------------------
+
+const MULTISIG_APPROVAL_CONTRACT_ID = process.env.MULTISIG_APPROVAL_CONTRACT_ID;
+const sorobanRpcUrl = process.env.SOROBAN_RPC_URL || (isTestnet
+  ? 'https://soroban-testnet.stellar.org'
+  : 'https://mainnet.soroban.stellar.org');
+const SOROBAN_CONFIRMATION_TIMEOUT_MS = parseInt(process.env.SOROBAN_CONFIRMATION_TIMEOUT_MS || '30000', 10);
+
+async function initMultisigApproval({ publicKey, encryptedSecretKey }) {
+  if (!MULTISIG_APPROVAL_CONTRACT_ID) {
+    const err = new Error('MULTISIG_APPROVAL_CONTRACT_ID is not configured.');
+    err.status = 500;
+    throw err;
+  }
+
+  const secretKey = decryptPrivateKey(encryptedSecretKey);
+  const keypair = StellarSdk.Keypair.fromSecret(secretKey);
+  const rpc = new StellarSdk.SorobanRpc.Server(sorobanRpcUrl);
+  const account = await rpc.getAccount(publicKey);
+  const contract = new StellarSdk.Contract(MULTISIG_APPROVAL_CONTRACT_ID);
+
+  let fee;
+  try {
+    const stats = await rpc.getFeeStats();
+    fee = stats?.sorobanInclusionFee?.p90 != null
+      ? String(stats.sorobanInclusionFee.p90)
+      : String(StellarSdk.BASE_FEE * 10);
+  } catch {
+    fee = String(StellarSdk.BASE_FEE * 10);
+  }
+
+  const args = [StellarSdk.nativeToScVal(publicKey, { type: 'address' })];
+
+  const tx = new StellarSdk.TransactionBuilder(account, { fee, networkPassphrase })
+    .addOperation(contract.call('register_business', ...args))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await rpc.prepareTransaction(tx);
+  prepared.sign(keypair);
+
+  const result = await rpc.sendTransaction(prepared);
+  if (result.status === 'ERROR') {
+    throw Object.assign(new Error(`register_business failed: ${result.errorResult}`), { status: 400 });
+  }
+
+  const maxIterations = Math.ceil(SOROBAN_CONFIRMATION_TIMEOUT_MS / 1000);
+  let response = result;
+  let iterations = 0;
+  while (response.status === 'PENDING' || response.status === 'NOT_FOUND') {
+    if (iterations >= maxIterations) {
+      throw Object.assign(new Error('Multisig approval confirmation timeout'), { status: 504 });
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+    response = await rpc.getTransaction(result.hash);
+    iterations++;
+  }
+
+  if (response.status !== 'SUCCESS') {
+    throw Object.assign(new Error(`Multisig approval transaction failed: ${response.status}`), { status: 400 });
+  }
+
+  return { transactionHash: result.hash };
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 module.exports = {
@@ -1382,4 +1450,5 @@ module.exports = {
   withSequenceRecovery,
   validateNetworkPassphrase,
   getAssetMetadataByCodeAndIssuer,
+  initMultisigApproval,
 };


### PR DESCRIPTION
…ract for business upgrade

- POST /api/wallet/trustline now requires asset_issuer for non-XLM assets and validates it as an Ed25519 public key; issuer is threaded through controller and stellar service so arbitrary trustlines are no longer restricted to env-configured issuers
- DELETE /api/wallet/trustline/:asset accepts optional ?asset_issuer query param with the same validation, enabling removal of user-defined trustlines
- POST /api/wallet/upgrade-business resolves the user wallet, invokes the Soroban multisig-approval contract (register_business), and only updates the DB on success, returning the transaction hash
- Added initMultisigApproval to stellar service following the agentEscrow Soroban RPC pattern; requires MULTISIG_APPROVAL_CONTRACT_ID env var
- Added MULTISIG_APPROVAL_CONTRACT_ID to .env.example

closes #515 
closes #516 