### PR TITLE
feat(dashboard): skeleton loading and error states for balance cards

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,6 +46,13 @@ body {
   background-size: 800px 100%;
 }
 
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { @apply bg-gray-200 dark:bg-gray-900; }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -126,6 +126,7 @@ export default function Dashboard() {
   const [fromCache, setFromCache] = useState(false);
   const [showZeroBalances, setShowZeroBalances] = useState(false);
   const [walletError, setWalletError] = useState(false);
+  const [transactionsError, setTransactionsError] = useState(false);
   const [queueCount, setQueueCount] = useState(0);
   const { currencies, convertFromXLM, usingApproximateRates } = useExchangeRates();
   const { isOnline } = useOnlineStatus();
@@ -212,6 +213,7 @@ export default function Dashboard() {
       setScheduledLoading(false);
       setFromCache(false);
       setWalletError(walletsData.length === 0);
+      setTransactionsError(false);
 
       await Promise.all([setCacheEntry('wallets', walletsData), setCacheEntry('history', txData)]).catch(
         () => {}
@@ -230,6 +232,9 @@ export default function Dashboard() {
         }
         if (cachedHistory?.data) {
           setTransactions(cachedHistory.data.slice(0, 5));
+          setTransactionsError(false);
+        } else {
+          setTransactionsError(true);
         }
         if (!cachedWallets?.data) {
           setWallets([]);
@@ -241,6 +246,7 @@ export default function Dashboard() {
         setWallets([]);
         setActiveWalletId(null);
         setWalletError(true);
+        setTransactionsError(true);
         toast.error('Failed to load wallet data');
       }
     } finally {
@@ -974,7 +980,29 @@ export default function Dashboard() {
           </button>
         </div>
 
-        {transactions.length === 0 ? (
+        {loading && transactions.length === 0 ? (
+          <div className="space-y-2" data-testid="transactions-skeleton" aria-hidden="true">
+            {[0, 1, 2].map((i) => (
+              <TransactionRowSkeleton key={i} />
+            ))}
+          </div>
+        ) : transactionsError && transactions.length === 0 ? (
+          <div
+            role="alert"
+            className="bg-red-500/10 border border-red-500/30 rounded-xl px-4 py-4 text-red-300 shadow-sm"
+          >
+            <p className="text-sm font-medium">Could not load recent activity.</p>
+            <button
+              type="button"
+              onClick={() => loadDashboard(true)}
+              disabled={refreshing}
+              className="mt-3 inline-flex items-center gap-2 rounded-lg bg-red-500/20 px-3 py-2 text-sm font-semibold text-red-100 hover:bg-red-500/30 disabled:opacity-50"
+            >
+              <RefreshCw size={14} className={refreshing ? 'animate-spin' : ''} />
+              Retry
+            </button>
+          </div>
+        ) : transactions.length === 0 ? (
           <div className="bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-6 text-center text-gray-500 text-sm shadow-sm">
             {t('dashboard.no_transactions')}
           </div>

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -95,6 +95,21 @@ describe('Dashboard', () => {
     expect(document.querySelector('.animate-spin')).toBeInTheDocument();
   });
 
+  test('shows transaction skeleton rows during the initial fetch', () => {
+    api.get.mockReturnValue(new Promise(() => {}));
+    renderDashboard();
+    expect(screen.getByTestId('transactions-skeleton')).toBeInTheDocument();
+  });
+
+  test('replaces transaction skeletons with a retryable error state on fetch failure', async () => {
+    api.get.mockRejectedValue(new Error('history unavailable'));
+
+    renderDashboard();
+
+    expect(await screen.findByText('Could not load recent activity.')).toBeInTheDocument();
+    expect(screen.queryByTestId('transactions-skeleton')).not.toBeInTheDocument();
+  });
+
   test('displays XLM balance after loading', async () => {
     api.get
       .mockResolvedValueOnce(walletResponse)


### PR DESCRIPTION
## Summary

- Render 3 `TransactionRowSkeleton` placeholders in the recent-activity list during the initial fetch (reusing the existing `Skeleton.jsx` primitives; the balance card already used `BalanceCardSkeleton`).
- Add a retryable error state (alert + Retry button) that replaces the transaction skeletons when the fetch fails, instead of a blank "no transactions" card.
- Disable the skeleton shimmer under `prefers-reduced-motion: reduce`.

## Validation

- format: prettier not installed in CI env (devDependency unavailable)
- lint: eslint config extends `airbnb`, which is not resolvable in this environment (pre-existing)
- tests: `react-scripts test Dashboard.test` — 2 new tests pass (skeleton rows shown on initial fetch; skeleton replaced by retryable error). 11 pre-existing failures in this suite are unrelated to this change (they assert a `.animate-spin` loader that the page no longer renders on initial load).

Closes #642