### PR TITLE
feat: scheduled calendar, login rate-limit, password strength, escrow partial release

### DIFF
--- a/backend/src/controllers/agentEscrowController.js
+++ b/backend/src/controllers/agentEscrowController.js
@@ -169,6 +169,78 @@ async function cancel(req, res, next) {
 }
 
 /**
+ * POST /api/contracts/escrow/:id/partial-release
+ * Body: { amount }
+ *
+ * Sender releases part of a pending escrow to the agent (issue #657).
+ * Validates the amount against the remaining balance, applies the platform fee,
+ * records the cumulative released amount, and returns the new remaining balance.
+ */
+async function partialRelease(req, res, next) {
+  try {
+    const { id } = req.params;
+    const amount = parseFloat(req.body.amount);
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return res.status(400).json({ error: "Amount must be greater than 0" });
+    }
+
+    const escrowResult = await db.query("SELECT * FROM agent_escrows WHERE id = $1", [id]);
+    if (!escrowResult.rows[0]) {
+      return res.status(404).json({ error: "Escrow not found" });
+    }
+    const escrow = escrowResult.rows[0];
+
+    if (escrow.status !== "pending") {
+      return res.status(400).json({ error: "Only pending escrows can be partially released" });
+    }
+    if (escrow.sender_wallet !== req.user.walletAddress) {
+      return res.status(403).json({ error: "Only the sender can release this escrow" });
+    }
+
+    const total = parseFloat(escrow.amount);
+    const alreadyReleased = parseFloat(escrow.released_amount || 0);
+    const remaining = total - alreadyReleased;
+
+    if (amount > remaining + 1e-7) {
+      return res.status(400).json({
+        error: `Amount exceeds remaining escrow balance (${remaining})`,
+      });
+    }
+
+    const feeBps = escrow.fee_bps || DEFAULT_FEE_BPS;
+    const feeAmount = (amount * feeBps) / 10000;
+    const netToAgent = amount - feeAmount;
+
+    const newReleased = alreadyReleased + amount;
+    const newRemaining = total - newReleased;
+    // Fully drained escrows transition to completed.
+    const fullyReleased = newRemaining <= 1e-7;
+
+    const updated = await db.query(
+      `UPDATE agent_escrows
+         SET released_amount = $1,
+             status = CASE WHEN $2 THEN 'completed' ELSE status END
+       WHERE id = $3
+       RETURNING *`,
+      [newReleased, fullyReleased, id]
+    );
+
+    res.json({
+      message: "Partial release successful",
+      escrow: updated.rows[0],
+      released: amount,
+      fee: feeAmount,
+      net_to_agent: netToAgent,
+      remaining_balance: newRemaining,
+      status: updated.rows[0].status,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
  * GET /api/escrow/:id
  */
 async function getEscrow(req, res, next) {
@@ -186,4 +258,4 @@ async function getEscrow(req, res, next) {
   }
 }
 
-module.exports = { create, confirm, cancel, getEscrow };
+module.exports = { create, confirm, cancel, getEscrow, partialRelease };

--- a/backend/src/routes/contracts.js
+++ b/backend/src/routes/contracts.js
@@ -4,7 +4,16 @@
  */
 
 const router = require('express').Router();
+const { body, param, validationResult } = require('express-validator');
 const { getContractEvents } = require('../jobs/contractEventIndexer');
+const authMiddleware = require('../middleware/auth');
+const { partialRelease } = require('../controllers/agentEscrowController');
+
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  next();
+};
 
 /**
  * GET /api/contracts/:contractId/events
@@ -51,5 +60,20 @@ async function getContractEventsHandler(req, res, next) {
 }
 
 router.get('/:contractId/events', getContractEventsHandler);
+
+/**
+ * POST /api/contracts/escrow/:id/partial-release
+ * Releases part of a pending agent escrow to the agent (issue #657).
+ */
+router.post(
+  '/escrow/:id/partial-release',
+  authMiddleware,
+  [
+    param('id').isUUID().withMessage('Invalid escrow ID'),
+    body('amount').isFloat({ gt: 0 }).withMessage('Amount must be greater than 0'),
+  ],
+  validate,
+  partialRelease
+);
 
 module.exports = router;

--- a/database/migrations/025_add_released_amount_to_agent_escrows.js
+++ b/database/migrations/025_add_released_amount_to_agent_escrows.js
@@ -1,0 +1,17 @@
+/**
+ * Migration: 025_add_released_amount_to_agent_escrows
+ *
+ * Adds a released_amount column to support partial releases (issue #657).
+ * Tracks the cumulative amount released so the remaining escrow balance can be
+ * derived as (amount - released_amount).
+ */
+
+exports.up = (pgm) => {
+  pgm.addColumn("agent_escrows", {
+    released_amount: { type: "numeric(20,7)", notNull: true, default: 0 },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn("agent_escrows", "released_amount");
+};

--- a/frontend/src/components/ScheduledPaymentsCalendar.jsx
+++ b/frontend/src/components/ScheduledPaymentsCalendar.jsx
@@ -1,0 +1,217 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+// Local-date key (avoids UTC off-by-one from toISOString()).
+const dayKey = (date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+const startOfDay = (date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+function advance(date, frequency) {
+  const d = new Date(date);
+  if (frequency === 'daily') d.setDate(d.getDate() + 1);
+  else if (frequency === 'weekly') d.setDate(d.getDate() + 7);
+  else d.setMonth(d.getMonth() + 1); // monthly (default)
+  return d;
+}
+
+/**
+ * Project each scheduled payment forward over the [rangeStart, rangeEnd] window
+ * from its next run date + interval. Returns a map of dayKey -> [payments].
+ */
+function projectOccurrences(payments, rangeStart, rangeEnd) {
+  const map = {};
+  payments
+    .filter((p) => p.active !== false)
+    .forEach((p) => {
+      const base = new Date(p.next_run_at || p.next_payment_at);
+      if (Number.isNaN(base.getTime())) return;
+      const frequency = p.frequency || p.interval || 'monthly';
+
+      let cursor = startOfDay(base);
+      let guard = 0;
+      // Skip occurrences before the visible window.
+      while (cursor < rangeStart && guard < 2000) {
+        cursor = advance(cursor, frequency);
+        guard += 1;
+      }
+      // Collect occurrences inside the window.
+      while (cursor <= rangeEnd && guard < 2000) {
+        const key = dayKey(cursor);
+        (map[key] = map[key] || []).push(p);
+        cursor = advance(cursor, frequency);
+        guard += 1;
+      }
+    });
+  return map;
+}
+
+function buildMonthCells(year, month) {
+  const startDow = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells = [];
+  for (let i = 0; i < startDow; i += 1) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d += 1) cells.push(new Date(year, month, d));
+  while (cells.length % 7 !== 0) cells.push(null);
+  return cells;
+}
+
+function buildWeekCells(anchor) {
+  const start = new Date(anchor);
+  start.setDate(start.getDate() - start.getDay()); // back to Sunday
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    return d;
+  });
+}
+
+function DayDots({ count }) {
+  if (!count) return null;
+  const dots = Math.min(count, 3);
+  return (
+    <div className="mt-1 flex items-center justify-center gap-0.5">
+      {Array.from({ length: dots }).map((_, i) => (
+        <span key={i} className="w-1.5 h-1.5 rounded-full bg-primary-500" />
+      ))}
+      {count > 3 && <span className="text-[9px] text-primary-400 ml-0.5">+{count - 3} more</span>}
+    </div>
+  );
+}
+
+export default function ScheduledPaymentsCalendar({ payments }) {
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const [viewDate, setViewDate] = useState(today); // anchor for month (desktop)
+  const [weekAnchor, setWeekAnchor] = useState(today); // anchor for week strip (mobile)
+  const [selectedKey, setSelectedKey] = useState(null);
+
+  // Payments are projected forward 3 months from today (issue #654).
+  const occurrences = useMemo(() => {
+    const rangeEnd = new Date(today);
+    rangeEnd.setMonth(rangeEnd.getMonth() + 3);
+    return projectOccurrences(payments, today, rangeEnd);
+  }, [payments, today]);
+
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const monthCells = useMemo(() => buildMonthCells(year, month), [year, month]);
+  const weekCells = useMemo(() => buildWeekCells(weekAnchor), [weekAnchor]);
+
+  const goMonth = (delta) => {
+    setSelectedKey(null);
+    setViewDate(new Date(year, month + delta, 1));
+  };
+  const goWeek = (delta) => {
+    setSelectedKey(null);
+    const next = new Date(weekAnchor);
+    next.setDate(next.getDate() + delta * 7);
+    setWeekAnchor(next);
+  };
+
+  const selectedPayments = selectedKey ? occurrences[selectedKey] || [] : [];
+
+  const renderDayCell = (date, { compact = false } = {}) => {
+    if (!date) return <div className="aspect-square" />;
+    const key = dayKey(date);
+    const list = occurrences[key] || [];
+    const hasPayments = list.length > 0;
+    const isToday = key === dayKey(today);
+    const isSelected = key === selectedKey;
+
+    return (
+      <button
+        type="button"
+        disabled={!hasPayments}
+        onClick={() => setSelectedKey(isSelected ? null : key)}
+        className={`relative flex flex-col items-center justify-start rounded-lg p-1 text-xs transition-colors
+          ${compact ? 'min-w-[44px] h-16' : 'aspect-square'}
+          ${hasPayments ? 'cursor-pointer hover:bg-gray-800' : 'cursor-default'}
+          ${isSelected ? 'ring-2 ring-primary-500 bg-gray-800' : ''}
+          ${isToday ? 'text-primary-400 font-bold' : 'text-gray-300'}`}
+        aria-label={`${MONTHS[date.getMonth()]} ${date.getDate()}${hasPayments ? `, ${list.length} payment(s)` : ''}`}
+      >
+        <span className="mt-1">{date.getDate()}</span>
+        <DayDots count={list.length} />
+      </button>
+    );
+  };
+
+  return (
+    <div className="bg-gray-900 rounded-xl p-3 sm:p-4">
+      {/* ── Desktop: month navigation ── */}
+      <div className="hidden sm:flex items-center justify-between mb-3">
+        <button type="button" onClick={() => goMonth(-1)} className="p-1.5 rounded-lg hover:bg-gray-800 text-gray-400" aria-label="Previous month">
+          <ChevronLeft size={18} />
+        </button>
+        <h3 className="text-white font-semibold">{MONTHS[month]} {year}</h3>
+        <button type="button" onClick={() => goMonth(1)} className="p-1.5 rounded-lg hover:bg-gray-800 text-gray-400" aria-label="Next month">
+          <ChevronRight size={18} />
+        </button>
+      </div>
+
+      {/* ── Mobile: week navigation ── */}
+      <div className="flex sm:hidden items-center justify-between mb-3">
+        <button type="button" onClick={() => goWeek(-1)} className="p-1.5 rounded-lg hover:bg-gray-800 text-gray-400" aria-label="Previous week">
+          <ChevronLeft size={18} />
+        </button>
+        <h3 className="text-white font-semibold text-sm">
+          {MONTHS[weekCells[0].getMonth()]} {weekCells[0].getDate()} – {weekCells[6].getDate()}
+        </h3>
+        <button type="button" onClick={() => goWeek(1)} className="p-1.5 rounded-lg hover:bg-gray-800 text-gray-400" aria-label="Next week">
+          <ChevronRight size={18} />
+        </button>
+      </div>
+
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {WEEKDAYS.map((wd) => (
+          <div key={wd} className="text-center text-[10px] font-medium text-gray-500">{wd}</div>
+        ))}
+      </div>
+
+      {/* ── Desktop: full month grid ── */}
+      <div className="hidden sm:grid grid-cols-7 gap-1">
+        {monthCells.map((date, i) => (
+          <React.Fragment key={i}>{renderDayCell(date)}</React.Fragment>
+        ))}
+      </div>
+
+      {/* ── Mobile: condensed week-row strip ── */}
+      <div className="grid sm:hidden grid-cols-7 gap-1">
+        {weekCells.map((date, i) => (
+          <React.Fragment key={i}>{renderDayCell(date, { compact: true })}</React.Fragment>
+        ))}
+      </div>
+
+      {/* Popover: payments due on the selected day */}
+      {selectedKey && selectedPayments.length > 0 && (
+        <div className="mt-3 border border-gray-700 rounded-xl bg-gray-800 p-3">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-semibold text-white">
+              {new Date(`${selectedKey}T00:00:00`).toLocaleDateString(undefined, {
+                weekday: 'long', month: 'long', day: 'numeric',
+              })}
+            </p>
+            <button type="button" onClick={() => setSelectedKey(null)} className="text-gray-400 hover:text-white" aria-label="Close">
+              <X size={16} />
+            </button>
+          </div>
+          <div className="space-y-2">
+            {selectedPayments.map((p, i) => (
+              <div key={`${p.id}-${i}`} className="flex items-center justify-between text-sm">
+                <span className="font-mono text-gray-400 text-xs">{p.recipient_wallet.slice(0, 14)}…</span>
+                <span className="text-white font-medium">{p.amount} {p.asset}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Escrow.jsx
+++ b/frontend/src/pages/Escrow.jsx
@@ -20,6 +20,26 @@ export default function Escrow() {
   // Confirm/Cancel escrow
   const [selectedEscrow, setSelectedEscrow] = useState(null);
 
+  // Partial release modal (issue #657)
+  const [partialEscrow, setPartialEscrow] = useState(null);
+  const [partialAmount, setPartialAmount] = useState('');
+  const [partialLoading, setPartialLoading] = useState(false);
+
+  const FEE_BPS = 250; // platform fee fallback (2.5%)
+
+  const remainingBalance = (escrow) =>
+    parseFloat(escrow.amount) - parseFloat(escrow.released_amount || 0);
+
+  const openPartialRelease = (escrow) => {
+    setPartialEscrow(escrow);
+    setPartialAmount(String(remainingBalance(escrow)));
+  };
+
+  const closePartialRelease = () => {
+    setPartialEscrow(null);
+    setPartialAmount('');
+  };
+
   useEffect(() => {
     if (activeTab === 'list') {
       fetchEscrows();
@@ -88,6 +108,52 @@ export default function Escrow() {
       setLoading(false);
     }
   };
+
+  const handlePartialRelease = async (e) => {
+    e.preventDefault();
+    if (!partialEscrow) return;
+
+    const amount = parseFloat(partialAmount);
+    const remaining = remainingBalance(partialEscrow);
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      toast.error('Enter an amount greater than 0');
+      return;
+    }
+    if (amount > remaining) {
+      toast.error('Amount cannot exceed the escrowed balance');
+      return;
+    }
+
+    setPartialLoading(true);
+    try {
+      const { data } = await api.post(`/contracts/escrow/${partialEscrow.id}/partial-release`, {
+        amount,
+      });
+      toast.success('Partial release successful');
+      // Update the affected row in place without a full reload.
+      setEscrows((prev) =>
+        prev.map((esc) =>
+          esc.id === partialEscrow.id ? { ...esc, ...(data.escrow || {}) } : esc
+        )
+      );
+      closePartialRelease();
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Failed to release escrow');
+    } finally {
+      setPartialLoading(false);
+    }
+  };
+
+  const previewAmount = parseFloat(partialAmount) || 0;
+  const previewFee = (previewAmount * FEE_BPS) / 10000;
+  const previewNet = previewAmount - previewFee;
+  const partialError =
+    partialEscrow && previewAmount > 0 && previewAmount > remainingBalance(partialEscrow)
+      ? 'Amount cannot exceed the escrowed balance'
+      : partialEscrow && partialAmount !== '' && previewAmount <= 0
+      ? 'Amount must be greater than 0'
+      : '';
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 p-4 md:p-6">
@@ -207,6 +273,11 @@ export default function Escrow() {
                       <p className="font-medium text-gray-900 dark:text-white">
                         {escrow.amount} {escrow.asset}
                       </p>
+                      {parseFloat(escrow.released_amount || 0) > 0 && (
+                        <p className="text-sm text-blue-600 dark:text-blue-400">
+                          Remaining: {remainingBalance(escrow)} {escrow.asset}
+                        </p>
+                      )}
                       <p className="text-sm text-gray-500 dark:text-gray-400">
                         Status: <span className="font-medium capitalize">{escrow.status}</span>
                       </p>
@@ -235,16 +306,26 @@ export default function Escrow() {
                       </p>
 
                       {escrow.status === 'pending' && (
-                        <div className="flex gap-2 mt-4">
+                        <div className="flex flex-wrap gap-2 mt-4">
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
                               handleConfirmEscrow(escrow.id);
                             }}
                             disabled={loading}
-                            className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
+                            className="flex-1 min-w-[120px] bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
                           >
-                            Confirm
+                            Full Release
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openPartialRelease(escrow);
+                            }}
+                            disabled={loading}
+                            className="flex-1 min-w-[120px] bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
+                          >
+                            Partial Release
                           </button>
                           <button
                             onClick={(e) => {
@@ -252,7 +333,7 @@ export default function Escrow() {
                               handleCancelEscrow(escrow.id);
                             }}
                             disabled={loading}
-                            className="flex-1 bg-red-600 hover:bg-red-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
+                            className="flex-1 min-w-[120px] bg-red-600 hover:bg-red-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
                           >
                             Cancel
                           </button>
@@ -266,6 +347,72 @@ export default function Escrow() {
           </div>
         )}
       </div>
+
+      {/* Partial Release Modal (issue #657) */}
+      {partialEscrow && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+          <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 w-full max-w-sm">
+            <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-1">Partial Release</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              Escrowed balance: {remainingBalance(partialEscrow)} {partialEscrow.asset}
+            </p>
+
+            <form onSubmit={handlePartialRelease} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Amount to release
+                </label>
+                <input
+                  type="number"
+                  step="0.0000001"
+                  min="0"
+                  max={remainingBalance(partialEscrow)}
+                  value={partialAmount}
+                  onChange={(e) => setPartialAmount(e.target.value)}
+                  autoFocus
+                  className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none ${
+                    partialError ? 'border-red-500' : 'border-gray-300 dark:border-gray-700'
+                  }`}
+                />
+                {partialError && <p className="text-xs text-red-500 mt-1">{partialError}</p>}
+              </div>
+
+              {/* Preview */}
+              <div className="rounded-lg bg-gray-50 dark:bg-gray-800 p-3 space-y-1 text-sm">
+                <div className="flex justify-between text-gray-600 dark:text-gray-400">
+                  <span>Amount to release</span>
+                  <span className="text-gray-900 dark:text-white">{previewAmount.toFixed(7)} {partialEscrow.asset}</span>
+                </div>
+                <div className="flex justify-between text-gray-600 dark:text-gray-400">
+                  <span>Platform fee ({(FEE_BPS / 100).toFixed(2)}%)</span>
+                  <span className="text-red-500">-{previewFee.toFixed(7)} {partialEscrow.asset}</span>
+                </div>
+                <div className="flex justify-between font-medium border-t border-gray-200 dark:border-gray-700 pt-1 mt-1">
+                  <span className="text-gray-700 dark:text-gray-300">Net to agent</span>
+                  <span className="text-green-600 dark:text-green-400">{previewNet.toFixed(7)} {partialEscrow.asset}</span>
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={closePartialRelease}
+                  className="flex-1 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-white font-medium py-2 rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={partialLoading || !!partialError || previewAmount <= 0}
+                  className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
+                >
+                  {partialLoading ? 'Releasing…' : 'Confirm Release'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -17,6 +17,15 @@ export default function Login() {
     return localStorage.getItem('afripay_remember_me') === 'true';
   });
 
+  // Rate-limit cooldown (issue #655) — persisted across refreshes via sessionStorage
+  const COOLDOWN_KEY = 'afripay_login_cooldown_until';
+  const DEFAULT_COOLDOWN_SECONDS = 60;
+  const [secondsLeft, setSecondsLeft] = useState(() => {
+    const until = parseInt(sessionStorage.getItem(COOLDOWN_KEY) || '0', 10);
+    const remaining = Math.ceil((until - Date.now()) / 1000);
+    return remaining > 0 ? remaining : 0;
+  });
+
   // 2FA TOTP step
   const [requires2fa, setRequires2fa] = useState(false);
   const [totp, setTotp] = useState('');
@@ -28,6 +37,28 @@ export default function Login() {
       totpInputRef.current.focus();
     }
   }, [requires2fa]);
+
+  // Tick the cooldown down every second; re-enable the button automatically at 0.
+  useEffect(() => {
+    if (secondsLeft <= 0) return undefined;
+    const timer = setInterval(() => {
+      const until = parseInt(sessionStorage.getItem(COOLDOWN_KEY) || '0', 10);
+      const remaining = Math.ceil((until - Date.now()) / 1000);
+      if (remaining <= 0) {
+        sessionStorage.removeItem(COOLDOWN_KEY);
+        setSecondsLeft(0);
+      } else {
+        setSecondsLeft(remaining);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [secondsLeft]);
+
+  const startCooldown = (seconds) => {
+    const until = Date.now() + seconds * 1000;
+    sessionStorage.setItem(COOLDOWN_KEY, String(until));
+    setSecondsLeft(seconds);
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -42,6 +73,10 @@ export default function Login() {
       if (err.response?.status === 403 && data?.requires_2fa) {
         // Backend signals that a TOTP code is required — switch to TOTP step
         setRequires2fa(true);
+      } else if (err.response?.status === 429) {
+        // Rate limit exceeded (issue #655) — start a countdown from Retry-After.
+        const retryAfter = parseInt(err.response.headers?.['retry-after'], 10);
+        startCooldown(Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : DEFAULT_COOLDOWN_SECONDS);
       } else {
         toast.error(data?.error || t('login.error'));
       }
@@ -187,12 +222,29 @@ export default function Login() {
                 </Link>
               </div>
 
+              {secondsLeft > 0 && (
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  className="flex items-start gap-2 rounded-xl border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 px-4 py-3 text-sm text-red-600 dark:text-red-400"
+                >
+                  <ShieldCheck size={16} className="mt-0.5 flex-shrink-0" />
+                  <span>
+                    {t('login.rate_limited', 'Too many login attempts.')} Please wait {secondsLeft}s before trying again.
+                  </span>
+                </div>
+              )}
+
               <button
                 type="submit"
-                disabled={loading}
-                className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold py-3.5 rounded-xl transition-colors mt-2"
+                disabled={loading || secondsLeft > 0}
+                className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-3.5 rounded-xl transition-colors mt-2"
               >
-                {loading ? t('login.submitting') : t('login.submit')}
+                {secondsLeft > 0
+                  ? `${t('login.try_again_in', 'Try again in')} ${secondsLeft}s`
+                  : loading
+                  ? t('login.submitting')
+                  : t('login.submit')}
               </button>
             </form>
 

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -2,10 +2,9 @@ import React, { useState, useMemo } from 'react';
 import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import toast from 'react-hot-toast';
-import { Eye, EyeOff, ArrowLeft, ChevronDown, ChevronUp, Check, X, Phone } from 'lucide-react';
-import { Eye, EyeOff, ArrowLeft, ChevronDown, ChevronUp, Check, X, AlertCircle } from 'lucide-react';
+import { Eye, EyeOff, ArrowLeft, ChevronDown, ChevronUp, Check, X, AlertCircle, Phone } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { getPasswordStrength, validateEmail, getEmailError, getPasswordError } from '../utils/passwordValidator';
+import { getRegisterPasswordStrength, getEmailError } from '../utils/passwordValidator';
 
 export default function Register() {
   const { register } = useAuth();
@@ -13,6 +12,7 @@ export default function Register() {
   const [searchParams] = useSearchParams();
   const { t } = useTranslation();
   const [form, setForm] = useState({ full_name: '', email: '', password: '', phone: '' });
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [showPass, setShowPass] = useState(false);
   const [loading, setLoading] = useState(false);
   const [showPINSetup, setShowPINSetup] = useState(false);
@@ -28,9 +28,18 @@ export default function Register() {
   const [phoneVerifyLoading, setPhoneVerifyLoading] = useState(false);
   const [registeredPhone, setRegisteredPhone] = useState('');
 
-  const strength = useMemo(() => getPasswordStrength(form.password), [form.password]);
+  // Password strength indicator (issue #656)
+  const strength = useMemo(() => getRegisterPasswordStrength(form.password), [form.password]);
   const emailError = touched.email ? getEmailError(form.email) : '';
-  const passwordError = touched.password ? getPasswordError(form.password) : '';
+  const passwordsMatch = confirmPassword.length > 0 && confirmPassword === form.password;
+  const passwordsMismatch = confirmPassword.length > 0 && confirmPassword !== form.password;
+
+  const checklist = [
+    { key: 'length', label: 'At least 8 characters' },
+    { key: 'uppercase', label: 'One uppercase letter' },
+    { key: 'number', label: 'One number' },
+    { key: 'special', label: 'One special character' },
+  ];
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -43,12 +52,16 @@ export default function Register() {
       toast.error('Full name is required');
       return;
     }
-    if (emailError) {
-      toast.error(emailError);
+    if (getEmailError(form.email)) {
+      toast.error(getEmailError(form.email));
       return;
     }
-    if (passwordError) {
-      toast.error(passwordError);
+    if (!strength.isAcceptable) {
+      toast.error('Please choose a stronger password (at least "Fair").');
+      return;
+    }
+    if (confirmPassword !== form.password) {
+      toast.error('Passwords do not match');
       return;
     }
 
@@ -88,7 +101,6 @@ export default function Register() {
     setPhoneVerifyLoading(true);
     try {
       // Note: This requires authentication, so user needs to login first
-      // For now, we'll navigate to login and show a message
       toast.success('Account created. Please log in to verify your phone number.');
       navigate('/login');
     } catch (err) {
@@ -97,6 +109,9 @@ export default function Register() {
       setPhoneVerifyLoading(false);
     }
   };
+
+  const submitDisabled =
+    loading || !form.full_name.trim() || !!emailError || !strength.isAcceptable || passwordsMismatch;
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col px-6 py-8 transition-colors duration-200">
@@ -124,7 +139,6 @@ export default function Register() {
               placeholder="[Full Name]"
               value={form.full_name}
               onChange={(e) => setForm({ ...form, full_name: e.target.value })}
-              onChange={e => setForm({ ...form, full_name: e.target.value })}
               onBlur={() => setTouched({ ...touched, full_name: true })}
               className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors shadow-sm"
             />
@@ -134,6 +148,7 @@ export default function Register() {
               </p>
             )}
           </div>
+
           <div>
             <label className="text-sm text-gray-600 dark:text-gray-400 mb-1 block">
               {t('register.email')}
@@ -144,8 +159,6 @@ export default function Register() {
               placeholder="[email]"
               value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })}
-              className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors shadow-sm"
-              onChange={e => setForm({ ...form, email: e.target.value })}
               onBlur={() => setTouched({ ...touched, email: true })}
               className={`w-full bg-white dark:bg-gray-800 border rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors shadow-sm ${
                 emailError ? 'border-red-500 dark:border-red-500' : 'border-gray-200 dark:border-gray-700'
@@ -157,6 +170,7 @@ export default function Register() {
               </p>
             )}
           </div>
+
           <div>
             <label className="text-sm text-gray-600 dark:text-gray-400 mb-1 block">
               {t('register.phone')}
@@ -169,6 +183,7 @@ export default function Register() {
               className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors shadow-sm"
             />
           </div>
+
           <div>
             <label className="text-sm text-gray-600 dark:text-gray-400 mb-1 block">
               {t('register.password')}
@@ -181,12 +196,8 @@ export default function Register() {
                 placeholder={t('register.password_placeholder')}
                 value={form.password}
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
-                className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors pr-12 shadow-sm"
-                onChange={e => setForm({ ...form, password: e.target.value })}
                 onBlur={() => setTouched({ ...touched, password: true })}
-                className={`w-full bg-white dark:bg-gray-800 border rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors pr-12 shadow-sm ${
-                  passwordError ? 'border-red-500 dark:border-red-500' : 'border-gray-200 dark:border-gray-700'
-                }`}
+                className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors pr-12 shadow-sm"
               />
               <button
                 type="button"
@@ -196,37 +207,30 @@ export default function Register() {
                 {showPass ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>
             </div>
-            {passwordError && (
-              <p className="text-xs text-red-500 mt-1 flex items-center gap-1">
-                <AlertCircle size={12} /> {passwordError}
-              </p>
-            )}
+
+            {/* Strength indicator (issue #656) — hidden when password is empty */}
             {form.password && (
-              <div className="mt-2 space-y-2">
+              <div className="mt-2 space-y-2" aria-live="polite">
                 <div className="flex gap-1">
                   {[1, 2, 3, 4].map((i) => (
                     <div
                       key={i}
-                      className={`h-1 flex-1 rounded-full transition-colors ${i <= strength.score ? strength.barColor : 'bg-gray-200 dark:bg-gray-700'}`}
+                      className={`h-1.5 flex-1 rounded-full transition-colors ${
+                        i <= strength.score ? strength.barColor : 'bg-gray-200 dark:bg-gray-700'
+                      }`}
                     />
-                  {[1, 2, 3, 4, 5].map(i => (
-                    <div key={i} className={`h-1 flex-1 rounded-full transition-colors ${i <= strength.score ? strength.barColor : 'bg-gray-200 dark:bg-gray-700'}`} />
                   ))}
                 </div>
-                <p className={`text-xs font-medium capitalize ${strength.textColor}`}>
+                <p className={`text-xs font-medium ${strength.textColor}`}>
                   {strength.label}
                 </p>
-                <ul className="space-y-1">
-                  {[
-                    { key: 'length', label: 'At least 8 characters' },
-                    { key: 'uppercase', label: 'One uppercase letter' },
-                    { key: 'lowercase', label: 'One lowercase letter' },
-                    { key: 'number', label: 'One number' },
-                    { key: 'special', label: 'One special character' },
-                  ].map(({ key, label }) => (
+                <ul className="grid grid-cols-2 gap-x-3 gap-y-1">
+                  {checklist.map(({ key, label }) => (
                     <li
                       key={key}
-                      className={`flex items-center gap-1.5 text-xs ${strength.checks[key] ? 'text-green-500' : 'text-gray-400 dark:text-gray-500'}`}
+                      className={`flex items-center gap-1.5 text-xs ${
+                        strength.checks[key] ? 'text-green-500' : 'text-gray-400 dark:text-gray-500'
+                      }`}
                     >
                       {strength.checks[key] ? <Check size={12} /> : <X size={12} />} {label}
                     </li>
@@ -236,10 +240,40 @@ export default function Register() {
             )}
           </div>
 
+          {/* Confirm password (issue #656) */}
+          <div>
+            <label className="text-sm text-gray-600 dark:text-gray-400 mb-1 block">
+              Confirm password
+            </label>
+            <div className="relative">
+              <input
+                type={showPass ? 'text' : 'password'}
+                placeholder="Re-enter your password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className={`w-full bg-white dark:bg-gray-800 border rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors pr-12 shadow-sm ${
+                  passwordsMismatch
+                    ? 'border-red-500 dark:border-red-500'
+                    : passwordsMatch
+                    ? 'border-green-500 dark:border-green-500'
+                    : 'border-gray-200 dark:border-gray-700'
+                }`}
+              />
+              {passwordsMatch && (
+                <Check size={18} className="absolute right-3 top-1/2 -translate-y-1/2 text-green-500" />
+              )}
+            </div>
+            {passwordsMismatch && (
+              <p className="text-xs text-red-500 mt-1 flex items-center gap-1">
+                <AlertCircle size={12} /> Passwords do not match
+              </p>
+            )}
+          </div>
+
           <button
             type="submit"
-            disabled={loading || !form.full_name.trim() || emailError || passwordError}
-            className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold py-3.5 rounded-xl transition-colors mt-2"
+            disabled={submitDisabled}
+            className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-3.5 rounded-xl transition-colors mt-2"
           >
             {loading ? t('register.submitting') : t('register.submit')}
           </button>

--- a/frontend/src/pages/ScheduledPayments.jsx
+++ b/frontend/src/pages/ScheduledPayments.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Plus, Trash2, Edit2 } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, Edit2, List, Calendar } from 'lucide-react';
 import api from '../utils/api';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { CURRENCIES } from '../utils/currency';
+import ScheduledPaymentsCalendar from '../components/ScheduledPaymentsCalendar';
 
 export default function ScheduledPayments() {
   const navigate = useNavigate();
@@ -12,6 +13,7 @@ export default function ScheduledPayments() {
   const [payments, setPayments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
+  const [view, setView] = useState('list'); // 'list' | 'calendar'
   const [form, setForm] = useState({
     recipient_wallet: '',
     amount: '',
@@ -160,7 +162,29 @@ export default function ScheduledPayments() {
         </form>
       )}
 
-      {payments.length === 0 ? (
+      {/* View toggle: List ↔ Calendar (issue #654) */}
+      <div className="flex items-center gap-1 bg-gray-900 rounded-lg p-1 mb-4 w-fit">
+        <button
+          onClick={() => setView('list')}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            view === 'list' ? 'bg-primary-500 text-white' : 'text-gray-400 hover:text-white'
+          }`}
+        >
+          <List size={15} /> {t('scheduled.list_view') || 'List View'}
+        </button>
+        <button
+          onClick={() => setView('calendar')}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            view === 'calendar' ? 'bg-primary-500 text-white' : 'text-gray-400 hover:text-white'
+          }`}
+        >
+          <Calendar size={15} /> {t('scheduled.calendar_view') || 'Calendar View'}
+        </button>
+      </div>
+
+      {view === 'calendar' ? (
+        <ScheduledPaymentsCalendar payments={payments} />
+      ) : payments.length === 0 ? (
         <p className="text-gray-400 text-center py-8">{t('scheduled.none') || 'No scheduled payments'}</p>
       ) : (
         <div className="space-y-3">

--- a/frontend/src/utils/__tests__/passwordValidator.test.js
+++ b/frontend/src/utils/__tests__/passwordValidator.test.js
@@ -1,0 +1,96 @@
+import { getRegisterPasswordStrength } from '../passwordValidator';
+
+describe('getRegisterPasswordStrength (issue #656)', () => {
+  it('scores an empty password as 0 with no label', () => {
+    const s = getRegisterPasswordStrength('');
+    expect(s.score).toBe(0);
+    expect(s.label).toBe('');
+  });
+
+  describe('Weak (score 1)', () => {
+    it('is weak when shorter than 8 characters', () => {
+      const s = getRegisterPasswordStrength('Ab1!');
+      expect(s.score).toBe(1);
+      expect(s.label).toBe('Weak');
+      expect(s.barColor).toBe('bg-red-500');
+    });
+
+    it('is weak when 8+ chars but only one character class', () => {
+      const s = getRegisterPasswordStrength('passwordpassword');
+      expect(s.score).toBe(1);
+      expect(s.label).toBe('Weak');
+    });
+  });
+
+  describe('Fair (score 2)', () => {
+    it('is fair with 8+ chars and exactly two character classes', () => {
+      const s = getRegisterPasswordStrength('passWord');
+      expect(s.classes).toBe(2);
+      expect(s.score).toBe(2);
+      expect(s.label).toBe('Fair');
+      expect(s.barColor).toBe('bg-orange-500');
+    });
+  });
+
+  describe('Strong (score 3)', () => {
+    it('is strong with 8+ chars and three character classes', () => {
+      const s = getRegisterPasswordStrength('Password1');
+      expect(s.classes).toBe(3);
+      expect(s.score).toBe(3);
+      expect(s.label).toBe('Strong');
+      expect(s.barColor).toBe('bg-blue-500');
+    });
+
+    it('stays strong (not very strong) with all 4 classes but under 12 chars', () => {
+      const s = getRegisterPasswordStrength('Pass1!ab');
+      expect(s.classes).toBe(4);
+      expect(s.score).toBe(3);
+      expect(s.label).toBe('Strong');
+    });
+  });
+
+  describe('Very Strong (score 4)', () => {
+    it('is very strong with 12+ chars and all four character classes', () => {
+      const s = getRegisterPasswordStrength('Password123!');
+      expect(s.classes).toBe(4);
+      expect(s.score).toBe(4);
+      expect(s.label).toBe('Very Strong');
+      expect(s.barColor).toBe('bg-green-500');
+    });
+
+    it('drops to strong if 12+ chars but missing a class', () => {
+      const s = getRegisterPasswordStrength('Passwordabc1');
+      expect(s.classes).toBe(3);
+      expect(s.score).toBe(3);
+    });
+  });
+
+  describe('checklist dimensions', () => {
+    it('reports each requirement independently', () => {
+      const s = getRegisterPasswordStrength('Abcdef1!');
+      expect(s.checks).toEqual({
+        length: true,
+        uppercase: true,
+        number: true,
+        special: true,
+      });
+    });
+
+    it('flags unmet requirements', () => {
+      const s = getRegisterPasswordStrength('abc');
+      expect(s.checks).toEqual({
+        length: false,
+        uppercase: false,
+        number: false,
+        special: false,
+      });
+    });
+  });
+
+  it('marks Fair and above as acceptable for submission', () => {
+    expect(getRegisterPasswordStrength('passWord').isAcceptable).toBe(true);
+    expect(getRegisterPasswordStrength('Password123!').isAcceptable).toBe(true);
+    expect(getRegisterPasswordStrength('password').isAcceptable).toBe(false);
+    expect(getRegisterPasswordStrength('Ab1!').isAcceptable).toBe(false);
+  });
+});

--- a/frontend/src/utils/passwordValidator.js
+++ b/frontend/src/utils/passwordValidator.js
@@ -27,6 +27,69 @@ export function getPasswordStrength(password) {
   };
 }
 
+/**
+ * Issue #656: 4-level password strength model for the Register page.
+ *
+ * Scored across four dimensions surfaced in the checklist (length, uppercase,
+ * number, special character) and four character classes used for the level
+ * thresholds (lowercase, uppercase, number, special):
+ *   - Weak (red):        < 8 chars OR only one character class
+ *   - Fair (orange):     >= 8 chars and 2 character classes
+ *   - Strong (blue):     >= 8 chars and 3 character classes
+ *   - Very Strong (green): >= 12 chars and all 4 character classes
+ *
+ * Returns score 0 for an empty password (nothing to render).
+ */
+export function getRegisterPasswordStrength(password = '') {
+  const checks = {
+    length: password.length >= 8,
+    uppercase: /[A-Z]/.test(password),
+    number: /[0-9]/.test(password),
+    special: /[^A-Za-z0-9]/.test(password),
+  };
+
+  const classes =
+    (/[a-z]/.test(password) ? 1 : 0) +
+    (/[A-Z]/.test(password) ? 1 : 0) +
+    (/[0-9]/.test(password) ? 1 : 0) +
+    (/[^A-Za-z0-9]/.test(password) ? 1 : 0);
+
+  const len = password.length;
+
+  // 0 = empty, 1 = weak, 2 = fair, 3 = strong, 4 = very strong
+  let score;
+  if (len === 0) {
+    score = 0;
+  } else if (len >= 12 && classes === 4) {
+    score = 4;
+  } else if (len >= 8 && classes >= 3) {
+    score = 3;
+  } else if (len >= 8 && classes >= 2) {
+    score = 2;
+  } else {
+    score = 1;
+  }
+
+  const meta = [
+    { label: '', barColor: '', textColor: '' },
+    { label: 'Weak', barColor: 'bg-red-500', textColor: 'text-red-500' },
+    { label: 'Fair', barColor: 'bg-orange-500', textColor: 'text-orange-500' },
+    { label: 'Strong', barColor: 'bg-blue-500', textColor: 'text-blue-500' },
+    { label: 'Very Strong', barColor: 'bg-green-500', textColor: 'text-green-500' },
+  ][score];
+
+  return {
+    score,
+    classes,
+    checks,
+    label: meta.label,
+    barColor: meta.barColor,
+    textColor: meta.textColor,
+    // The Create Account button is enabled at "Fair" strength or above.
+    isAcceptable: score >= 2,
+  };
+}
+
 export function validateEmail(email) {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);


### PR DESCRIPTION
Implements four issues in one PR.

Closes #654
Closes #655
Closes #656
Closes #657

## #654 — ScheduledPayments: Calendar View
- List ↔ Calendar toggle on the ScheduledPayments page.
- Tailwind-only Sun–Sat monthly grid (no external calendar lib), month prev/next nav.
- Days with payments show a colored dot; multiple payments stack (max 3 dots, then "+N more").
- Clicking a highlighted date opens a popover listing recipient, amount, currency.
- Occurrences projected forward 3 months from `next_run_at`/`next_payment_at` + `frequency`/`interval`.
- Responsive: condensed week-row strip with week nav under 640px.

## #655 — Login: Rate-Limit Countdown
- On 429, parses `Retry-After` (defaults to 60s when absent).
- Inline live-decrementing message: "Too many login attempts. Please wait Xs before trying again."
- Login button disabled + styled for the cooldown, auto-re-enabled at 0.
- Countdown persisted in `sessionStorage` so a refresh restores remaining time.

## #656 — Register: Password Strength Indicator
- Real-time 4-segment strength bar: Weak / Fair / Strong / Very Strong.
- Live checklist: ≥8 chars, uppercase, number, special character.
- Bar + checklist hidden when the field is empty.
- Confirm-password field with green check on match / red error on mismatch.
- Create Account disabled until at least "Fair".
- New `getRegisterPasswordStrength()` helper + unit tests covering each level.
- Also repairs `Register.jsx`, which was committed in a broken half-merged state (duplicate imports/attributes that would not compile).

## #657 — Escrow: Partial Release
- "Partial Release" button alongside Full Release / Cancel (pending escrows only).
- Modal pre-filled with the escrowed balance; validates amount > 0 and ≤ balance.
- Preview of amount to release, platform fee deducted, and net to agent.
- `POST /api/contracts/escrow/:id/partial-release` with `{ amount }`.
- Row updates with the new remaining balance without a full reload; descriptive error toast on failure.
- Backend `partialRelease` controller + route (auth + validation) and `released_amount` migration.

## Notes
- Run `cd frontend && npm install && npm test` to exercise the new unit tests.
- Apply migration `025_add_released_amount_to_agent_escrows` before using partial release.