### PR TITLE
feat(contracts): add max supply cap, expiring allowances, and quorum …

### DIFF
--- a/contracts/loyalty-token/src/lib.rs
+++ b/contracts/loyalty-token/src/lib.rs
@@ -24,6 +24,12 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Env, String,
 };
 
+#[contracttype]
+pub struct AllowanceValue {
+    pub amount: i128,
+    pub expires_at: u64,
+}
+
 mod test;
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -32,6 +38,7 @@ mod test;
 pub enum DataKey {
     Admin,
     TotalSupply,
+    MaxSupply,
     Balance(Address),
     Allowance(Address, Address), // (owner, spender)
 }
@@ -53,13 +60,18 @@ impl LoyaltyTokenContract {
     /// Initialise the contract. Must be called once before any other function.
     ///
     /// # Arguments
-    /// * `admin` — Address authorised to mint tokens (the AfriPay backend).
-    pub fn initialize(env: Env, admin: Address) {
+    /// * `admin`      — Address authorised to mint tokens (the AfriPay backend).
+    /// * `max_supply` — Hard ceiling on total points that can ever be minted (must be > 0).
+    pub fn initialize(env: Env, admin: Address, max_supply: i128) {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("already initialized");
         }
+        if max_supply <= 0 {
+            panic!("max_supply must be positive");
+        }
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::TotalSupply, &0i128);
+        env.storage().persistent().set(&DataKey::MaxSupply, &max_supply);
     }
 
     // ── SEP-41: token metadata ────────────────────────────────────────────────
@@ -86,6 +98,13 @@ impl LoyaltyTokenContract {
             .unwrap_or(0)
     }
 
+    pub fn max_supply(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MaxSupply)
+            .expect("not initialized")
+    }
+
     pub fn balance(env: Env, account: Address) -> i128 {
         env.storage()
             .persistent()
@@ -96,22 +115,37 @@ impl LoyaltyTokenContract {
     // ── SEP-41: allowances ────────────────────────────────────────────────────
 
     pub fn allowance(env: Env, owner: Address, spender: Address) -> i128 {
-        env.storage()
+        let entry: Option<AllowanceValue> = env
+            .storage()
             .persistent()
-            .get(&DataKey::Allowance(owner, spender))
-            .unwrap_or(0)
+            .get(&DataKey::Allowance(owner, spender));
+        match entry {
+            None => 0,
+            Some(v) => {
+                if env.ledger().timestamp() > v.expires_at {
+                    0
+                } else {
+                    v.amount
+                }
+            }
+        }
     }
 
     /// Approve `spender` to transfer up to `amount` points on behalf of the
-    /// caller.
-    pub fn approve(env: Env, owner: Address, spender: Address, amount: i128) {
+    /// caller until `expires_at` (inclusive, Unix ledger timestamp).
+    ///
+    /// Set `amount` to 0 to revoke an existing allowance.
+    pub fn approve(env: Env, owner: Address, spender: Address, amount: i128, expires_at: u64) {
         if amount < 0 {
             panic!("amount must be non-negative");
+        }
+        if expires_at < env.ledger().timestamp() {
+            panic!("expires_at must be in the future");
         }
         owner.require_auth();
         env.storage()
             .persistent()
-            .set(&DataKey::Allowance(owner, spender), &amount);
+            .set(&DataKey::Allowance(owner, spender), &AllowanceValue { amount, expires_at });
     }
 
     // ── SEP-41: transfers ─────────────────────────────────────────────────────
@@ -139,19 +173,25 @@ impl LoyaltyTokenContract {
         }
         spender.require_auth();
 
-        let allowance: i128 = env
+        let entry: AllowanceValue = env
             .storage()
             .persistent()
             .get(&DataKey::Allowance(from.clone(), spender.clone()))
-            .unwrap_or(0);
+            .unwrap_or(AllowanceValue { amount: 0, expires_at: 0 });
 
-        if allowance < amount {
+        if env.ledger().timestamp() > entry.expires_at {
+            panic!("allowance expired");
+        }
+        if entry.amount < amount {
             panic!("insufficient allowance");
         }
 
         env.storage()
             .persistent()
-            .set(&DataKey::Allowance(from.clone(), spender), &(allowance - amount));
+            .set(&DataKey::Allowance(from.clone(), spender), &AllowanceValue {
+                amount: entry.amount - amount,
+                expires_at: entry.expires_at,
+            });
 
         Self::_debit(&env, &from, amount);
         Self::_credit(&env, &to, amount);
@@ -184,19 +224,25 @@ impl LoyaltyTokenContract {
         }
         spender.require_auth();
 
-        let allowance: i128 = env
+        let entry: AllowanceValue = env
             .storage()
             .persistent()
             .get(&DataKey::Allowance(from.clone(), spender.clone()))
-            .unwrap_or(0);
+            .unwrap_or(AllowanceValue { amount: 0, expires_at: 0 });
 
-        if allowance < amount {
+        if env.ledger().timestamp() > entry.expires_at {
+            panic!("allowance expired");
+        }
+        if entry.amount < amount {
             panic!("insufficient allowance");
         }
 
         env.storage()
             .persistent()
-            .set(&DataKey::Allowance(from.clone(), spender), &(allowance - amount));
+            .set(&DataKey::Allowance(from.clone(), spender), &AllowanceValue {
+                amount: entry.amount - amount,
+                expires_at: entry.expires_at,
+            });
 
         Self::_debit(&env, &from, amount);
         let supply: i128 = env
@@ -236,13 +282,21 @@ impl LoyaltyTokenContract {
             panic!("unauthorized: caller is not admin");
         }
 
-        Self::_credit(&env, &to, amount);
-
         let supply: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
+        let cap: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MaxSupply)
+            .expect("not initialized");
+        if supply + amount > cap {
+            panic!("minting would exceed max supply");
+        }
+
+        Self::_credit(&env, &to, amount);
         env.storage()
             .persistent()
             .set(&DataKey::TotalSupply, &(supply + amount));

--- a/contracts/loyalty-token/src/test.rs
+++ b/contracts/loyalty-token/src/test.rs
@@ -1,18 +1,23 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
 
 use crate::{LoyaltyTokenContract, LoyaltyTokenContractClient};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+const DEFAULT_MAX_SUPPLY: i128 = 1_000_000_000;
+const BASE_TIMESTAMP: u64 = 1_000_000;
+const FAR_FUTURE: u64 = 9_999_999_999;
+
 fn setup() -> (Env, LoyaltyTokenContractClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = BASE_TIMESTAMP);
     let contract_id = env.register_contract(None, LoyaltyTokenContract);
     let client = LoyaltyTokenContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &DEFAULT_MAX_SUPPLY);
     (env, client, admin)
 }
 
@@ -28,7 +33,24 @@ fn test_initialize_sets_zero_supply() {
 #[should_panic(expected = "already initialized")]
 fn test_double_initialize_panics() {
     let (_, client, admin) = setup();
-    client.initialize(&admin);
+    client.initialize(&admin, &DEFAULT_MAX_SUPPLY);
+}
+
+#[test]
+#[should_panic(expected = "max_supply must be positive")]
+fn test_initialize_zero_max_supply_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, LoyaltyTokenContract);
+    let client = LoyaltyTokenContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &0);
+}
+
+#[test]
+fn test_initialize_stores_max_supply() {
+    let (_, client, _) = setup();
+    assert_eq!(client.max_supply(), DEFAULT_MAX_SUPPLY);
 }
 
 // ── metadata ──────────────────────────────────────────────────────────────────
@@ -115,6 +137,47 @@ fn test_mint_negative_amount_panics() {
     client.mint(&admin, &user, &-1);
 }
 
+#[test]
+fn test_mint_exactly_to_cap_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, LoyaltyTokenContract);
+    let client = LoyaltyTokenContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &500);
+    client.mint(&admin, &user, &500);
+    assert_eq!(client.total_supply(), 500);
+    assert_eq!(client.balance(&user), 500);
+}
+
+#[test]
+#[should_panic(expected = "minting would exceed max supply")]
+fn test_mint_exceeds_cap_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, LoyaltyTokenContract);
+    let client = LoyaltyTokenContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &100);
+    client.mint(&admin, &user, &101);
+}
+
+#[test]
+#[should_panic(expected = "minting would exceed max supply")]
+fn test_mint_cumulative_exceeds_cap_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, LoyaltyTokenContract);
+    let client = LoyaltyTokenContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &100);
+    client.mint(&admin, &user, &60);
+    client.mint(&admin, &user, &41); // 60 + 41 = 101 > 100
+}
+
 // ── burn ──────────────────────────────────────────────────────────────────────
 
 #[test]
@@ -187,7 +250,7 @@ fn test_approve_sets_allowance() {
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
     client.mint(&admin, &owner, &100);
-    client.approve(&owner, &spender, &50);
+    client.approve(&owner, &spender, &50, &FAR_FUTURE);
     assert_eq!(client.allowance(&owner, &spender), 50);
 }
 
@@ -198,7 +261,7 @@ fn test_transfer_from_uses_allowance() {
     let spender = Address::generate(&env);
     let receiver = Address::generate(&env);
     client.mint(&admin, &owner, &100);
-    client.approve(&owner, &spender, &40);
+    client.approve(&owner, &spender, &40, &FAR_FUTURE);
     client.transfer_from(&spender, &owner, &receiver, &40);
     assert_eq!(client.balance(&owner), 60);
     assert_eq!(client.balance(&receiver), 40);
@@ -213,7 +276,7 @@ fn test_transfer_from_exceeds_allowance_panics() {
     let spender = Address::generate(&env);
     let receiver = Address::generate(&env);
     client.mint(&admin, &owner, &100);
-    client.approve(&owner, &spender, &10);
+    client.approve(&owner, &spender, &10, &FAR_FUTURE);
     client.transfer_from(&spender, &owner, &receiver, &11);
 }
 
@@ -223,7 +286,7 @@ fn test_burn_from_uses_allowance() {
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
     client.mint(&admin, &owner, &100);
-    client.approve(&owner, &spender, &30);
+    client.approve(&owner, &spender, &30, &FAR_FUTURE);
     client.burn_from(&spender, &owner, &30);
     assert_eq!(client.balance(&owner), 70);
     assert_eq!(client.total_supply(), 70);
@@ -237,8 +300,60 @@ fn test_burn_from_exceeds_allowance_panics() {
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
     client.mint(&admin, &owner, &100);
-    client.approve(&owner, &spender, &5);
+    client.approve(&owner, &spender, &5, &FAR_FUTURE);
     client.burn_from(&spender, &owner, &6);
+}
+
+// ── allowance expiry ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_allowance_returns_zero_after_expiry() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    client.mint(&admin, &owner, &100);
+    // approve with expiry 1 second in the future from BASE_TIMESTAMP
+    client.approve(&owner, &spender, &50, &(BASE_TIMESTAMP + 1));
+    assert_eq!(client.allowance(&owner, &spender), 50);
+    // advance past expiry
+    env.ledger().with_mut(|l| l.timestamp = BASE_TIMESTAMP + 2);
+    assert_eq!(client.allowance(&owner, &spender), 0);
+}
+
+#[test]
+#[should_panic(expected = "allowance expired")]
+fn test_transfer_from_expired_allowance_panics() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    client.mint(&admin, &owner, &100);
+    client.approve(&owner, &spender, &50, &(BASE_TIMESTAMP + 1));
+    env.ledger().with_mut(|l| l.timestamp = BASE_TIMESTAMP + 2);
+    client.transfer_from(&spender, &owner, &receiver, &10);
+}
+
+#[test]
+#[should_panic(expected = "allowance expired")]
+fn test_burn_from_expired_allowance_panics() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    client.mint(&admin, &owner, &100);
+    client.approve(&owner, &spender, &50, &(BASE_TIMESTAMP + 1));
+    env.ledger().with_mut(|l| l.timestamp = BASE_TIMESTAMP + 2);
+    client.burn_from(&spender, &owner, &10);
+}
+
+#[test]
+#[should_panic(expected = "expires_at must be in the future")]
+fn test_approve_past_expiry_panics() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    client.mint(&admin, &owner, &100);
+    // BASE_TIMESTAMP - 1 is in the past
+    client.approve(&owner, &spender, &50, &(BASE_TIMESTAMP - 1));
 }
 
 // ── redeem ────────────────────────────────────────────────────────────────────

--- a/contracts/multisig-approval/src/lib.rs
+++ b/contracts/multisig-approval/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec};
 
 mod test;
 
@@ -18,8 +18,20 @@ pub enum TxStatus {
 #[derive(Clone)]
 pub struct Proposal {
     pub proposer: Address,
+    pub description: String,
     pub amount: i128,
     pub recipient: Address,
+    pub approvals: u32,
+    pub rejections: u32,
+    pub status: TxStatus,
+    pub expires_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct QuorumChangeProposal {
+    pub proposer: Address,
+    pub new_quorum: u32,
     pub approvals: u32,
     pub rejections: u32,
     pub status: TxStatus,
@@ -34,6 +46,9 @@ pub enum DataKey {
     TxCounter,
     Proposal(u64),
     Voted(u64, Address),
+    QuorumCounter,
+    QuorumProposal(u64),
+    QuorumVoted(u64, Address),
 }
 
 #[contract]
@@ -52,10 +67,14 @@ impl MultisigContract {
         env.storage().instance().set(&DataKey::Approvers, &approvers);
         env.storage().instance().set(&DataKey::Quorum, &quorum);
         env.storage().instance().set(&DataKey::TxCounter, &0u64);
+        env.storage().instance().set(&DataKey::QuorumCounter, &0u64);
     }
 
     /// Propose a new transaction. Any approver may propose.
-    pub fn propose_transaction(env: Env, proposer: Address, amount: i128, recipient: Address) -> u64 {
+    ///
+    /// # Arguments
+    /// * `description` — Human-readable summary of the transaction so approvers know what they are voting on.
+    pub fn propose_transaction(env: Env, proposer: Address, description: String, amount: i128, recipient: Address) -> u64 {
         proposer.require_auth();
         Self::assert_is_approver(&env, &proposer);
         assert!(amount > 0, "amount must be positive");
@@ -65,6 +84,7 @@ impl MultisigContract {
 
         let proposal = Proposal {
             proposer,
+            description,
             amount,
             recipient,
             approvals: 0,
@@ -132,6 +152,75 @@ impl MultisigContract {
             .expect("proposal not found")
     }
 
+    /// Propose a quorum threshold change. Any approver may propose.
+    /// The change takes effect only when the current quorum of approvers approve it.
+    pub fn propose_quorum_change(env: Env, proposer: Address, new_quorum: u32) -> u64 {
+        proposer.require_auth();
+        Self::assert_is_approver(&env, &proposer);
+        let approvers: Vec<Address> = env.storage().instance().get(&DataKey::Approvers).unwrap();
+        assert!(new_quorum > 0 && new_quorum as usize <= approvers.len(), "invalid quorum");
+
+        let id: u64 = env.storage().instance().get(&DataKey::QuorumCounter).unwrap();
+        let expires_at = env.ledger().timestamp() + EXPIRY_SECONDS;
+
+        let proposal = QuorumChangeProposal {
+            proposer,
+            new_quorum,
+            approvals: 0,
+            rejections: 0,
+            status: TxStatus::Pending,
+            expires_at,
+        };
+        env.storage().persistent().set(&DataKey::QuorumProposal(id), &proposal);
+        env.storage().instance().set(&DataKey::QuorumCounter, &(id + 1));
+        id
+    }
+
+    /// Approve a pending quorum-change proposal. Updates quorum when threshold is reached.
+    pub fn approve_quorum_change(env: Env, approver: Address, id: u64) {
+        approver.require_auth();
+        Self::assert_is_approver(&env, &approver);
+
+        let mut proposal = Self::get_pending_quorum(&env, id);
+        assert!(!env.storage().persistent().has(&DataKey::QuorumVoted(id, approver.clone())), "already voted");
+
+        env.storage().persistent().set(&DataKey::QuorumVoted(id, approver), &true);
+        proposal.approvals += 1;
+
+        let quorum: u32 = env.storage().instance().get(&DataKey::Quorum).unwrap();
+        if proposal.approvals >= quorum {
+            proposal.status = TxStatus::Executed;
+            env.storage().instance().set(&DataKey::Quorum, &proposal.new_quorum);
+        }
+        env.storage().persistent().set(&DataKey::QuorumProposal(id), &proposal);
+    }
+
+    /// Reject a pending quorum-change proposal. Marks as rejected when quorum is no longer reachable.
+    pub fn reject_quorum_change(env: Env, approver: Address, id: u64) {
+        approver.require_auth();
+        Self::assert_is_approver(&env, &approver);
+
+        let mut proposal = Self::get_pending_quorum(&env, id);
+        assert!(!env.storage().persistent().has(&DataKey::QuorumVoted(id, approver.clone())), "already voted");
+
+        env.storage().persistent().set(&DataKey::QuorumVoted(id, approver), &true);
+        proposal.rejections += 1;
+
+        let approvers: Vec<Address> = env.storage().instance().get(&DataKey::Approvers).unwrap();
+        let quorum: u32 = env.storage().instance().get(&DataKey::Quorum).unwrap();
+        let remaining = approvers.len() as u32 - proposal.approvals - proposal.rejections;
+        if proposal.approvals + remaining < quorum {
+            proposal.status = TxStatus::Rejected;
+        }
+        env.storage().persistent().set(&DataKey::QuorumProposal(id), &proposal);
+    }
+
+    /// Read a quorum-change proposal.
+    pub fn get_quorum_proposal(env: Env, id: u64) -> QuorumChangeProposal {
+        env.storage().persistent().get(&DataKey::QuorumProposal(id))
+            .expect("quorum proposal not found")
+    }
+
     // --- helpers ---
 
     fn assert_is_approver(env: &Env, addr: &Address) {
@@ -142,6 +231,14 @@ impl MultisigContract {
     fn get_pending(env: &Env, tx_id: u64) -> Proposal {
         let proposal: Proposal = env.storage().persistent().get(&DataKey::Proposal(tx_id))
             .expect("proposal not found");
+        assert!(proposal.status == TxStatus::Pending, "not pending");
+        assert!(env.ledger().timestamp() < proposal.expires_at, "proposal expired");
+        proposal
+    }
+
+    fn get_pending_quorum(env: &Env, id: u64) -> QuorumChangeProposal {
+        let proposal: QuorumChangeProposal = env.storage().persistent().get(&DataKey::QuorumProposal(id))
+            .expect("quorum proposal not found");
         assert!(proposal.status == TxStatus::Pending, "not pending");
         assert!(env.ledger().timestamp() < proposal.expires_at, "proposal expired");
         proposal

--- a/contracts/multisig-approval/src/test.rs
+++ b/contracts/multisig-approval/src/test.rs
@@ -24,7 +24,8 @@ fn setup(quorum: u32, n_approvers: usize) -> (Env, Address, soroban_sdk::Vec<Add
 fn propose(env: &Env, contract_id: &Address, proposer: &Address) -> u64 {
     let client = MultisigContractClient::new(env, contract_id);
     let recipient = Address::generate(env);
-    client.propose_transaction(proposer, &1_000_000, &recipient)
+    let desc = soroban_sdk::String::from_str(env, "Test payment");
+    client.propose_transaction(proposer, &desc, &1_000_000, &recipient)
 }
 
 // ── initialization ────────────────────────────────────────────────────────────
@@ -97,7 +98,8 @@ fn test_propose_non_approver_panics() {
 fn test_propose_zero_amount_panics() {
     let (env, contract_id, approvers, _) = setup(2, 3);
     let client = MultisigContractClient::new(&env, &contract_id);
-    client.propose_transaction(&approvers.get(0).unwrap(), &0, &Address::generate(&env));
+    let desc = soroban_sdk::String::from_str(&env, "Zero amount");
+    client.propose_transaction(&approvers.get(0).unwrap(), &desc, &0, &Address::generate(&env));
 }
 
 // ── approve / quorum ──────────────────────────────────────────────────────────
@@ -282,11 +284,13 @@ fn test_proposal_fields_correct() {
     let client = MultisigContractClient::new(&env, &contract_id);
     let proposer = approvers.get(0).unwrap();
     let recipient = Address::generate(&env);
-    let tx_id = client.propose_transaction(&proposer, &500_000, &recipient);
+    let desc = soroban_sdk::String::from_str(&env, "Send funds to recipient");
+    let tx_id = client.propose_transaction(&proposer, &desc, &500_000, &recipient);
     let p = client.get_proposal(&tx_id);
     assert_eq!(p.amount, 500_000);
     assert_eq!(p.recipient, recipient);
     assert_eq!(p.proposer, proposer);
+    assert_eq!(p.description, desc);
     assert_eq!(p.approvals, 0);
     assert_eq!(p.rejections, 0);
     assert_eq!(p.status, TxStatus::Pending);
@@ -309,4 +313,162 @@ fn test_mixed_votes_pending_until_decided() {
     // third approval reaches quorum
     client.approve(&approvers.get(3).unwrap(), &tx_id);
     assert_eq!(client.get_proposal(&tx_id).status, TxStatus::Executed);
+}
+
+// ── quorum change ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_propose_quorum_change_increments_counter() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let id0 = client.propose_quorum_change(&proposer, &3);
+    let id1 = client.propose_quorum_change(&proposer, &1);
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+}
+
+#[test]
+fn test_get_quorum_proposal_fields_correct() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let id = client.propose_quorum_change(&proposer, &3);
+    let p = client.get_quorum_proposal(&id);
+    assert_eq!(p.new_quorum, 3);
+    assert_eq!(p.proposer, proposer);
+    assert_eq!(p.approvals, 0);
+    assert_eq!(p.rejections, 0);
+    assert_eq!(p.status, TxStatus::Pending);
+}
+
+#[test]
+#[should_panic(expected = "not an approver")]
+fn test_propose_quorum_change_non_approver_panics() {
+    let (env, contract_id, _, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    client.propose_quorum_change(&Address::generate(&env), &2);
+}
+
+#[test]
+#[should_panic(expected = "invalid quorum")]
+fn test_propose_quorum_change_zero_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    client.propose_quorum_change(&approvers.get(0).unwrap(), &0);
+}
+
+#[test]
+#[should_panic(expected = "invalid quorum")]
+fn test_propose_quorum_change_exceeds_approvers_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    // 3 approvers, requesting quorum of 4
+    client.propose_quorum_change(&approvers.get(0).unwrap(), &4);
+}
+
+#[test]
+fn test_approve_quorum_change_reaches_quorum_updates_quorum() {
+    // current quorum 2, 3 approvers. propose quorum → 3, need 2 approvals.
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+
+    client.approve_quorum_change(&approvers.get(0).unwrap(), &id);
+    assert_eq!(client.get_quorum_proposal(&id).status, TxStatus::Pending);
+
+    client.approve_quorum_change(&approvers.get(1).unwrap(), &id);
+    let p = client.get_quorum_proposal(&id);
+    assert_eq!(p.status, TxStatus::Executed);
+
+    // new quorum takes effect: a tx now needs 3 approvals
+    let tx_id = propose(&env, &contract_id, &approvers.get(0).unwrap());
+    client.approve(&approvers.get(0).unwrap(), &tx_id);
+    client.approve(&approvers.get(1).unwrap(), &tx_id);
+    assert_eq!(client.get_proposal(&tx_id).status, TxStatus::Pending);
+    client.approve(&approvers.get(2).unwrap(), &tx_id);
+    assert_eq!(client.get_proposal(&tx_id).status, TxStatus::Executed);
+}
+
+#[test]
+#[should_panic(expected = "already voted")]
+fn test_double_approve_quorum_change_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+    let approver = approvers.get(0).unwrap();
+    client.approve_quorum_change(&approver, &id);
+    client.approve_quorum_change(&approver, &id);
+}
+
+#[test]
+#[should_panic(expected = "not an approver")]
+fn test_approve_quorum_change_non_approver_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+    client.approve_quorum_change(&Address::generate(&env), &id);
+}
+
+#[test]
+fn test_reject_quorum_change_makes_quorum_impossible() {
+    // 3 approvers, quorum 2. 2 rejections → remaining 1 can't reach quorum of 2.
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &1);
+
+    client.reject_quorum_change(&approvers.get(0).unwrap(), &id);
+    assert_eq!(client.get_quorum_proposal(&id).status, TxStatus::Pending);
+
+    client.reject_quorum_change(&approvers.get(1).unwrap(), &id);
+    assert_eq!(client.get_quorum_proposal(&id).status, TxStatus::Rejected);
+}
+
+#[test]
+#[should_panic(expected = "already voted")]
+fn test_double_reject_quorum_change_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+    let approver = approvers.get(0).unwrap();
+    client.reject_quorum_change(&approver, &id);
+    client.reject_quorum_change(&approver, &id);
+}
+
+#[test]
+#[should_panic(expected = "already voted")]
+fn test_approve_then_reject_quorum_change_same_voter_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+    let approver = approvers.get(0).unwrap();
+    client.approve_quorum_change(&approver, &id);
+    client.reject_quorum_change(&approver, &id);
+}
+
+#[test]
+#[should_panic(expected = "quorum proposal not found")]
+fn test_get_nonexistent_quorum_proposal_panics() {
+    let (env, contract_id, _, _) = setup(2, 3);
+    MultisigContractClient::new(&env, &contract_id).get_quorum_proposal(&99);
+}
+
+#[test]
+#[should_panic(expected = "proposal expired")]
+fn test_approve_quorum_change_after_expiry_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.approve_quorum_change(&approvers.get(0).unwrap(), &id);
+}
+
+#[test]
+#[should_panic(expected = "proposal expired")]
+fn test_reject_quorum_change_after_expiry_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let id = client.propose_quorum_change(&approvers.get(0).unwrap(), &3);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.reject_quorum_change(&approvers.get(0).unwrap(), &id);
 }


### PR DESCRIPTION
#422 fix: transaction state_history is stored in every record but never exposed via any contract API
Repo Avatar
[abore9769/SorobanAnchor](https://github.com/abore9769/SorobanAnchor)
Severity: Low
Location
src/contract.rs:4884–4886 (create_txn_record_with_reason / create_transaction_record_internal)

Problem
The TransactionStateRecord struct contains a state_history: Vec<(TransactionState, u64)> field. The create_transaction_record_internal function initializes it with the initial state entry. This vector is stored in persistent storage for every transaction record.

However, there is no contract function to retrieve state_history. The data occupies ledger storage but is completely inaccessible to callers.

Impact
Wasted storage (each record includes history that can't be read)
State transitions appended during update_transaction_state (if any) are unreadable

closes #545 closes #546 closes #555 closes #553