### PR TITLE
feat(dashboard): add skeleton loading states for balance cards and transactions

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,6 +36,12 @@ body {
   animation: shimmer 1.4s ease-in-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
 .dark .skeleton {
   background: linear-gradient(
     90deg,

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -113,6 +113,7 @@ export default function Dashboard() {
   const wallet = wallets.find((w) => w.id === activeWalletId) || wallets[0] || null;
 
   const [transactions, setTransactions] = useState([]);
+  const [txError, setTxError] = useState(false);
   const [scheduledPayments, setScheduledPayments] = useState([]);
   const [scheduledLoading, setScheduledLoading] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -208,6 +209,7 @@ export default function Dashboard() {
       setWallets(walletsData);
       setActiveWalletId((id) => id || walletsData[0]?.id || null);
       setTransactions(txData.slice(0, 5));
+      setTxError(false);
       setScheduledPayments((scheduledRes.data.payments || []).filter((p) => p.active).slice(0, 3));
       setScheduledLoading(false);
       setFromCache(false);
@@ -230,6 +232,9 @@ export default function Dashboard() {
         }
         if (cachedHistory?.data) {
           setTransactions(cachedHistory.data.slice(0, 5));
+          setTxError(false);
+        } else {
+          setTxError(true);
         }
         if (!cachedWallets?.data) {
           setWallets([]);
@@ -974,7 +979,23 @@ export default function Dashboard() {
           </button>
         </div>
 
-        {transactions.length === 0 ? (
+        {loading ? (
+          <div className="space-y-2" aria-busy="true" aria-label="Loading transactions">
+            <TransactionRowSkeleton />
+            <TransactionRowSkeleton />
+            <TransactionRowSkeleton />
+          </div>
+        ) : txError ? (
+          <div className="bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-6 text-center text-sm shadow-sm">
+            <p className="text-gray-500 mb-3">Failed to load transactions.</p>
+            <button
+              onClick={() => loadDashboard(false)}
+              className="text-primary-500 font-medium hover:underline"
+            >
+              {t('common.retry')}
+            </button>
+          </div>
+        ) : transactions.length === 0 ? (
           <div className="bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-6 text-center text-gray-500 text-sm shadow-sm">
             {t('dashboard.no_transactions')}
           </div>

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -267,3 +267,45 @@ describe('Dashboard', () => {
     }
   );
 });
+
+// Issue #642 — Skeleton loading state tests
+describe('Dashboard skeleton loading states', () => {
+  beforeEach(() => {
+    // Delay resolution so we can assert skeleton state
+    api.get.mockImplementation(
+      () => new Promise(() => {}) // never resolves — tests skeleton snapshot
+    );
+  });
+
+  it('renders BalanceCardSkeleton while loading', () => {
+    renderDashboard();
+    // The skeleton container for the balance card uses the Skeleton component
+    const skeletons = document.querySelectorAll('.skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders 3 TransactionRowSkeleton placeholders while loading', () => {
+    renderDashboard();
+    // TransactionRowSkeleton renders 3 .skeleton elements per row (icon, label, amount)
+    // We verify the aria-busy container is present
+    expect(document.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+});
+
+// Issue #642 — Skeleton loading state tests
+describe('Dashboard skeleton loading states', () => {
+  beforeEach(() => {
+    api.get.mockImplementation(() => new Promise(() => {}));
+  });
+
+  it('renders skeleton placeholders while loading', () => {
+    renderDashboard();
+    const skeletons = document.querySelectorAll('.skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders aria-busy transaction skeleton container while loading', () => {
+    renderDashboard();
+    expect(document.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `txError` state; show 3 `TransactionRowSkeleton` rows while `loading=true`
- Show error + Retry button when transaction fetch fails (no cached data)
- Respect `prefers-reduced-motion`: add `@media` rule to `index.css` disabling shimmer animation
- Reuse existing `BalanceCardSkeleton` and `TransactionRowSkeleton` from `Skeleton.jsx`
- Snapshot tests updated: skeleton state and `aria-busy` container verified

## Validation

- `Dashboard.test.jsx` — 2 new skeleton state tests added

Closes #642