### PR TITLE
feat(agent-escrow): add minimum withdrawal amount check to withdraw_fees

### DIFF
--- a/contracts/agent-escrow/src/lib.rs
+++ b/contracts/agent-escrow/src/lib.rs
@@ -322,13 +322,17 @@ impl AgentEscrowContract {
             panic!("unauthorized: caller is not admin");
         }
 
+        if amount <= 0 {
+            panic!("withdrawal amount must be greater than zero");
+        }
+
         let fees: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Fees)
             .unwrap_or(0);
         if amount > fees {
-            panic!("insufficient accumulated fees");
+            panic!("withdrawal amount exceeds accumulated fees");
         }
 
         let usdc: Address = env


### PR DESCRIPTION
Validate that the requested withdrawal amount is greater than zero before checking against accumulated fees, providing a clearer panic message for each invalid condition.

closes #537 