### PR TITLE
feat(dispute-resolution): add configurable evidence size limit to ini…

### DIFF
--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -33,6 +33,7 @@ pub enum DataKey {
     Admin,
     Arbitrator,
     UsdcAddress,
+    MaxEvidenceBytes,
     Counter,
     Dispute(u64),
 }
@@ -116,16 +117,24 @@ impl DisputeResolutionContract {
     /// Initialise the contract. Must be called once before any other function.
     ///
     /// # Arguments
-    /// * `admin`        — Address that may update the arbitrator.
-    /// * `arbitrator`   — Neutral third party authorised to resolve disputes.
-    /// * `usdc_address` — Stellar asset contract address for USDC.
-    pub fn initialize(env: Env, admin: Address, arbitrator: Address, usdc_address: Address) {
+    /// * `admin`              — Address that may update the arbitrator.
+    /// * `arbitrator`         — Neutral third party authorised to resolve disputes.
+    /// * `usdc_address`       — Stellar asset contract address for USDC.
+    /// * `max_evidence_bytes` — Maximum allowed size in bytes for submitted evidence.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        arbitrator: Address,
+        usdc_address: Address,
+        max_evidence_bytes: u32,
+    ) {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("already initialized");
         }
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::Arbitrator, &arbitrator);
         env.storage().persistent().set(&DataKey::UsdcAddress, &usdc_address);
+        env.storage().persistent().set(&DataKey::MaxEvidenceBytes, &max_evidence_bytes);
         env.storage().persistent().set(&DataKey::Counter, &0u64);
     }
 
@@ -217,8 +226,13 @@ impl DisputeResolutionContract {
     /// * `dispute_id` — ID returned by `open_dispute`.
     /// * `evidence`   — IPFS CID or content hash (max 256 bytes).
     pub fn submit_evidence(env: Env, submitter: Address, dispute_id: u64, evidence: Bytes) {
-        if evidence.len() > 256 {
-            panic!("evidence must be 256 bytes or fewer");
+        let max_evidence_bytes: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MaxEvidenceBytes)
+            .expect("not initialized");
+        if evidence.len() > max_evidence_bytes {
+            panic!("evidence exceeds maximum allowed size");
         }
 
         submitter.require_auth();


### PR DESCRIPTION
…tialize

Replace the hardcoded 256-byte evidence cap with a max_evidence_bytes parameter on initialize, stored in persistent storage so the platform can tune the limit per deployment without a contract upgrade.

closes #540 