### PR TITLE
feat(send): add fee estimation preview before submission

### DIFF
--- a/frontend/src/pages/SendMoney.fee.test.jsx
+++ b/frontend/src/pages/SendMoney.fee.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+import { AuthContext } from '../context/AuthContext';
+import SendMoney from './SendMoney';
+
+jest.mock('../utils/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
+jest.mock('react-hot-toast', () => ({ error: jest.fn(), success: jest.fn() }));
+jest.mock('../components/QRScanner', () => () => null);
+jest.mock('../components/PINVerificationModal', () => () => null);
+jest.mock('../components/XDRInspectorModal', () => () => null);
+jest.mock('../components/LedgerSignModal', () => () => null);
+
+import api from '../utils/api';
+
+const mockUser = { full_name: 'Ada', pin_setup_completed: true };
+const feeStatsResponse = { data: { fee_bps: 50, fee_xlm: 0.00001 } };
+
+function renderSendMoney() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <MemoryRouter>
+        <AuthContext.Provider value={{ user: mockUser, updateUser: jest.fn() }}>
+          <SendMoney />
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </I18nextProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  api.get.mockResolvedValue(feeStatsResponse);
+});
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+test('fee panel hidden when amount is empty', async () => {
+  renderSendMoney();
+  await act(async () => jest.runAllTimers());
+  expect(screen.queryByText(/Recipient receives/i)).not.toBeInTheDocument();
+});
+
+test('fee panel shows loading skeleton while debouncing', async () => {
+  renderSendMoney();
+  const amountInput = screen.getByPlaceholderText('0.00');
+  await userEvent.type(amountInput, '100');
+  // skeleton present before debounce fires
+  const skeletons = document.querySelectorAll('.skeleton');
+  expect(skeletons.length).toBeGreaterThan(0);
+});
+
+test('fee panel displays breakdown after debounce resolves', async () => {
+  renderSendMoney();
+  const amountInput = screen.getByPlaceholderText('0.00');
+  await userEvent.type(amountInput, '100');
+  await act(async () => jest.advanceTimersByTime(300));
+  await waitFor(() =>
+    expect(screen.getByText(/Recipient receives/i)).toBeInTheDocument()
+  );
+  expect(screen.getByText(/Platform fee/i)).toBeInTheDocument();
+  expect(screen.getByText(/Network fee/i)).toBeInTheDocument();
+});
+
+test('fee panel shows error fallback when API fails', async () => {
+  api.get.mockRejectedValue(new Error('network'));
+  renderSendMoney();
+  const amountInput = screen.getByPlaceholderText('0.00');
+  await userEvent.type(amountInput, '50');
+  await act(async () => jest.advanceTimersByTime(300));
+  await waitFor(() =>
+    expect(
+      screen.getByText(/Fee estimate unavailable/i)
+    ).toBeInTheDocument()
+  );
+});

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -169,6 +169,35 @@ export default function SendMoney() {
       .catch(() => {});
   }, []);
 
+  // Fee estimation preview (Issue #641)
+  const [feePreview, setFeePreview] = useState(null);
+  const [feePreviewLoading, setFeePreviewLoading] = useState(false);
+  const [feePreviewError, setFeePreviewError] = useState(false);
+  useEffect(() => {
+    const amount = parseFloat(form.amount);
+    if (!amount || amount <= 0) {
+      setFeePreview(null);
+      setFeePreviewError(false);
+      return;
+    }
+    setFeePreviewLoading(true);
+    setFeePreviewError(false);
+    const timer = setTimeout(() => {
+      api
+        .get('/payments/fee-stats')
+        .then((r) => {
+          const feeBps = r.data?.fee_bps ?? 50;
+          const networkFeeXlm = r.data?.fee_xlm ?? 0.00001;
+          const platformFee = (amount * feeBps) / 10000;
+          const net = amount - platformFee;
+          setFeePreview({ amount, platformFee, feeBps, networkFeeXlm, net, asset: form.asset });
+        })
+        .catch(() => setFeePreviewError(true))
+        .finally(() => setFeePreviewLoading(false));
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [form.amount, form.asset]);
+
   // Warn the user before closing/refreshing the tab when the form has data
   useBeforeUnload(
     React.useCallback(
@@ -926,6 +955,41 @@ export default function SendMoney() {
           {feeXLM && form.asset !== 'XLM' && availableXlm !== null && availableXlm < feeXLM && (
             <div className="mt-2 bg-yellow-500/10 border border-yellow-500/40 rounded-xl px-4 py-3 text-yellow-300 text-sm">
               ⚠️ Low XLM balance. You need at least {feeXLM} XLM to cover the network fee.
+            </div>
+          )}
+          {/* Fee estimation preview (Issue #641) */}
+          {(feePreviewLoading || feePreview || feePreviewError) && (
+            <div className="mt-3 bg-gray-800/60 border border-gray-700 rounded-xl px-4 py-3 text-sm space-y-1.5">
+              {feePreviewLoading ? (
+                <>
+                  <div className="skeleton h-3 w-32 rounded" />
+                  <div className="skeleton h-3 w-24 rounded" />
+                  <div className="skeleton h-3 w-28 rounded" />
+                </>
+              ) : feePreviewError ? (
+                <p className="text-gray-400 text-xs">
+                  Fee estimate unavailable — final fee will be shown at confirmation.
+                </p>
+              ) : feePreview ? (
+                <>
+                  <div className="flex justify-between text-gray-400">
+                    <span>Gross amount</span>
+                    <span className="text-white">{feePreview.amount.toFixed(7)} {feePreview.asset}</span>
+                  </div>
+                  <div className="flex justify-between text-gray-400">
+                    <span>Platform fee ({(feePreview.feeBps / 100).toFixed(2)}%)</span>
+                    <span className="text-red-400">− {feePreview.platformFee.toFixed(7)} {feePreview.asset}</span>
+                  </div>
+                  <div className="flex justify-between text-gray-400">
+                    <span>Network fee (est.)</span>
+                    <span className="text-red-400">~ {feePreview.networkFeeXlm} XLM</span>
+                  </div>
+                  <div className="flex justify-between font-semibold border-t border-gray-700 pt-1.5">
+                    <span className="text-gray-300">Recipient receives</span>
+                    <span className="text-green-400">{feePreview.net.toFixed(7)} {feePreview.asset}</span>
+                  </div>
+                </>
+              ) : null}
             </div>
           )}
           {belowMinBalance && (


### PR DESCRIPTION
## Summary

- Add debounced (300ms) fee estimation panel below the amount input in `SendMoney.jsx`
- Shows gross amount, platform fee (bps%), estimated Stellar network fee (XLM), and net recipient amount
- Skeleton loading state shown while estimate is fetching
- Error fallback: "Fee estimate unavailable — final fee will be shown at confirmation."
- Panel hidden when amount is empty or zero
- Updates when currency changes
- Unit tests: loading state, successful display, error fallback, zero-amount hiding

## Validation

- `SendMoney.fee.test.jsx` covers 4 cases

Closes #641