### PR TITLE
feat: offline queue, DEX auto-refresh, vault countdown (#651 #652 #653)

### DIFF
--- a/frontend/src/components/OfflineBanner.jsx
+++ b/frontend/src/components/OfflineBanner.jsx
@@ -2,28 +2,82 @@
  * OfflineBanner
  *
  * Displays a persistent banner when the device is offline.
- * Also shows a transient "Back online — syncing payments…" notice
- * when connectivity is restored after an offline period.
+ * Shows queued payment count, a dropdown list of queued transactions,
+ * and allows the user to cancel individual queued items.
  *
- * Rendered inside Layout so it appears on every authenticated page.
+ * When connectivity is restored, automatically retries all queued
+ * payments in order and notifies on success / persistent failure.
  */
 
-import React, { useEffect, useState } from 'react';
-import { WifiOff, Wifi, Clock } from 'lucide-react';
+import React, { useEffect, useState, useCallback } from 'react';
+import { WifiOff, Wifi, Clock, ChevronDown, X } from 'lucide-react';
+import toast from 'react-hot-toast';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
-import { getQueueCount } from '../utils/offlineDB';
+import {
+  getQueueCount,
+  getQueuedPayments,
+  removeQueuedPayment,
+} from '../utils/offlineDB';
+import api from '../utils/api';
 
 export default function OfflineBanner({ onPaymentSynced }) {
   const { isOnline, wasOffline } = useOnlineStatus({ onPaymentSynced });
-  const [showBackOnline, setShowBackOnline]   = useState(false);
-  const [queueCount,     setQueueCount]       = useState(0);
+  const [showBackOnline, setShowBackOnline] = useState(false);
+  const [queueCount, setQueueCount] = useState(0);
+  const [queuedItems, setQueuedItems] = useState([]);
+  const [showQueue, setShowQueue] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+
+  const refreshQueue = useCallback(async () => {
+    try {
+      const [count, items] = await Promise.all([getQueueCount(), getQueuedPayments()]);
+      setQueueCount(count);
+      setQueuedItems(items);
+    } catch {
+      setQueueCount(0);
+      setQueuedItems([]);
+    }
+  }, []);
 
   // Refresh queue count whenever online status changes
   useEffect(() => {
-    getQueueCount()
-      .then(setQueueCount)
-      .catch(() => setQueueCount(0));
-  }, [isOnline]);
+    refreshQueue();
+  }, [isOnline, refreshQueue]);
+
+  // Auto-submit queued payments when coming back online
+  useEffect(() => {
+    if (!isOnline || !wasOffline) return;
+
+    const syncQueue = async () => {
+      const items = await getQueuedPayments();
+      if (items.length === 0) return;
+
+      setSyncing(true);
+      for (const item of items) {
+        try {
+          await api.post('/payments/send', item.payload);
+          await removeQueuedPayment(item.id);
+          toast.success(
+            `Payment of ${item.payload.amount} ${item.payload.asset || 'XLM'} sent successfully.`,
+            { duration: 4000 }
+          );
+          onPaymentSynced?.();
+        } catch (err) {
+          // Move to failed state — notify persistently
+          toast.error(
+            `Failed to send queued payment (${item.payload.amount} ${item.payload.asset || 'XLM'}): ${
+              err.response?.data?.error || err.message || 'Unknown error'
+            }`,
+            { duration: 0, id: `queue-fail-${item.id}` }
+          );
+        }
+      }
+      setSyncing(false);
+      refreshQueue();
+    };
+
+    syncQueue();
+  }, [isOnline]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Show the "back online" notice for 4 seconds after reconnecting
   useEffect(() => {
@@ -34,20 +88,80 @@ export default function OfflineBanner({ onPaymentSynced }) {
     }
   }, [isOnline, wasOffline]);
 
+  const handleCancel = async (id) => {
+    await removeQueuedPayment(id);
+    refreshQueue();
+    toast('Queued payment cancelled.', { icon: '🗑️' });
+  };
+
   if (!isOnline) {
     return (
-      <div
-        role="status"
-        aria-live="assertive"
-        className="bg-red-600 text-white text-xs font-semibold py-2 px-4 flex items-center justify-center gap-2"
-      >
-        <WifiOff size={14} aria-hidden="true" />
-        <span>You're offline — showing cached data</span>
-        {queueCount > 0 && (
-          <span className="flex items-center gap-1 ml-2 bg-red-700 rounded-full px-2 py-0.5">
-            <Clock size={11} aria-hidden="true" />
-            {queueCount} payment{queueCount !== 1 ? 's' : ''} queued
-          </span>
+      <div className="relative">
+        <div
+          role="status"
+          aria-live="assertive"
+          className="bg-red-600 text-white text-xs font-semibold py-2 px-4 flex items-center justify-center gap-2"
+        >
+          <WifiOff size={14} aria-hidden="true" />
+          <span>You're offline — showing cached data</span>
+          {queueCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowQueue(v => !v)}
+              className="flex items-center gap-1 ml-2 bg-red-700 hover:bg-red-800 rounded-full px-2 py-0.5 transition-colors"
+              aria-expanded={showQueue}
+              aria-label={`${queueCount} payment${queueCount !== 1 ? 's' : ''} queued — click to view`}
+            >
+              <Clock size={11} aria-hidden="true" />
+              {queueCount} payment{queueCount !== 1 ? 's' : ''} queued
+              <ChevronDown
+                size={11}
+                className={`transition-transform ${showQueue ? 'rotate-180' : ''}`}
+                aria-hidden="true"
+              />
+            </button>
+          )}
+        </div>
+
+        {/* Queue dropdown */}
+        {showQueue && queuedItems.length > 0 && (
+          <div
+            role="region"
+            aria-label="Pending payment queue"
+            className="absolute top-full left-0 right-0 z-50 bg-gray-900 border border-red-600/40 shadow-xl max-h-64 overflow-y-auto"
+          >
+            <p className="px-4 py-2 text-xs text-gray-400 font-semibold uppercase tracking-wide border-b border-gray-800">
+              Pending Queue
+            </p>
+            {queuedItems.map(item => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between px-4 py-2.5 border-b border-gray-800 last:border-0"
+              >
+                <div className="text-xs text-gray-300">
+                  <span className="font-semibold text-white">
+                    {item.payload.amount} {item.payload.asset || 'XLM'}
+                  </span>
+                  {item.payload.recipient_address && (
+                    <span className="ml-1 text-gray-500 font-mono">
+                      → {item.payload.recipient_address.slice(0, 8)}…
+                    </span>
+                  )}
+                  <span className="ml-2 text-gray-600">
+                    {new Date(item.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleCancel(item.id)}
+                  className="ml-3 text-gray-400 hover:text-red-400 transition-colors shrink-0"
+                  aria-label="Cancel this queued payment"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
         )}
       </div>
     );
@@ -62,10 +176,9 @@ export default function OfflineBanner({ onPaymentSynced }) {
       >
         <Wifi size={14} aria-hidden="true" />
         <span>
-          Back online
-          {queueCount > 0
-            ? ` — syncing ${queueCount} queued payment${queueCount !== 1 ? 's' : ''}…`
-            : ' — all caught up'}
+          {syncing
+            ? `Back online — syncing ${queueCount} queued payment${queueCount !== 1 ? 's' : ''}…`
+            : 'Back online — all caught up'}
         </span>
       </div>
     );

--- a/frontend/src/pages/SaveMoney.jsx
+++ b/frontend/src/pages/SaveMoney.jsx
@@ -1,17 +1,110 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, PiggyBank, Clock } from 'lucide-react';
+import { ArrowLeft, PiggyBank, Clock, Unlock, RefreshCw } from 'lucide-react';
 import api from '../utils/api';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
+/** Calculate remaining seconds from now until unlockTimestamp (unix seconds). */
+function secondsUntil(unlockTimestamp) {
+  return Math.max(0, unlockTimestamp - Math.floor(Date.now() / 1000));
+}
+
+/** Format a seconds value as "14d 6h 32m 18s". */
+function formatCountdown(secs) {
+  if (secs <= 0) return null;
+  const d = Math.floor(secs / 86400);
+  const h = Math.floor((secs % 86400) / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  const parts = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0 || d > 0) parts.push(`${h}h`);
+  if (m > 0 || h > 0 || d > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(' ');
+}
+
+/**
+ * Per-vault countdown component.
+ * Ticks every second; cleans up on unmount.
+ */
+function VaultCountdown({ unlockTimestamp, balance }) {
+  const [secs, setSecs] = useState(() => secondsUntil(unlockTimestamp));
+
+  useEffect(() => {
+    if (secs <= 0) return;
+    const id = setInterval(() => {
+      setSecs(secondsUntil(unlockTimestamp));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [unlockTimestamp]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const unlocked = secs <= 0;
+  const penalty = (parseFloat(balance) * 0.1).toFixed(7);
+  const label = formatCountdown(secs);
+
+  if (unlocked) {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/20 text-green-400 text-xs font-semibold">
+        <Unlock size={11} aria-hidden="true" />
+        Ready to withdraw
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={`${label} remaining until unlock`}
+        className="inline-flex items-center gap-1 text-xs font-mono text-amber-400"
+      >
+        <Clock size={11} aria-hidden="true" />
+        {label} remaining
+      </span>
+      {/* Withdraw button with early-penalty tooltip */}
+      <div className="relative group inline-block">
+        <button
+          type="button"
+          className="text-xs px-2 py-0.5 rounded border border-gray-600 text-gray-400 cursor-not-allowed"
+          aria-disabled="true"
+          tabIndex={-1}
+        >
+          Withdraw
+        </button>
+        <div
+          role="tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-52 bg-gray-900 border border-yellow-500/40 text-yellow-300 text-xs rounded-lg px-3 py-2 opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity z-10"
+        >
+          Early withdrawal incurs a 10% penalty ({penalty} XLM)
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Demo vault list – replace with real API data once the Soroban contract is live. */
+const DEMO_VAULTS = [
+  {
+    id: 1,
+    label: 'Emergency Fund',
+    balance: '100.0000000',
+    unlockTimestamp: Math.floor(Date.now() / 1000) + 14 * 86400 + 6 * 3600 + 32 * 60 + 18,
+  },
+  {
+    id: 2,
+    label: 'Holiday Savings',
+    balance: '250.0000000',
+    unlockTimestamp: Math.floor(Date.now() / 1000) - 60, // already unlocked
+  },
+];
+
 export default function SaveMoney() {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const [form, setForm] = useState({
-    amount: '',
-    lock_period_days: '30'
-  });
+  const [form, setForm] = useState({ amount: '', lock_period_days: '30' });
   const [loading, setLoading] = useState(false);
   const [wallet, setWallet] = useState(null);
 
@@ -36,15 +129,10 @@ export default function SaveMoney() {
 
     setLoading(true);
     try {
-      // Calculate unlock time (current time + lock period in seconds)
       const lockPeriodSeconds = parseInt(form.lock_period_days) * 24 * 60 * 60;
       const unlockTime = Math.floor(Date.now() / 1000) + lockPeriodSeconds;
-
-      // TODO: Integrate with Soroban contract
-      // For now, just show a placeholder
+      // TODO: Integrate with Soroban savings-vault contract
       toast.success(`Savings vault feature coming soon! Amount: ${form.amount} XLM, Unlock in ${form.lock_period_days} days`);
-
-      // Navigate back to dashboard
       navigate('/dashboard');
     } catch (err) {
       toast.error(err.response?.data?.error || 'Failed to save funds');
@@ -82,9 +170,34 @@ export default function SaveMoney() {
           </div>
         </div>
 
-        {/* Form */}
+        {/* Active Vaults */}
+        {DEMO_VAULTS.length > 0 && (
+          <section aria-label="Active savings vaults">
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Your Vaults</h2>
+            <div className="space-y-3">
+              {DEMO_VAULTS.map(vault => (
+                <div
+                  key={vault.id}
+                  className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 space-y-2"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-gray-900 dark:text-white text-sm">{vault.label}</span>
+                    <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      {parseFloat(vault.balance).toFixed(2)} XLM
+                    </span>
+                  </div>
+                  <VaultCountdown
+                    unlockTimestamp={vault.unlockTimestamp}
+                    balance={vault.balance}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* New Vault Form */}
         <form onSubmit={handleSubmit} className="space-y-6">
-          {/* Amount */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Amount to Save (XLM)
@@ -101,7 +214,6 @@ export default function SaveMoney() {
             />
           </div>
 
-          {/* Lock Period */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Lock Period
@@ -119,7 +231,6 @@ export default function SaveMoney() {
             </select>
           </div>
 
-          {/* Info */}
           <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-4">
             <div className="flex items-start gap-3">
               <Clock className="text-blue-500 mt-0.5" size={20} />
@@ -133,7 +244,6 @@ export default function SaveMoney() {
             </div>
           </div>
 
-          {/* Submit Button */}
           <button
             type="submit"
             disabled={loading || !form.amount}

--- a/frontend/src/pages/Swap.jsx
+++ b/frontend/src/pages/Swap.jsx
@@ -1,24 +1,27 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { ArrowUpDown, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { ArrowUpDown, AlertTriangle, CheckCircle2, RefreshCw } from 'lucide-react';
 import api from '../utils/api';
 import toast from 'react-hot-toast';
 
-const PAIRS = [
-  { sell: 'XLM', buy: 'USDC' },
-  { sell: 'USDC', buy: 'XLM' },
-];
-
-// Price impact is considered high above this threshold (%)
+const REFRESH_INTERVAL = 15; // seconds
 const HIGH_IMPACT_PCT = 2;
+const PRICE_CHANGE_TOAST_THRESHOLD = 0.005; // 0.5%
 
 export default function Swap() {
   const [sellAsset, setSellAsset] = useState('XLM');
   const [buyAsset, setBuyAsset] = useState('USDC');
   const [sellAmount, setSellAmount] = useState('');
-  const [quote, setQuote] = useState(null); // { midPrice, estimatedReceived, priceImpactPct }
+  const [quote, setQuote] = useState(null);
   const [quoteLoading, setQuoteLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [result, setResult] = useState(null);
+
+  // Auto-refresh countdown (counts down from REFRESH_INTERVAL to 0)
+  const [refreshCountdown, setRefreshCountdown] = useState(REFRESH_INTERVAL);
+  const prevMidPriceRef = useRef(null);
+  const countdownRef = useRef(null);
+  const refreshIntervalRef = useRef(null);
 
   const flipPair = () => {
     setSellAsset(buyAsset);
@@ -26,29 +29,37 @@ export default function Swap() {
     setSellAmount('');
     setQuote(null);
     setResult(null);
+    prevMidPriceRef.current = null;
   };
 
-  const fetchQuote = useCallback(async () => {
+  const fetchQuote = useCallback(async (isAutoRefresh = false) => {
     if (!sellAmount || parseFloat(sellAmount) <= 0) { setQuote(null); return; }
     setQuoteLoading(true);
     try {
-      const [bookRes, pathRes] = await Promise.all([
-        api.get(`/dex/orderbook?selling=${sellAsset}&buying=${buyAsset}`),
-        api.get(`/dex/orderbook?selling=${buyAsset}&buying=${sellAsset}`), // reverse for impact calc
-      ]);
+      const bookRes = await api.get(`/dex/orderbook?selling=${sellAsset}&buying=${buyAsset}`);
       const { midPrice, asks } = bookRes.data;
 
-      // Estimate received using best ask price
       const bestAsk = asks[0] ? parseFloat(asks[0].price) : null;
       const estimatedReceived = bestAsk ? (parseFloat(sellAmount) / bestAsk).toFixed(7) : null;
-
-      // Rough price impact: compare sell amount to total ask liquidity at best price
       const bestAskVolume = asks[0] ? parseFloat(asks[0].amount) : Infinity;
       const priceImpactPct = bestAskVolume > 0
         ? Math.min(((parseFloat(sellAmount) / bestAskVolume) * 100), 100)
         : 0;
 
       setQuote({ midPrice, estimatedReceived, priceImpactPct });
+
+      // Notify on significant price change during auto-refresh
+      if (isAutoRefresh && prevMidPriceRef.current !== null && midPrice) {
+        const change = Math.abs((midPrice - prevMidPriceRef.current) / prevMidPriceRef.current);
+        if (change > PRICE_CHANGE_TOAST_THRESHOLD) {
+          toast('Price updated', {
+            icon: '🔄',
+            style: { background: '#1e293b', color: '#e2e8f0' },
+            duration: 2500,
+          });
+        }
+      }
+      if (midPrice) prevMidPriceRef.current = midPrice;
     } catch {
       setQuote(null);
     } finally {
@@ -56,14 +67,57 @@ export default function Swap() {
     }
   }, [sellAsset, buyAsset, sellAmount]);
 
-  // Debounce quote fetch
+  // Debounce on user input
   useEffect(() => {
-    const t = setTimeout(fetchQuote, 500);
+    const t = setTimeout(() => fetchQuote(false), 500);
     return () => clearTimeout(t);
   }, [fetchQuote]);
 
+  // Start/stop the 15s auto-refresh cycle; pause when confirm modal is open
+  useEffect(() => {
+    if (confirmOpen) {
+      clearInterval(refreshIntervalRef.current);
+      clearInterval(countdownRef.current);
+      return;
+    }
+
+    setRefreshCountdown(REFRESH_INTERVAL);
+
+    // Countdown ticker (1s)
+    countdownRef.current = setInterval(() => {
+      setRefreshCountdown(prev => (prev <= 1 ? REFRESH_INTERVAL : prev - 1));
+    }, 1000);
+
+    // Auto-refresh trigger
+    refreshIntervalRef.current = setInterval(() => {
+      fetchQuote(true);
+      setRefreshCountdown(REFRESH_INTERVAL);
+    }, REFRESH_INTERVAL * 1000);
+
+    return () => {
+      clearInterval(refreshIntervalRef.current);
+      clearInterval(countdownRef.current);
+    };
+  }, [confirmOpen, fetchQuote]);
+
+  const handleManualRefresh = () => {
+    fetchQuote(false);
+    setRefreshCountdown(REFRESH_INTERVAL);
+    // Reset the auto-refresh interval so it restarts from now
+    clearInterval(refreshIntervalRef.current);
+    clearInterval(countdownRef.current);
+    countdownRef.current = setInterval(() => {
+      setRefreshCountdown(prev => (prev <= 1 ? REFRESH_INTERVAL : prev - 1));
+    }, 1000);
+    refreshIntervalRef.current = setInterval(() => {
+      fetchQuote(true);
+      setRefreshCountdown(REFRESH_INTERVAL);
+    }, REFRESH_INTERVAL * 1000);
+  };
+
   const handleSwap = async (e) => {
     e.preventDefault();
+    if (!confirmOpen) { setConfirmOpen(true); return; }
     setSubmitting(true);
     setResult(null);
     try {
@@ -75,27 +129,62 @@ export default function Swap() {
       setResult(res.data);
       setSellAmount('');
       setQuote(null);
+      prevMidPriceRef.current = null;
       toast.success('Swap executed successfully');
     } catch (err) {
       toast.error(err.response?.data?.error || err.response?.data?.errors?.[0]?.msg || 'Swap failed');
     } finally {
       setSubmitting(false);
+      setConfirmOpen(false);
     }
   };
 
   const highImpact = quote && quote.priceImpactPct >= HIGH_IMPACT_PCT;
+  const progressPct = ((REFRESH_INTERVAL - refreshCountdown) / REFRESH_INTERVAL) * 100;
 
   return (
     <div className="px-4 py-6 max-w-lg mx-auto space-y-5">
       <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Swap</h2>
 
-      {/* Rate display */}
+      {/* Rate display + refresh controls */}
       {quote?.midPrice && (
-        <div className="bg-primary-500/10 border border-primary-500/20 rounded-xl px-4 py-2.5 flex items-center justify-between text-sm">
-          <span className="text-gray-500 dark:text-gray-400">DEX rate</span>
-          <span className="font-semibold text-gray-900 dark:text-white">
-            1 {sellAsset} ≈ {(1 / quote.midPrice).toFixed(6)} {buyAsset}
-          </span>
+        <div className="bg-primary-500/10 border border-primary-500/20 rounded-xl px-4 py-2.5 space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-500 dark:text-gray-400">DEX rate</span>
+            <div className="flex items-center gap-2">
+              <span className="font-semibold text-gray-900 dark:text-white">
+                1 {sellAsset} ≈ {(1 / quote.midPrice).toFixed(6)} {buyAsset}
+              </span>
+              <button
+                type="button"
+                onClick={handleManualRefresh}
+                disabled={quoteLoading}
+                className="text-gray-400 hover:text-primary-500 transition-colors disabled:opacity-40"
+                aria-label="Refresh price"
+              >
+                <RefreshCw size={13} className={quoteLoading ? 'animate-spin' : ''} />
+              </button>
+            </div>
+          </div>
+          {/* Countdown progress bar */}
+          {!confirmOpen && (
+            <div className="space-y-0.5">
+              <div
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={REFRESH_INTERVAL}
+                aria-valuenow={REFRESH_INTERVAL - refreshCountdown}
+                aria-label={`Next price refresh in ${refreshCountdown}s`}
+                className="h-1 bg-primary-500/20 rounded-full overflow-hidden"
+              >
+                <div
+                  className="h-full bg-primary-500 transition-all duration-1000 ease-linear rounded-full"
+                  style={{ width: `${progressPct}%` }}
+                />
+              </div>
+              <p className="text-xs text-gray-500 text-right">refreshes in {refreshCountdown}s</p>
+            </div>
+          )}
         </div>
       )}
 
@@ -141,7 +230,6 @@ export default function Swap() {
           </div>
         </div>
 
-        {/* Price impact warning */}
         {highImpact && (
           <div className="flex items-start gap-2 bg-yellow-500/10 border border-yellow-500/30 rounded-xl px-4 py-3 text-sm text-yellow-500">
             <AlertTriangle size={16} className="shrink-0 mt-0.5" />
@@ -152,13 +240,34 @@ export default function Swap() {
           </div>
         )}
 
+        {/* Confirm step */}
+        {confirmOpen && (
+          <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl px-4 py-3 text-sm text-yellow-400">
+            <p className="font-semibold mb-1">Confirm swap</p>
+            <p>Sell <span className="font-semibold">{sellAmount} {sellAsset}</span> for approximately{' '}
+              <span className="font-semibold">{quote?.estimatedReceived} {buyAsset}</span>?
+            </p>
+            <p className="text-xs text-gray-400 mt-1">Price is locked — auto-refresh paused.</p>
+          </div>
+        )}
+
         <button
           type="submit"
           disabled={submitting || !sellAmount || parseFloat(sellAmount) <= 0}
           className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold py-3.5 rounded-2xl transition-colors"
         >
-          {submitting ? 'Swapping…' : `Swap ${sellAsset} → ${buyAsset}`}
+          {submitting ? 'Swapping…' : confirmOpen ? 'Confirm Swap' : `Swap ${sellAsset} → ${buyAsset}`}
         </button>
+
+        {confirmOpen && (
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(false)}
+            className="w-full text-gray-400 hover:text-white text-sm py-2 transition-colors"
+          >
+            Cancel
+          </button>
+        )}
       </form>
 
       {/* Success result */}


### PR DESCRIPTION
## Summary

Resolves #651, #652, and #653.

---

### #651 — OfflineBanner: Queue Outgoing Transactions When Offline

**OfflineBanner.jsx**
- Shows `"You are offline. N payment(s) queued."` when the IDB queue has entries.
- Clicking the queued-count pill opens a **Pending Queue dropdown** listing each queued payment (amount, asset, truncated address, timestamp).
- Each item has an **X button** to cancel (removes from IDB, refreshes count).
- On the `online` event, all queued payments are **auto-submitted in order** via `POST /payments/send`.
  - Success → per-payment success toast; entry removed from IDB.
  - Failure (e.g. insufficient balance) → persistent error toast with reason; entry kept for inspection.
- No changes to SendMoney.jsx — the `res.data?.queued` path already existed.
- No changes to api.js or offlineDB.js — the `enqueuePayment` interceptor and IDB `queue` store already existed.

---

### #652 — Swap: Real-Time DEX Price Auto-Refresh

**Swap.jsx**
- Fetches the exchange rate from `/dex/orderbook` **every 15 seconds** automatically.
- A **countdown progress bar** beneath the rate display shows time until the next refresh (animated, 15-second cycle).
- When the price refreshes, the output amount **recalculates automatically** if a sell amount is entered.
- A subtle **"Price updated" toast** fires when the rate changes by more than 0.5%.
- Auto-refresh is **paused while the confirm modal is open** to prevent confusing mid-confirmation changes.
- A **RefreshCw button** next to the rate lets the user trigger a manual refresh, resetting the countdown.
- Intervals are cleaned up on unmount.

---

### #653 — SaveMoney: Vault Unlock Countdown Timer

**SaveMoney.jsx**
- New `VaultCountdown` component ticks every second with `setInterval` (cleaned up on unmount).
- Displays countdown in `14d 6h 32m 18s remaining` format.
- When countdown reaches zero: timer replaced with a **"Ready to withdraw" badge** (Unlock icon, green).
- While locked: **withdraw button is disabled** with an **aria-`tooltip`** showing `Early withdrawal incurs a 10% penalty (X XLM)` calculated as `balance × 0.10`.
- If `unlockTimestamp` is in the past on first render, no countdown is shown (badge shown immediately).
- Countdown uses `aria-live="polite"` for screen reader announcements.
- Demo vault list added (replace with real Soroban contract API once live).

---

### Testing

- All three components were manually traced through their acceptance criteria.
- No new dependencies added — `idb` (^8.0.3), `lucide-react`, and `react-hot-toast` were already installed.
closes #651 
closes #652 
closes #653 