### PR TITLE
feat(payments): fee estimation preview before submission

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -160,6 +160,10 @@ async function estimateFee(req, res, next) {
   }
 }
 
+function getFeeRate(req, res) {
+  res.json({ fee_bps: FEE_BPS });
+}
+
 async function getFeeStats(req, res, next) {
   try {
     const stats = await fetchFeeStats();
@@ -931,4 +935,4 @@ async function exportCSV(req, res, next) {
   }
 }
 
-module.exports = { send, sendBatch, history, findPath, sendPath, exportCSV, estimateFee, getFeeStats, findReceivePathHandler, sendStrictReceivePath };
+module.exports = { send, sendBatch, history, findPath, sendPath, exportCSV, estimateFee, getFeeStats, getFeeRate, findReceivePathHandler, sendStrictReceivePath };

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -14,6 +14,7 @@ const {
   exportCSV,
   estimateFee,
   getFeeStats,
+  getFeeRate,
   findPath,
   sendPath,
   findReceivePathHandler,
@@ -52,6 +53,7 @@ router.use(authMiddleware);
 
 router.get("/estimate-fee", estimateFee);
 router.get("/fee-stats", getFeeStats);
+router.get("/fee-rate", getFeeRate);
 
 /**
  * POST /api/payments/send

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -17,6 +17,7 @@ import api from '../utils/api';
 import { useExchangeRates } from '../hooks/useExchangeRates';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { Skeleton } from '../components/Skeleton';
 import QRScanner from '../components/QRScanner';
 import PINVerificationModal from '../components/PINVerificationModal';
 import XDRInspectorModal from '../components/XDRInspectorModal';
@@ -29,6 +30,10 @@ const getSavedSlippage = () => {
   const v = parseFloat(localStorage.getItem('afripay_slippage'));
   return SLIPPAGE_OPTIONS.includes(v) ? v : DEFAULT_SLIPPAGE;
 };
+
+/** Trims trailing zeros from a Stellar-precision (7dp) amount for display. */
+const fmtFee = (n) =>
+  parseFloat(Number(n).toFixed(7)).toLocaleString(undefined, { maximumFractionDigits: 7 });
 
 export default function SendMoney() {
   const navigate = useNavigate();
@@ -59,6 +64,10 @@ export default function SendMoney() {
   const [loading, setLoading] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
   const [feeXLM, setFeeXLM] = useState(null);
+  // Issue #641: pre-submission fee estimation preview
+  const [feeEstimate, setFeeEstimate] = useState(null);
+  const [feeEstimateLoading, setFeeEstimateLoading] = useState(false);
+  const [feeEstimateError, setFeeEstimateError] = useState(false);
   const [contractSimData, setContractSimData] = useState(null);
   const [contractSimLoading, setContractSimLoading] = useState(false);
   const [requestId] = useState(searchParams.get('request'));
@@ -168,6 +177,55 @@ export default function SendMoney() {
       .then((r) => setFeeStats(r.data))
       .catch(() => {});
   }, []);
+
+  // Issue #641: debounced fee estimation preview as the user types an amount.
+  useEffect(() => {
+    const gross = parseFloat(form.amount);
+    if (!form.amount || !Number.isFinite(gross) || gross <= 0) {
+      setFeeEstimate(null);
+      setFeeEstimateError(false);
+      setFeeEstimateLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setFeeEstimateLoading(true);
+    setFeeEstimateError(false);
+
+    const timer = setTimeout(async () => {
+      try {
+        const [rateRes, networkRes] = await Promise.all([
+          api.get('/payments/fee-rate'),
+          api.get('/payments/estimate-fee'),
+        ]);
+        if (cancelled) return;
+        const feeBps = rateRes.data?.fee_bps;
+        if (feeBps == null || Number.isNaN(Number(feeBps))) {
+          throw new Error('Fee rate unavailable');
+        }
+        const platformFee = gross * (Number(feeBps) / 10000);
+        setFeeEstimate({
+          gross,
+          asset: form.asset,
+          feePct: Number(feeBps) / 100,
+          platformFee,
+          networkFeeXLM: networkRes.data?.fee_xlm ?? null,
+          netAmount: gross - platformFee,
+        });
+      } catch {
+        if (cancelled) return;
+        setFeeEstimate(null);
+        setFeeEstimateError(true);
+      } finally {
+        if (!cancelled) setFeeEstimateLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [form.amount, form.asset]);
 
   // Warn the user before closing/refreshing the tab when the form has data
   useBeforeUnload(
@@ -935,6 +993,56 @@ export default function SendMoney() {
             </div>
           )}
         </div>
+
+        {/* Fee estimation preview (issue #641) */}
+        {(feeEstimateLoading || feeEstimate || feeEstimateError) && (
+          <div
+            data-testid="fee-estimate"
+            className="bg-gray-800 border border-gray-700 rounded-xl p-4"
+          >
+            <p className="text-sm font-semibold text-gray-300 mb-2">Fee breakdown</p>
+            {feeEstimateLoading ? (
+              <div className="space-y-2" data-testid="fee-estimate-skeleton" aria-hidden="true">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+            ) : feeEstimateError ? (
+              <p className="text-sm text-yellow-400">
+                Fee estimate unavailable — final fee will be shown at confirmation.
+              </p>
+            ) : feeEstimate ? (
+              <dl className="space-y-1.5 text-sm">
+                <div className="flex justify-between">
+                  <dt className="text-gray-400">Gross amount</dt>
+                  <dd className="text-white">
+                    {fmtFee(feeEstimate.gross)} {feeEstimate.asset}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-gray-400">
+                    Platform fee ({feeEstimate.feePct}%)
+                  </dt>
+                  <dd className="text-white">
+                    {fmtFee(feeEstimate.platformFee)} {feeEstimate.asset}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-gray-400">Est. network fee</dt>
+                  <dd className="text-white">
+                    {feeEstimate.networkFeeXLM != null ? `${feeEstimate.networkFeeXLM} XLM` : '—'}
+                  </dd>
+                </div>
+                <div className="flex justify-between border-t border-gray-700 pt-1.5 font-semibold">
+                  <dt className="text-gray-300">Recipient receives</dt>
+                  <dd className="text-green-400">
+                    {fmtFee(feeEstimate.netAmount)} {feeEstimate.asset}
+                  </dd>
+                </div>
+              </dl>
+            ) : null}
+          </div>
+        )}
 
         {/* Path payment toggle (issue #458) */}
         <div>

--- a/frontend/src/pages/__tests__/SendMoney.test.jsx
+++ b/frontend/src/pages/__tests__/SendMoney.test.jsx
@@ -538,3 +538,66 @@ test('no error shown when field is empty on blur', async () => {
   fireEvent.blur(input);
   expect(screen.queryByText(/invalid address/i)).not.toBeInTheDocument();
 });
+
+// ── Issue #641: fee estimation preview ──────────────────────────────────────
+
+function mockFeeApi({ feeBps = 250, mode = 'ok', networkFee = { fee_xlm: '0.0000100' } } = {}) {
+  api.get.mockImplementation((url) => {
+    if (url === '/payments/fee-rate') {
+      if (mode === 'pending') return new Promise(() => {}); // never resolves
+      if (mode === 'reject') return Promise.reject(new Error('fee rate unavailable'));
+      return Promise.resolve({ data: { fee_bps: feeBps } });
+    }
+    if (url === '/payments/estimate-fee') return Promise.resolve({ data: networkFee });
+    if (url === '/wallet/list') return Promise.resolve({ data: { wallets: [] } });
+    if (url === '/payments/fee-stats') return Promise.resolve({ data: {} });
+    return Promise.resolve({ data: { contacts: [] } });
+  });
+}
+
+test('shows fee breakdown after the user types an amount', async () => {
+  mockFeeApi({ feeBps: 250 });
+  renderComponent();
+
+  await userEvent.type(screen.getByPlaceholderText('0.00'), '100');
+
+  const panel = await screen.findByTestId('fee-estimate');
+  await waitFor(() => expect(panel).toHaveTextContent('Platform fee (2.5%)'));
+  expect(panel).toHaveTextContent('2.5 XLM'); // 100 * 250bps
+  expect(panel).toHaveTextContent('0.0000100 XLM'); // network fee
+  expect(panel).toHaveTextContent('97.5 XLM'); // recipient receives
+});
+
+test('shows a loading skeleton while the estimate is fetched', async () => {
+  mockFeeApi({ mode: 'pending' });
+  renderComponent();
+
+  await userEvent.type(screen.getByPlaceholderText('0.00'), '50');
+
+  expect(await screen.findByTestId('fee-estimate-skeleton')).toBeInTheDocument();
+});
+
+test('shows fallback message when the fee rate cannot be fetched', async () => {
+  mockFeeApi({ mode: 'reject' });
+  renderComponent();
+
+  await userEvent.type(screen.getByPlaceholderText('0.00'), '25');
+
+  expect(
+    await screen.findByText(/Fee estimate unavailable — final fee will be shown at confirmation\./i)
+  ).toBeInTheDocument();
+});
+
+test('hides the fee panel when the amount is empty or zero', async () => {
+  mockFeeApi({ feeRate: { fee_bps: 250 } });
+  renderComponent();
+
+  // Empty by default
+  expect(screen.queryByTestId('fee-estimate')).not.toBeInTheDocument();
+
+  // Zero amount stays hidden
+  await userEvent.type(screen.getByPlaceholderText('0.00'), '0');
+  await waitFor(() =>
+    expect(screen.queryByTestId('fee-estimate')).not.toBeInTheDocument()
+  );
+});


### PR DESCRIPTION
## Summary

- Add `GET /api/payments/fee-rate` returning the configured platform `fee_bps` (reuses the existing `FEE_BPS` constant).
- SendMoney now shows a fee breakdown panel below the amount input as the user types: gross amount, platform fee (amount + %), estimated Stellar network fee (XLM), and net amount the recipient receives.
- Estimation is debounced (300 ms); the panel is hidden for empty/zero amounts and re-computes when the asset/currency changes.
- Shows a loading skeleton (reusing `Skeleton`) while fetching and the fallback message "Fee estimate unavailable — final fee will be shown at confirmation." on error.

## Validation

- format: prettier not installed in CI env (devDependency unavailable)
- lint: eslint config extends `airbnb`, not resolvable in this environment (pre-existing)
- tests: `react-scripts test SendMoney.test` — 4 new tests pass (successful fee display, loading skeleton, error fallback, zero-amount hiding). 2 pre-existing failures in this suite are unrelated to this change.

Note: platform fee is displayed in the selected send asset alongside the percentage; a cross-asset→USDC conversion was not introduced as no reliable asset→USDC rate utility exists in the frontend.

Closes #641