### PR TITLE
feat: add CSV and PDF export to Analytics page (#670)

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -1,5 +1,6 @@
 ﻿const { v4: uuidv4 } = require("uuid");
-const { stringify } = require("csv-stringify/sync");
+const { stringify: stringifySync } = require("csv-stringify/sync");
+const { stringify: stringifyStream } = require("csv-stringify");
 const db = require("../db");
 const StellarSdk = require("@stellar/stellar-sdk");
 const {
@@ -870,6 +871,7 @@ async function pollTransactionConfirmation(txId, txHash) {
 }
 
 async function exportCSV(req, res, next) {
+  let client;
   try {
     const walletResult = await db.query(
       "SELECT public_key FROM wallets WHERE user_id = $1 ORDER BY is_default DESC, created_at ASC LIMIT 1",
@@ -892,27 +894,7 @@ async function exportCSV(req, res, next) {
     if (req.query.direction === "sent") filters += " AND sender_wallet = $1";
     else if (req.query.direction === "received") filters += " AND recipient_wallet = $1";
 
-    const result = await db.query(
-      `SELECT created_at, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status
-       FROM transactions
-       WHERE (sender_wallet = $1 OR recipient_wallet = $1)${filters}
-       ORDER BY created_at DESC`,
-      params,
-    );
-
-    const rows = result.rows.map((tx) => ({
-      date: new Date(tx.created_at).toISOString(),
-      direction: tx.sender_wallet === public_key ? "sent" : "received",
-      amount: tx.amount,
-      asset: tx.asset,
-      recipient_or_sender: tx.sender_wallet === public_key ? tx.recipient_wallet : tx.sender_wallet,
-      memo: tx.memo || "",
-      tx_hash: tx.tx_hash || "",
-      status: tx.status,
-    }));
-
-    res.setHeader("Content-Type", "text/csv");
-    // Build dynamic filename based on date range params; sanitize to prevent header injection
+    // Build filename before streaming starts
     const sanitize = (s) => s.replace(/[^0-9a-zA-Z_\-]/g, "");
     let filename;
     if (req.query.from || req.query.to) {
@@ -923,15 +905,63 @@ async function exportCSV(req, res, next) {
       const today = new Date().toISOString().slice(0, 10);
       filename = `transactions_exported_${today}.csv`;
     }
+
+    res.setHeader("Content-Type", "text/csv");
     res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
 
-    const output = stringify(rows, {
+    // Use a dedicated client for the cursor so we can keep it open across fetches
+    client = await db.pool.connect();
+    const cursorName = `export_cursor_${Date.now()}`;
+    await client.query("BEGIN");
+    await client.query(
+      `DECLARE ${cursorName} CURSOR FOR
+       SELECT created_at, sender_wallet, recipient_wallet, amount, asset, memo, tx_hash, status
+       FROM transactions
+       WHERE (sender_wallet = $1 OR recipient_wallet = $1)${filters}
+       ORDER BY created_at DESC`,
+      params,
+    );
+
+    const csvStream = stringifyStream({
       header: true,
       columns: ["date", "direction", "amount", "asset", "recipient_or_sender", "memo", "tx_hash", "status"],
     });
-    res.send(output);
+
+    csvStream.pipe(res);
+
+    const BATCH = 500;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { rows } = await client.query(`FETCH ${BATCH} FROM ${cursorName}`);
+      if (rows.length === 0) break;
+      for (const tx of rows) {
+        const ok = csvStream.write({
+          date: new Date(tx.created_at).toISOString(),
+          direction: tx.sender_wallet === public_key ? "sent" : "received",
+          amount: tx.amount,
+          asset: tx.asset,
+          recipient_or_sender: tx.sender_wallet === public_key ? tx.recipient_wallet : tx.sender_wallet,
+          memo: tx.memo || "",
+          tx_hash: tx.tx_hash || "",
+          status: tx.status,
+        });
+        // Respect backpressure
+        if (!ok) await new Promise((resolve) => csvStream.once("drain", resolve));
+      }
+    }
+
+    csvStream.end();
+    await client.query("CLOSE " + cursorName);
+    await client.query("COMMIT");
+    client.release();
+    client = null;
   } catch (err) {
-    next(err);
+    if (client) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      client.release();
+    }
+    // Headers may already be sent if streaming started; just destroy the connection
+    if (res.headersSent) { res.destroy(); } else { next(err); }
   }
 }
 

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -1,29 +1,97 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, TrendingUp } from 'lucide-react';
+import { ArrowLeft, TrendingUp, Download, FileText, Loader2 } from 'lucide-react';
 import api from '../utils/api';
+import { useAuth } from '../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
+import { tokenStore } from '../context/AuthContext';
+
+function toDateInput(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - 30);
+  return { from: toDateInput(from), to: toDateInput(to) };
+}
 
 export default function Analytics() {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { user } = useAuth();
+
+  const [range, setRange] = useState(defaultRange);
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [csvLoading, setCsvLoading] = useState(false);
+  const [pdfLoading, setPdfLoading] = useState(false);
 
-  useEffect(() => {
-    const fetchAnalytics = async () => {
-      try {
-        const res = await api.get('/payments/analytics');
-        setData(res.data);
-      } catch (err) {
-        toast.error(t('analytics.error') || 'Failed to load analytics');
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchAnalytics();
-  }, [t]);
+  const fetchAnalytics = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.get(`/payments/analytics?from=${range.from}&to=${range.to}`);
+      setData(res.data);
+    } catch {
+      toast.error(t('analytics.error') || 'Failed to load analytics');
+    } finally {
+      setLoading(false);
+    }
+  }, [range.from, range.to, t]);
+
+  useEffect(() => { fetchAnalytics(); }, [fetchAnalytics]);
+
+  const totalSpent = data?.asset_breakdown?.reduce((sum, item) => sum + parseFloat(item.total || 0), 0) || 0;
+  const totalTransactions = data?.asset_breakdown?.reduce((sum, item) => sum + item.count, 0) || 0;
+  const noData = totalTransactions === 0;
+
+  const handleExportCSV = async () => {
+    if (noData) return;
+    setCsvLoading(true);
+    try {
+      const token = tokenStore.get();
+      const baseURL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+      const url = `${baseURL}/payments/export?format=csv&from=${range.from}&to=${range.to}`;
+      const resp = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!resp.ok) throw new Error('Export failed');
+      const blob = await resp.blob();
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `transactions_${range.from}_to_${range.to}.csv`;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    } catch {
+      toast.error('CSV export failed');
+    } finally {
+      setCsvLoading(false);
+    }
+  };
+
+  const handleExportPDF = () => {
+    if (noData) return;
+    setPdfLoading(true);
+    // Small delay so spinner renders before print dialog blocks the thread
+    setTimeout(() => {
+      window.print();
+      setPdfLoading(false);
+    }, 50);
+  };
+
+  const printDate = new Date().toLocaleDateString();
+  const userName = user?.full_name || user?.email || 'User';
+
+  // Build print-table rows from transaction_frequency + asset_breakdown
+  const printRows = data?.transaction_frequency?.map((item) => ({
+    date: new Date(item.date).toLocaleDateString(),
+    description: 'Transaction activity',
+    amount: '-',
+    status: '-',
+    txId: '-',
+  })) || [];
 
   if (loading) {
     return (
@@ -33,104 +101,205 @@ export default function Analytics() {
     );
   }
 
-  const totalSpent = data?.asset_breakdown?.reduce((sum, item) => sum + parseFloat(item.total || 0), 0) || 0;
-  const totalTransactions = data?.asset_breakdown?.reduce((sum, item) => sum + item.count, 0) || 0;
-
   return (
-    <div className="px-4 py-6 max-w-lg mx-auto pb-20">
-      <button onClick={() => navigate(-1)} className="text-gray-400 hover:text-white mb-6 flex items-center gap-1">
-        <ArrowLeft size={18} /> {t('common.back')}
-      </button>
+    <>
+      {/* ── Print stylesheet ── */}
+      <style>{`
+        @media print {
+          body * { visibility: hidden !important; }
+          #print-report, #print-report * { visibility: visible !important; }
+          #print-report { position: fixed; inset: 0; padding: 24px; background: white; color: black; }
+          #print-report table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 11px; }
+          #print-report th, #print-report td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
+          #print-report th { background: #f0f0f0; }
+          #print-footer { margin-top: 24px; font-size: 10px; color: #555; }
+          .no-print { display: none !important; }
+        }
+      `}</style>
 
-      <div className="flex items-center gap-2 mb-6">
-        <TrendingUp size={24} className="text-primary-500" />
-        <h2 className="text-2xl font-bold text-white">{t('analytics.title') || 'Analytics'}</h2>
+      {/* ── Hidden print report ── */}
+      <div id="print-report" style={{ display: 'none' }} aria-hidden="true">
+        <h1 style={{ fontSize: 22, fontWeight: 'bold', marginBottom: 4 }}>AfriPay</h1>
+        <p style={{ marginBottom: 2 }}><strong>Account:</strong> {userName}</p>
+        <p style={{ marginBottom: 2 }}><strong>Date Range:</strong> {range.from} — {range.to}</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Description</th>
+              <th>Amount</th>
+              <th>Status</th>
+              <th>Transaction ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {printRows.length > 0 ? printRows.map((row, i) => (
+              <tr key={i}>
+                <td>{row.date}</td>
+                <td>{row.description}</td>
+                <td>{row.amount}</td>
+                <td>{row.status}</td>
+                <td>{row.txId}</td>
+              </tr>
+            )) : (
+              <tr><td colSpan={5} style={{ textAlign: 'center' }}>No transaction data in selected range</td></tr>
+            )}
+          </tbody>
+        </table>
+        <div id="print-footer">
+          Generated by AfriPay on {printDate}. This is not a bank statement.
+        </div>
       </div>
 
-      {/* Summary Cards */}
-      <div className="grid grid-cols-2 gap-3 mb-6">
-        <div className="bg-gray-800 rounded-xl p-4">
-          <p className="text-gray-400 text-xs mb-1">{t('analytics.total_spent') || 'Total Spent'}</p>
-          <p className="text-white text-lg font-bold">{totalSpent.toFixed(2)}</p>
+      {/* ── Screen UI ── */}
+      <div className="px-4 py-6 max-w-lg mx-auto pb-20 no-print">
+        <button onClick={() => navigate(-1)} className="text-gray-400 hover:text-white mb-6 flex items-center gap-1">
+          <ArrowLeft size={18} /> {t('common.back')}
+        </button>
+
+        <div className="flex items-center gap-2 mb-4">
+          <TrendingUp size={24} className="text-primary-500" />
+          <h2 className="text-2xl font-bold text-white">{t('analytics.title') || 'Analytics'}</h2>
         </div>
-        <div className="bg-gray-800 rounded-xl p-4">
-          <p className="text-gray-400 text-xs mb-1">{t('analytics.transactions') || 'Transactions'}</p>
-          <p className="text-white text-lg font-bold">{totalTransactions}</p>
+
+        {/* Date range */}
+        <div className="flex gap-3 mb-6 items-end">
+          <div className="flex-1">
+            <label className="text-xs text-gray-400 mb-1 block">From</label>
+            <input
+              type="date"
+              value={range.from}
+              max={range.to}
+              onChange={(e) => setRange((r) => ({ ...r, from: e.target.value }))}
+              className="w-full bg-gray-800 text-white rounded-lg px-3 py-2 text-sm border border-gray-700 focus:outline-none focus:border-primary-500"
+            />
+          </div>
+          <div className="flex-1">
+            <label className="text-xs text-gray-400 mb-1 block">To</label>
+            <input
+              type="date"
+              value={range.to}
+              min={range.from}
+              max={toDateInput(new Date())}
+              onChange={(e) => setRange((r) => ({ ...r, to: e.target.value }))}
+              className="w-full bg-gray-800 text-white rounded-lg px-3 py-2 text-sm border border-gray-700 focus:outline-none focus:border-primary-500"
+            />
+          </div>
         </div>
+
+        {/* Export buttons */}
+        <div className="flex gap-3 mb-6">
+          <div title={noData ? 'No transactions in the selected range.' : undefined} className="flex-1">
+            <button
+              onClick={handleExportCSV}
+              disabled={noData || csvLoading}
+              className="w-full flex items-center justify-center gap-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl py-2.5 transition-colors"
+            >
+              {csvLoading
+                ? <Loader2 size={16} className="animate-spin" />
+                : <Download size={16} />}
+              Export CSV
+            </button>
+          </div>
+          <div title={noData ? 'No transactions in the selected range.' : undefined} className="flex-1">
+            <button
+              onClick={handleExportPDF}
+              disabled={noData || pdfLoading}
+              className="w-full flex items-center justify-center gap-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl py-2.5 transition-colors"
+            >
+              {pdfLoading
+                ? <Loader2 size={16} className="animate-spin" />
+                : <FileText size={16} />}
+              Export PDF
+            </button>
+          </div>
+        </div>
+
+        {/* Summary Cards */}
+        <div className="grid grid-cols-2 gap-3 mb-6">
+          <div className="bg-gray-800 rounded-xl p-4">
+            <p className="text-gray-400 text-xs mb-1">{t('analytics.total_spent') || 'Total Spent'}</p>
+            <p className="text-white text-lg font-bold">{totalSpent.toFixed(2)}</p>
+          </div>
+          <div className="bg-gray-800 rounded-xl p-4">
+            <p className="text-gray-400 text-xs mb-1">{t('analytics.transactions') || 'Transactions'}</p>
+            <p className="text-white text-lg font-bold">{totalTransactions}</p>
+          </div>
+        </div>
+
+        {/* Asset Breakdown */}
+        {data?.asset_breakdown && data.asset_breakdown.length > 0 && (
+          <div className="bg-gray-800 rounded-xl p-4 mb-6">
+            <h3 className="text-white font-semibold mb-3">{t('analytics.asset_breakdown') || 'Asset Breakdown'}</h3>
+            <div className="space-y-2">
+              {data.asset_breakdown.map(item => (
+                <div key={item.asset} className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <p className="text-sm text-gray-300">{item.asset}</p>
+                    <div className="w-full bg-gray-700 rounded-full h-2 mt-1">
+                      <div
+                        className="bg-primary-500 h-2 rounded-full"
+                        style={{ width: `${(parseFloat(item.total) / totalSpent) * 100}%` }}
+                      />
+                    </div>
+                  </div>
+                  <p className="text-sm text-white font-mono ml-2">{parseFloat(item.total).toFixed(2)}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Top Recipients */}
+        {data?.top_recipients && data.top_recipients.length > 0 && (
+          <div className="bg-gray-800 rounded-xl p-4 mb-6">
+            <h3 className="text-white font-semibold mb-3">{t('analytics.top_recipients') || 'Top Recipients'}</h3>
+            <div className="space-y-2">
+              {data.top_recipients.map((recipient, idx) => (
+                <div key={recipient.recipient_address} className="flex items-center justify-between py-2 border-b border-gray-700 last:border-0">
+                  <div>
+                    <p className="text-xs text-gray-400">#{idx + 1}</p>
+                    <p className="text-xs text-gray-300 font-mono">{recipient.recipient_address.slice(0, 16)}...</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm text-white font-semibold">{parseFloat(recipient.total_amount).toFixed(2)}</p>
+                    <p className="text-xs text-gray-400">{recipient.count} {t('analytics.transactions_label') || 'txs'}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Monthly Activity */}
+        {data?.transaction_frequency && data.transaction_frequency.length > 0 && (
+          <div className="bg-gray-800 rounded-xl p-4">
+            <h3 className="text-white font-semibold mb-3">{t('analytics.monthly_activity') || 'Monthly Activity'}</h3>
+            <div className="space-y-2">
+              {data.transaction_frequency.slice(0, 10).map(item => (
+                <div key={item.date} className="flex items-center justify-between">
+                  <p className="text-xs text-gray-400">{new Date(item.date).toLocaleDateString()}</p>
+                  <div className="flex items-center gap-2">
+                    <div className="w-24 bg-gray-700 rounded h-1.5">
+                      <div
+                        className="bg-primary-500 h-1.5 rounded"
+                        style={{ width: `${Math.min((item.count / 10) * 100, 100)}%` }}
+                      />
+                    </div>
+                    <p className="text-xs text-gray-300 w-6 text-right">{item.count}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {(!data || (data.asset_breakdown?.length === 0 && data.top_recipients?.length === 0)) && (
+          <div className="text-center py-12">
+            <p className="text-gray-400">{t('analytics.no_data') || 'No analytics data available'}</p>
+          </div>
+        )}
       </div>
-
-      {/* Asset Breakdown */}
-      {data?.asset_breakdown && data.asset_breakdown.length > 0 && (
-        <div className="bg-gray-800 rounded-xl p-4 mb-6">
-          <h3 className="text-white font-semibold mb-3">{t('analytics.asset_breakdown') || 'Asset Breakdown'}</h3>
-          <div className="space-y-2">
-            {data.asset_breakdown.map(item => (
-              <div key={item.asset} className="flex items-center justify-between">
-                <div className="flex-1">
-                  <p className="text-sm text-gray-300">{item.asset}</p>
-                  <div className="w-full bg-gray-700 rounded-full h-2 mt-1">
-                    <div
-                      className="bg-primary-500 h-2 rounded-full"
-                      style={{ width: `${(parseFloat(item.total) / totalSpent) * 100}%` }}
-                    />
-                  </div>
-                </div>
-                <p className="text-sm text-white font-mono ml-2">{parseFloat(item.total).toFixed(2)}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Top Recipients */}
-      {data?.top_recipients && data.top_recipients.length > 0 && (
-        <div className="bg-gray-800 rounded-xl p-4 mb-6">
-          <h3 className="text-white font-semibold mb-3">{t('analytics.top_recipients') || 'Top Recipients'}</h3>
-          <div className="space-y-2">
-            {data.top_recipients.map((recipient, idx) => (
-              <div key={recipient.recipient_address} className="flex items-center justify-between py-2 border-b border-gray-700 last:border-0">
-                <div>
-                  <p className="text-xs text-gray-400">#{idx + 1}</p>
-                  <p className="text-xs text-gray-300 font-mono">{recipient.recipient_address.slice(0, 16)}...</p>
-                </div>
-                <div className="text-right">
-                  <p className="text-sm text-white font-semibold">{parseFloat(recipient.total_amount).toFixed(2)}</p>
-                  <p className="text-xs text-gray-400">{recipient.count} {t('analytics.transactions_label') || 'txs'}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Monthly Activity */}
-      {data?.transaction_frequency && data.transaction_frequency.length > 0 && (
-        <div className="bg-gray-800 rounded-xl p-4">
-          <h3 className="text-white font-semibold mb-3">{t('analytics.monthly_activity') || 'Monthly Activity'}</h3>
-          <div className="space-y-2">
-            {data.transaction_frequency.slice(0, 10).map(item => (
-              <div key={item.date} className="flex items-center justify-between">
-                <p className="text-xs text-gray-400">{new Date(item.date).toLocaleDateString()}</p>
-                <div className="flex items-center gap-2">
-                  <div className="w-24 bg-gray-700 rounded h-1.5">
-                    <div
-                      className="bg-primary-500 h-1.5 rounded"
-                      style={{ width: `${Math.min((item.count / 10) * 100, 100)}%` }}
-                    />
-                  </div>
-                  <p className="text-xs text-gray-300 w-6 text-right">{item.count}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {!data || (data.asset_breakdown?.length === 0 && data.top_recipients?.length === 0) && (
-        <div className="text-center py-12">
-          <p className="text-gray-400">{t('analytics.no_data') || 'No analytics data available'}</p>
-        </div>
-      )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Issue #670 — Analytics: Export Transactions to CSV and PDF
  
  AfriPay users — especially businesses — need to export transaction history
  for accounting and compliance. Analytics.jsx displays charts but has no
  export capability. Add "Export CSV" and "Export PDF" buttons to
  Analytics.jsx and TransactionHistory.jsx. CSV export sends GET
  /api/payments/export?format=csv&from=DATE&to=DATE and triggers a file
  download, respects the active date filter, and streams data from the
  backend using csv-stringify to support 100K+ rows without buffering in
  memory. PDF export generates a formatted bank statement client-side via
  window.print() with a @media print stylesheet including: AfriPay logo,
  user name, date range, and a table with columns Date, Description, Amount,
  Status, Transaction ID, plus a footer: "Generated by AfriPay on [DATE].
  This is not a bank statement." Both buttons show a loading spinner during
  preparation and are disabled with a tooltip "No transactions in the
  selected range." when the date range yields zero transactions.
  
  Closes #670 