### PR TITLE
feat: configurable vault penalty, multi-deposit query, recurring pause/resume, full deploy coverage

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -54,20 +54,36 @@ case "$TARGET_CONTRACT" in
     CONTRACT_NAME="recurring_payments_contract"
     CONTRACT_SUBDIR="recurring-payments"
     ;;
-  agent-escrow)
-    CONTRACT_NAME="agent_escrow_contract"
-    CONTRACT_SUBDIR="agent-escrow"
-    ;;
-  kyc-attestation)
-    CONTRACT_NAME="kyc_attestation_contract"
-    CONTRACT_SUBDIR="kyc-attestation"
+  savings-vault)
+    CONTRACT_NAME="savings_vault_contract"
+    CONTRACT_SUBDIR="savings-vault"
     ;;
   fee-distributor)
     CONTRACT_NAME="fee_distributor_contract"
     CONTRACT_SUBDIR="fee-distributor"
     ;;
+  dispute-resolution)
+    CONTRACT_NAME="dispute_resolution_contract"
+    CONTRACT_SUBDIR="dispute-resolution"
+    ;;
+  kyc-attestation)
+    CONTRACT_NAME="kyc_attestation_contract"
+    CONTRACT_SUBDIR="kyc-attestation"
+    ;;
+  agent-escrow)
+    CONTRACT_NAME="agent_escrow_contract"
+    CONTRACT_SUBDIR="agent-escrow"
+    ;;
+  multisig-approval)
+    CONTRACT_NAME="multisig_approval"
+    CONTRACT_SUBDIR="multisig-approval"
+    ;;
+  loyalty-token)
+    CONTRACT_NAME="loyalty_token_contract"
+    CONTRACT_SUBDIR="loyalty-token"
+    ;;
   *)
-    echo -e "${RED}Unknown contract: $TARGET_CONTRACT. Valid options: escrow, recurring-payments, agent-escrow, kyc-attestation, fee-distributor${NC}"
+    echo -e "${RED}Unknown contract: $TARGET_CONTRACT. Valid options: escrow, recurring-payments, savings-vault, fee-distributor, dispute-resolution, kyc-attestation, agent-escrow, multisig-approval, loyalty-token${NC}"
     exit 1
     ;;
 esac
@@ -254,21 +270,140 @@ echo -e "${GREEN}✓ Contract ID written to $DEPLOYED_IDS_FILE${NC}"
 # becomes admin. We call it here so there is no manual gap.
 echo -e "\n${YELLOW}Step 6: Initializing contract (front-running prevention — fix #336)...${NC}"
 
-if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${USDC_ADDRESS:-}" ]; then
-    $SOROBAN_CLI contract invoke \
-        --id "$CONTRACT_ID" \
-        --source "$SOROBAN_SECRET_KEY" \
-        --network "$NETWORK" \
-        -- initialize \
-        --admin "$ADMIN_ADDRESS" \
-        --usdc_address "$USDC_ADDRESS"
-    echo -e "${GREEN}✓ Contract initialized. Admin: ${ADMIN_ADDRESS}${NC}"
+INIT_OK=false
+
+case "$TARGET_CONTRACT" in
+  escrow|fee-distributor)
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${USDC_ADDRESS:-}" ]; then
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --usdc_address "$USDC_ADDRESS"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS and USDC_ADDRESS, then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --usdc_address \$USDC_ADDRESS"
+    fi
+    ;;
+  savings-vault)
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${USDC_ADDRESS:-}" ]; then
+        PENALTY="${PENALTY_BPS:-1000}"
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --token_address "$USDC_ADDRESS" \
+            --penalty_bps "$PENALTY"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS, USDC_ADDRESS, and optionally PENALTY_BPS (default 1000), then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --token_address \$USDC_ADDRESS --penalty_bps \${PENALTY_BPS:-1000}"
+    fi
+    ;;
+  recurring-payments)
+    if [ -n "${USDC_ADDRESS:-}" ]; then
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --token_address "$USDC_ADDRESS"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set USDC_ADDRESS, then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --token_address \$USDC_ADDRESS"
+    fi
+    ;;
+  kyc-attestation)
+    if [ -n "${ADMIN_ADDRESS:-}" ]; then
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS, then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS"
+    fi
+    ;;
+  agent-escrow)
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${USDC_ADDRESS:-}" ]; then
+        CANCEL_WINDOW="${CANCEL_WINDOW_SECONDS:-86400}"
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --usdc_address "$USDC_ADDRESS" \
+            --cancel_window_seconds "$CANCEL_WINDOW"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS, USDC_ADDRESS, and optionally CANCEL_WINDOW_SECONDS (default 86400), then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --usdc_address \$USDC_ADDRESS --cancel_window_seconds \${CANCEL_WINDOW_SECONDS:-86400}"
+    fi
+    ;;
+  dispute-resolution)
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${ARBITRATOR_ADDRESS:-}" ] && [ -n "${USDC_ADDRESS:-}" ]; then
+        MAX_EVIDENCE="${MAX_EVIDENCE_BYTES:-65536}"
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --arbitrator "$ARBITRATOR_ADDRESS" \
+            --usdc_address "$USDC_ADDRESS" \
+            --max_evidence_bytes "$MAX_EVIDENCE"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS, ARBITRATOR_ADDRESS, USDC_ADDRESS, and optionally MAX_EVIDENCE_BYTES (default 65536), then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --arbitrator \$ARBITRATOR_ADDRESS --usdc_address \$USDC_ADDRESS --max_evidence_bytes \${MAX_EVIDENCE_BYTES:-65536}"
+    fi
+    ;;
+  multisig-approval)
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${APPROVERS:-}" ] && [ -n "${QUORUM:-}" ]; then
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --approvers "$APPROVERS" \
+            --quorum "$QUORUM"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS, APPROVERS (JSON array of addresses), and QUORUM, then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --approvers \$APPROVERS --quorum \$QUORUM"
+    fi
+    ;;
+  loyalty-token)
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${MAX_SUPPLY:-}" ]; then
+        $SOROBAN_CLI contract invoke \
+            --id "$CONTRACT_ID" \
+            --source "$SOROBAN_SECRET_KEY" \
+            --network "$NETWORK" \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --max_supply "$MAX_SUPPLY"
+        INIT_OK=true
+    else
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS and MAX_SUPPLY, then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --max_supply \$MAX_SUPPLY"
+    fi
+    ;;
+esac
+
+if [ "$INIT_OK" = true ]; then
+    echo -e "${GREEN}✓ Contract initialized. Admin: ${ADMIN_ADDRESS:-N/A}${NC}"
 else
-    echo -e "${RED}WARNING: ADMIN_ADDRESS or USDC_ADDRESS not set — contract is uninitialized!${NC}"
-    echo -e "${RED}Anyone can call initialize() and become admin. Run immediately:${NC}"
-    echo "  export ADMIN_ADDRESS=G... USDC_ADDRESS=C..."
-    echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --usdc_address \$USDC_ADDRESS"
-    echo ""
     echo -e "${RED}Do not share this contract ID until initialize() has been called.${NC}"
 fi
 

--- a/contracts/recurring-payments/src/lib.rs
+++ b/contracts/recurring-payments/src/lib.rs
@@ -22,6 +22,7 @@ pub type IntervalSecs = u64;
 pub enum ScheduleStatus {
     Active,
     Cancelled,
+    Paused,
 }
 
 #[derive(Clone)]
@@ -72,6 +73,18 @@ pub struct PaymentExecuted {
 #[derive(Clone)]
 #[contracttype]
 pub struct ScheduleCancelled {
+    pub id: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct SchedulePaused {
+    pub id: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduleResumed {
     pub id: u64,
 }
 
@@ -234,6 +247,7 @@ impl RecurringPaymentsContract {
     }
 
     /// Cancel a recurring schedule. Only the original sender may cancel.
+    /// A paused schedule may also be cancelled.
     pub fn cancel_recurring_payment(env: Env, sender: Address, schedule_id: u64) {
         sender.require_auth();
 
@@ -246,8 +260,8 @@ impl RecurringPaymentsContract {
         if schedule.sender != sender {
             panic!("only the sender can cancel");
         }
-        if schedule.status != ScheduleStatus::Active {
-            panic!("schedule is not active");
+        if schedule.status == ScheduleStatus::Cancelled {
+            panic!("schedule is already cancelled");
         }
 
         schedule.status = ScheduleStatus::Cancelled;
@@ -258,6 +272,63 @@ impl RecurringPaymentsContract {
         env.events().publish(
             (Symbol::new(&env, "ScheduleCancelled"),),
             ScheduleCancelled { id: schedule_id },
+        );
+    }
+
+    /// Pause a recurring schedule. Only the original sender may pause.
+    /// A paused schedule will not execute until resumed.
+    pub fn pause_recurring_payment(env: Env, sender: Address, schedule_id: u64) {
+        sender.require_auth();
+
+        let mut schedule: RecurringSchedule = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(schedule_id))
+            .expect("schedule not found");
+
+        if schedule.sender != sender {
+            panic!("only the sender can pause");
+        }
+        if schedule.status != ScheduleStatus::Active {
+            panic!("schedule is not active");
+        }
+
+        schedule.status = ScheduleStatus::Paused;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(schedule_id), &schedule);
+
+        env.events().publish(
+            (Symbol::new(&env, "SchedulePaused"),),
+            SchedulePaused { id: schedule_id },
+        );
+    }
+
+    /// Resume a paused recurring schedule. Only the original sender may resume.
+    pub fn resume_recurring_payment(env: Env, sender: Address, schedule_id: u64) {
+        sender.require_auth();
+
+        let mut schedule: RecurringSchedule = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(schedule_id))
+            .expect("schedule not found");
+
+        if schedule.sender != sender {
+            panic!("only the sender can resume");
+        }
+        if schedule.status != ScheduleStatus::Paused {
+            panic!("schedule is not paused");
+        }
+
+        schedule.status = ScheduleStatus::Active;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(schedule_id), &schedule);
+
+        env.events().publish(
+            (Symbol::new(&env, "ScheduleResumed"),),
+            ScheduleResumed { id: schedule_id },
         );
     }
 

--- a/contracts/recurring-payments/src/test.rs
+++ b/contracts/recurring-payments/src/test.rs
@@ -228,7 +228,7 @@ fn test_cancel_by_non_sender_panics() {
 }
 
 #[test]
-#[should_panic(expected = "schedule is not active")]
+#[should_panic(expected = "schedule is already cancelled")]
 fn test_cancel_already_cancelled_panics() {
     let (env, contract_id, _, sender, recipient, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
@@ -253,4 +253,100 @@ fn test_get_schedule_unknown_id_panics() {
     let (env, contract_id, ..) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     client.get_schedule(&999);
+}
+
+// ── #550: pause / resume ──────────────────────────────────────────────────────
+
+#[test]
+fn test_pause_sets_status_paused() {
+    let (env, contract_id, _, sender, recipient, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    let s = client.get_recurring_payment(&id);
+    assert_eq!(s.status, ScheduleStatus::Paused);
+}
+
+#[test]
+fn test_resume_sets_status_active() {
+    let (env, contract_id, _, sender, recipient, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    client.resume_recurring_payment(&sender, &id);
+    let s = client.get_recurring_payment(&id);
+    assert_eq!(s.status, ScheduleStatus::Active);
+}
+
+#[test]
+#[should_panic(expected = "schedule is not active")]
+fn test_execute_payment_while_paused_panics() {
+    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+}
+
+#[test]
+fn test_resume_allows_execution() {
+    let (env, contract_id, token_id, sender, recipient, executor) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let amount = 100_0000000i128;
+    let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    advance_time(&env, 86400);
+    client.resume_recurring_payment(&sender, &id);
+    client.execute_payment(&executor, &id);
+    assert_eq!(token_balance(&env, &token_id, &recipient), amount);
+}
+
+#[test]
+#[should_panic(expected = "only the sender can pause")]
+fn test_pause_by_non_sender_panics() {
+    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&executor, &id);
+}
+
+#[test]
+#[should_panic(expected = "only the sender can resume")]
+fn test_resume_by_non_sender_panics() {
+    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    client.resume_recurring_payment(&executor, &id);
+}
+
+#[test]
+#[should_panic(expected = "schedule is not active")]
+fn test_pause_already_paused_panics() {
+    let (env, contract_id, _, sender, recipient, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    client.pause_recurring_payment(&sender, &id);
+}
+
+#[test]
+#[should_panic(expected = "schedule is not paused")]
+fn test_resume_active_schedule_panics() {
+    let (env, contract_id, _, sender, recipient, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.resume_recurring_payment(&sender, &id);
+}
+
+#[test]
+fn test_cancel_paused_schedule() {
+    let (env, contract_id, _, sender, recipient, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
+    client.pause_recurring_payment(&sender, &id);
+    client.cancel_recurring_payment(&sender, &id);
+    let s = client.get_recurring_payment(&id);
+    assert_eq!(s.status, ScheduleStatus::Cancelled);
 }

--- a/contracts/savings-vault/src/lib.rs
+++ b/contracts/savings-vault/src/lib.rs
@@ -40,10 +40,10 @@ pub enum DataKey {
     Admin,
     TokenAddress,
     InterestRateBps,
+    PenaltyBps,
     Vault(Address),
 }
 
-const EARLY_WITHDRAWAL_PENALTY_BPS: u32 = 1000;
 const SECONDS_PER_YEAR: u64 = 31_536_000;
 
 #[contract]
@@ -51,12 +51,13 @@ pub struct SavingsVaultContract;
 
 #[contractimpl]
 impl SavingsVaultContract {
-    pub fn initialize(env: Env, admin: Address, token_address: Address) {
+    pub fn initialize(env: Env, admin: Address, token_address: Address, penalty_bps: u32) {
         if env.storage().persistent().has(&DataKey::TokenAddress) {
             panic!("Contract already initialized");
         }
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::TokenAddress, &token_address);
+        env.storage().persistent().set(&DataKey::PenaltyBps, &penalty_bps);
     }
 
     /// Set the annual interest rate. Only admin may call this.
@@ -130,6 +131,8 @@ impl SavingsVaultContract {
         );
     }
 
+    /// Deposit tokens into the vault. Accumulates on top of any existing balance.
+    /// Extends the unlock time only if the new unlock_time is later than the current one.
     pub fn deposit(env: Env, user: Address, amount: i128, unlock_time: u64) {
         user.require_auth();
         if amount <= 0 {
@@ -204,9 +207,15 @@ impl SavingsVaultContract {
             .get(&DataKey::TokenAddress)
             .unwrap();
 
+        let penalty_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PenaltyBps)
+            .unwrap_or(1000);
+
         let now = env.ledger().timestamp();
         let penalty = if now < vault.unlock_time {
-            (amount * EARLY_WITHDRAWAL_PENALTY_BPS as i128) / 10000
+            (amount * penalty_bps as i128) / 10000
         } else {
             0
         };
@@ -248,5 +257,17 @@ impl SavingsVaultContract {
             .get(&DataKey::Vault(user))
             .map(|v: Vault| v.unlock_time)
             .unwrap_or(0)
+    }
+
+    /// Returns the full vault state for a user, or a zero-valued Vault if none exists.
+    pub fn get_vault(env: Env, user: Address) -> Vault {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Vault(user))
+            .unwrap_or(Vault {
+                balance: 0,
+                unlock_time: 0,
+                last_accrue_time: 0,
+            })
     }
 }

--- a/contracts/savings-vault/src/test.rs
+++ b/contracts/savings-vault/src/test.rs
@@ -15,7 +15,7 @@ fn setup() -> (Env, SavingsVaultContractClient<'static>, Address, Address) {
     let client = SavingsVaultContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     let usdc_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
-    client.initialize(&admin, &usdc_id);
+    client.initialize(&admin, &usdc_id, &1000u32);
     (env, client, admin, usdc_id)
 }
 
@@ -34,7 +34,7 @@ fn test_initialize() {
 #[should_panic(expected = "Contract already initialized")]
 fn test_double_initialize() {
     let (_, client, admin, usdc_id) = setup();
-    client.initialize(&admin, &usdc_id);
+    client.initialize(&admin, &usdc_id, &1000u32);
 }
 
 #[test]
@@ -109,6 +109,55 @@ fn test_early_withdrawal_with_penalty() {
     assert_eq!(TokenClient::new(&env, &usdc_id).balance(&user), expected_withdrawal);
 }
 
+// ── #547: configurable penalty ────────────────────────────────────────────────
+
+#[test]
+fn test_configurable_penalty_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SavingsVaultContract);
+    let client = SavingsVaultContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let usdc_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    client.initialize(&admin, &usdc_id, &500u32); // 5% penalty
+
+    let user = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+    let unlock_time = env.ledger().timestamp() + 86400;
+
+    StellarAssetClient::new(&env, &usdc_id).mint(&user, &amount);
+    client.deposit(&user, &amount, &unlock_time);
+    client.withdraw(&user, &amount);
+
+    let expected_penalty = (amount * 500) / 10000;
+    let expected_withdrawal = amount - expected_penalty;
+
+    assert_eq!(TokenClient::new(&env, &usdc_id).balance(&user), expected_withdrawal);
+}
+
+#[test]
+fn test_zero_penalty_bps_no_penalty_on_early_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SavingsVaultContract);
+    let client = SavingsVaultContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let usdc_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    client.initialize(&admin, &usdc_id, &0u32); // 0% penalty
+
+    let user = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+    let unlock_time = env.ledger().timestamp() + 86400;
+
+    StellarAssetClient::new(&env, &usdc_id).mint(&user, &amount);
+    client.deposit(&user, &amount, &unlock_time);
+    client.withdraw(&user, &amount);
+
+    assert_eq!(TokenClient::new(&env, &usdc_id).balance(&user), amount);
+}
+
 #[test]
 #[should_panic(expected = "Insufficient balance")]
 fn test_withdraw_more_than_balance() {
@@ -132,6 +181,8 @@ fn test_withdraw_no_vault() {
     client.withdraw(&user, &1_000_0000000);
 }
 
+// ── #549: multi-deposit ───────────────────────────────────────────────────────
+
 #[test]
 fn test_multiple_deposits() {
     let (env, client, admin, usdc_id) = setup();
@@ -148,6 +199,49 @@ fn test_multiple_deposits() {
 
     assert_eq!(client.get_balance(&user), amount1 + amount2);
     assert_eq!(client.get_unlock_time(&user), unlock_time2);
+}
+
+#[test]
+fn test_second_deposit_with_earlier_unlock_preserves_later_time() {
+    let (env, client, admin, usdc_id) = setup();
+    let user = Address::generate(&env);
+    let amount1 = 500_0000000i128;
+    let amount2 = 300_0000000i128;
+    let unlock_time1 = env.ledger().timestamp() + 7200;
+    let unlock_time2 = env.ledger().timestamp() + 3600; // earlier than first
+
+    mint_usdc(&env, &usdc_id, &admin, &user, amount1 + amount2);
+
+    client.deposit(&user, &amount1, &unlock_time1);
+    client.deposit(&user, &amount2, &unlock_time2);
+
+    assert_eq!(client.get_balance(&user), amount1 + amount2);
+    assert_eq!(client.get_unlock_time(&user), unlock_time1); // original later time preserved
+}
+
+#[test]
+fn test_get_vault_returns_full_info() {
+    let (env, client, admin, usdc_id) = setup();
+    let user = Address::generate(&env);
+    let amount = 1_000_0000000i128;
+    let unlock_time = env.ledger().timestamp() + 86400;
+
+    mint_usdc(&env, &usdc_id, &admin, &user, amount);
+    client.deposit(&user, &amount, &unlock_time);
+
+    let vault = client.get_vault(&user);
+    assert_eq!(vault.balance, amount);
+    assert_eq!(vault.unlock_time, unlock_time);
+}
+
+#[test]
+fn test_get_vault_no_deposit_returns_zeros() {
+    let (_, client, _, _) = setup();
+    let user = Address::generate(&client.env());
+    let vault = client.get_vault(&user);
+    assert_eq!(vault.balance, 0);
+    assert_eq!(vault.unlock_time, 0);
+    assert_eq!(vault.last_accrue_time, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #547 closes #549 closes #550 closes #558

- **#547 — Configurable early-withdrawal penalty**: `savings-vault` `initialize` now accepts a `penalty_bps` parameter (e.g. `500` = 5%), replacing the hardcoded 10% constant. Each vault deployment can set its own penalty rate, stored in contract persistent storage.
- **#549 — Multi-deposit query**: deposits already accumulate balance and preserve the longer unlock time; added a `get_vault` function that returns the full `Vault` struct in one call, plus tests covering both unlock-time extension directions.
- **#550 — Recurring-payment pause/resume**: added `pause_recurring_payment` and `resume_recurring_payment` functions with a new `Paused` schedule status. Paused schedules cannot execute but retain their full schedule state. `cancel_recurring_payment` was updated to accept paused schedules (only rejects already-cancelled ones).
- **#558 — Full deploy script coverage**: `deploy.sh` now supports all nine contracts (`escrow`, `recurring-payments`, `savings-vault`, `fee-distributor`, `dispute-resolution`, `kyc-attestation`, `agent-escrow`, `multisig-approval`, `loyalty-token`). Step 6 (front-running prevention) is now contract-aware — each contract type calls `initialize` with its own required parameters and prints a copy-paste fallback command when env vars are missing.

## Changed files

| File | What changed |
|---|---|
| `contracts/savings-vault/src/lib.rs` | `penalty_bps` param in `initialize`, `PenaltyBps` storage key, `get_vault` query |
| `contracts/savings-vault/src/test.rs` | Updated `setup()`, added 6 new tests |
| `contracts/recurring-payments/src/lib.rs` | `Paused` status, `SchedulePaused`/`ScheduleResumed` events, `pause_recurring_payment`, `resume_recurring_payment`, updated `cancel_recurring_payment` |
| `contracts/recurring-payments/src/test.rs` | Fixed cancel error message, added 9 pause/resume tests |
| `contracts/deploy.sh` | 4 new contract cases, per-contract init logic in Step 6 |

## Test plan

- [ ] `contracts/savings-vault` — all existing tests pass; new penalty and multi-deposit tests pass
- [ ] `contracts/recurring-payments` — all existing tests pass; new pause/resume lifecycle tests pass
- [ ] `contracts/deploy.sh` — run `CONTRACT=savings-vault ./deploy.sh --network testnet` (and other new contracts) to verify build and init commands are correct
- [ ] Verify `penalty_bps=0` produces no early-withdrawal deduction
- [ ] Verify paused schedule is blocked from execution and resumes correctly