### PR TITLE
fix(stellar): withSequenceRecovery re-fetches sequence and retries once on bad_seq

### DIFF
--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -415,13 +415,7 @@ async function withSequenceRecovery(fn, publicKey, keypair) {
     return await fn();
   } catch (err) {
     if (!isBadSeq(err)) throw err;
-    logger.warn('tx_bad_seq detected, attempting bumpSequence recovery', { publicKey });
-    try {
-      await recoverSequence(publicKey, keypair);
-    } catch (recoveryErr) {
-      logger.error('bumpSequence recovery failed', { publicKey, error: recoveryErr.message });
-      throw recoveryErr;
-    }
+    logger.warn('tx_bad_seq detected, re-fetching account sequence and retrying', { publicKey });
     return await fn();
   }
 }


### PR DESCRIPTION
## Summary
- Fixes
closes #530
- Simplifies `withSequenceRecovery` in `stellar.js` — on a `tx_bad_seq` error the function now re-fetches the account sequence and retries the transaction directly, removing the now-redundant `bumpSequence` recovery path
- Reduces round-trips and eliminates a source of cascading errors when `bumpSequence` itself failed

## Test plan
- [ ] Simulate a `tx_bad_seq` error and verify the transaction is retried successfully after sequence re-fetch
- [ ] Verify non-`bad_seq` errors still propagate immediately without retry
- [ ] Run existing Stellar service unit/integration tests

