### PR TITLE
test(i18n): verify Hausa (ha) translation coverage

### DIFF
--- a/frontend/src/locales/ha.i18n.test.jsx
+++ b/frontend/src/locales/ha.i18n.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { I18nextProvider, useTranslation } from 'react-i18next';
+import i18n from '../i18n';
+import en from './en/translation.json';
+import ha from './ha/translation.json';
+
+// Issue #643: verify that switching to Hausa (ha) renders real Hausa strings
+// — not silent English fallbacks — for key UI labels (≥10), following the
+// Profile.i18n.test.jsx integration pattern.
+const KEYS = [
+  'common.back',
+  'common.loading',
+  'common.cancel',
+  'common.continue',
+  'common.share',
+  'common.add',
+  'common.see_all',
+  'common.sign_out',
+  'dashboard.send',
+  'profile.title',
+  'send.title',
+];
+
+const get = (obj, path) => path.split('.').reduce((o, k) => (o ? o[k] : undefined), obj);
+
+function Labels() {
+  const { t } = useTranslation();
+  return (
+    <ul>
+      {KEYS.map((k) => (
+        <li key={k} data-testid={k}>
+          {t(k)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+describe('Hausa (ha) translation coverage', () => {
+  afterAll(async () => {
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+  });
+
+  test('covers at least 10 key UI labels', () => {
+    expect(KEYS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  test('renders Hausa strings (no English fallback) when locale is ha', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('ha');
+    });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <Labels />
+      </I18nextProvider>
+    );
+
+    for (const key of KEYS) {
+      const expected = get(ha, key);
+      const node = screen.getByTestId(key);
+      // Renders the documented Hausa string …
+      expect(node).toHaveTextContent(expected);
+      // … and never the English baseline (no silent fallback) or the raw key.
+      expect(node.textContent).not.toBe(get(en, key));
+      expect(node.textContent).not.toBe(key);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Audited `locales/en` vs `locales/ha` (flattened key comparison). Result: **0 missing keys** — the Hausa locale already mirrors the English baseline at 151/151 keys, so there were no gaps to fill. The only English-identical values are technical terms intentionally kept untranslated: `auth.pin_label` ("PIN") and `send.confirm_memo` ("Memo:").
- Added an integration test following the `Profile.i18n.test.jsx` pattern that switches the live i18n instance to `ha` and renders 11 key UI labels, asserting each shows the documented Hausa string and never the English baseline or raw key (i.e. no silent English fallback).

### Audit (en → ha)

- Total keys: en=151, ha=151
- Missing in ha: 0
- Extra in ha: 0
- Identical (untranslated) strings: `auth.pin_label`, `send.confirm_memo` (technical terms)

## Validation

- format: prettier not installed in CI env (devDependency unavailable)
- lint: eslint config extends `airbnb`, not resolvable in this environment (pre-existing)
- tests: `react-scripts test ha.i18n.test` — 2 tests pass.

Closes #643