### PR TITLE
feat: add push notification pre-prompt flow (#671)

### DIFF
--- a/frontend/src/components/PushNotificationPrompt.jsx
+++ b/frontend/src/components/PushNotificationPrompt.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import api from '../utils/api';
+
+const VAPID_PUBLIC_KEY = process.env.REACT_APP_VAPID_PUBLIC_KEY;
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
+}
+
+export default function PushNotificationPrompt({ onDismiss }) {
+  const permission = typeof Notification !== 'undefined' ? Notification.permission : 'default';
+
+  const handleNotNow = () => {
+    localStorage.setItem('notifications_deferred', Date.now().toString());
+    onDismiss();
+  };
+
+  const handleEnable = async () => {
+    const result = await Notification.requestPermission();
+    if (result === 'granted' && 'serviceWorker' in navigator && VAPID_PUBLIC_KEY) {
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+        });
+        await api.post('/notifications/subscribe', { subscription: sub.toJSON() });
+      } catch (err) {
+        console.error('Push subscribe failed', err);
+      }
+    }
+    onDismiss();
+  };
+
+  return (
+    <>
+      <style>{`
+        @keyframes slideUp {
+          from { transform: translateY(100%); opacity: 0; }
+          to { transform: translateY(0); opacity: 1; }
+        }
+        .push-prompt { animation: slideUp 0.3s ease-out; }
+      `}</style>
+      <div
+        className="push-prompt fixed bottom-0 left-0 right-0 z-50 p-4 pb-safe"
+        style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
+      >
+        <div className="bg-gray-900 border border-gray-700 rounded-2xl p-5 max-w-lg mx-auto shadow-2xl">
+          {permission === 'denied' ? (
+            <p className="text-sm text-gray-300">
+              Enable notifications in your browser settings to get payment alerts.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-gray-200 mb-4">
+                Get notified when your payments are confirmed. Enable notifications?
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={handleEnable}
+                  className="flex-1 bg-primary-600 hover:bg-primary-700 text-white text-sm font-semibold py-2.5 rounded-xl transition-colors"
+                >
+                  Enable
+                </button>
+                <button
+                  onClick={handleNotNow}
+                  className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm font-medium py-2.5 rounded-xl transition-colors"
+                >
+                  Not now
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/hooks/usePushNotifications.js
+++ b/frontend/src/hooks/usePushNotifications.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import api from '../utils/api';
 
 const VAPID_PUBLIC_KEY = process.env.REACT_APP_VAPID_PUBLIC_KEY;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 function urlBase64ToUint8Array(base64String) {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -14,12 +15,15 @@ export function usePushNotifications() {
   const [supported, setSupported] = useState(false);
   const [subscribed, setSubscribed] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [permissionStatus, setPermissionStatus] = useState(
+    typeof Notification !== 'undefined' ? Notification.permission : 'default'
+  );
 
   useEffect(() => {
     setSupported('serviceWorker' in navigator && 'PushManager' in window);
   }, []);
 
-  // Register SW and check existing subscription on mount
+  // Register SW and check existing subscription on mount (no auto-subscribe)
   useEffect(() => {
     if (!supported) return;
     navigator.serviceWorker
@@ -28,6 +32,13 @@ export function usePushNotifications() {
       .then((sub) => setSubscribed(!!sub))
       .catch(() => {});
   }, [supported]);
+
+  const shouldShowPrompt = useCallback(() => {
+    if (permissionStatus !== 'default') return false;
+    const deferred = localStorage.getItem('notifications_deferred');
+    if (!deferred) return true;
+    return Date.now() - parseInt(deferred, 10) > SEVEN_DAYS_MS;
+  }, [permissionStatus]);
 
   const subscribe = useCallback(async () => {
     if (!supported || !VAPID_PUBLIC_KEY) return;
@@ -40,6 +51,7 @@ export function usePushNotifications() {
       });
       await api.post('/notifications/subscribe', { subscription: sub.toJSON() });
       setSubscribed(true);
+      setPermissionStatus(Notification.permission);
     } catch (err) {
       console.error('Push subscribe failed', err);
     } finally {
@@ -63,5 +75,5 @@ export function usePushNotifications() {
     }
   }, [supported]);
 
-  return { supported, subscribed, loading, subscribe, unsubscribe };
+  return { supported, subscribed, loading, subscribe, unsubscribe, permissionStatus, shouldShowPrompt };
 }

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1490,6 +1490,43 @@ export default function Profile() {
         </div>
       </div>
 
+      {/* Notification Preferences */}
+      {'serviceWorker' in navigator && 'PushManager' in window && (() => {
+        const PREFS_KEY = 'afripay_notification_prefs';
+        const defaultPrefs = { payment_confirmed: true, payment_received: true, kyc_approved: true };
+        let prefs;
+        try { prefs = { ...defaultPrefs, ...JSON.parse(localStorage.getItem(PREFS_KEY) || '{}') }; }
+        catch { prefs = defaultPrefs; }
+        const savePrefs = (key, value) => {
+          const updated = { ...prefs, [key]: value };
+          localStorage.setItem(PREFS_KEY, JSON.stringify(updated));
+        };
+        const NotifToggle = ({ label, prefKey }) => {
+          const [on, setOn] = React.useState(prefs[prefKey]);
+          return (
+            <div className="flex items-center justify-between py-2">
+              <span className="text-sm text-gray-300">{label}</span>
+              <button
+                role="switch"
+                aria-checked={on}
+                onClick={() => { const next = !on; setOn(next); savePrefs(prefKey, next); }}
+                className={`relative w-10 h-6 rounded-full transition-colors ${on ? 'bg-primary-600' : 'bg-gray-700'}`}
+              >
+                <span className={`absolute top-1 w-4 h-4 bg-white rounded-full transition-transform ${on ? 'translate-x-5' : 'translate-x-1'}`} />
+              </button>
+            </div>
+          );
+        };
+        return (
+          <div className="bg-gray-900 rounded-2xl p-5">
+            <h3 className="font-semibold text-white mb-3">Notification Preferences</h3>
+            <NotifToggle label="Payment confirmed" prefKey="payment_confirmed" />
+            <NotifToggle label="Payment received" prefKey="payment_received" />
+            <NotifToggle label="KYC approved" prefKey="kyc_approved" />
+          </div>
+        );
+      })()}
+
       {/* Close Account */}
       <div className="bg-gray-900 rounded-2xl p-5">
         <div className="flex items-center justify-between mb-1">

--- a/frontend/src/pages/SendMoney.jsx
+++ b/frontend/src/pages/SendMoney.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useMemoValidation } from '../hooks/useMemoValidation';
-import { useNavigate, useSearchParams, useBeforeUnload } from 'react-router-dom';
+import { useNavigate, useSearchParams, useBeforeUnload, Link } from 'react-router-dom';
 import {
   ArrowLeft,
   Send,
@@ -12,6 +12,7 @@ import {
   Wallet,
   AlertTriangle,
   CheckCircle,
+  BookUser,
 } from 'lucide-react';
 import api from '../utils/api';
 import { useExchangeRates } from '../hooks/useExchangeRates';
@@ -22,6 +23,8 @@ import QRScanner from '../components/QRScanner';
 import PINVerificationModal from '../components/PINVerificationModal';
 import XDRInspectorModal from '../components/XDRInspectorModal';
 import LedgerSignModal from '../components/LedgerSignModal';
+import PushNotificationPrompt from '../components/PushNotificationPrompt';
+import { usePushNotifications } from '../hooks/usePushNotifications';
 
 const SLIPPAGE_OPTIONS = [0.5, 1, 2];
 const DEFAULT_SLIPPAGE = 1;
@@ -57,6 +60,10 @@ export default function SendMoney() {
   const [selectedContactIndex, setSelectedContactIndex] = useState(-1);
   const contactSearchRef = useRef(null);
   const contactListRef = useRef(null);
+  const [selectedContactName, setSelectedContactName] = useState('');
+  const [showSaveContactPrompt, setShowSaveContactPrompt] = useState(null); // address string or null
+  const [saveContactName, setSaveContactName] = useState('');
+  const [saveContactLoading, setSaveContactLoading] = useState(false);
   const [showScanner, setShowScanner] = useState(false);
   const [showPINVerification, setShowPINVerification] = useState(false);
   const [showXDRInspector, setShowXDRInspector] = useState(false);
@@ -72,6 +79,8 @@ export default function SendMoney() {
   const [contractSimLoading, setContractSimLoading] = useState(false);
   const [requestId] = useState(searchParams.get('request'));
   const [keyboardOpen, setKeyboardOpen] = useState(false);
+  const [showPushPrompt, setShowPushPrompt] = useState(false);
+  const { shouldShowPrompt } = usePushNotifications();
 
   // Pre-fill form from payment request when only requestId is in the URL
   useEffect(() => {
@@ -706,8 +715,18 @@ export default function SendMoney() {
       }
 
       toast.success(t('send.success'));
+      const count = parseInt(localStorage.getItem('afripay_payment_count') || '0', 10) + 1;
+      localStorage.setItem('afripay_payment_count', count.toString());
+      if (count === 1 && shouldShowPrompt()) setShowPushPrompt(true);
+      const recipientAddr = form.recipient_address;
+      const isKnown = contacts.some((c) => c.wallet_address === recipientAddr);
       resetForm();
-      navigate('/dashboard');
+      if (!isKnown && recipientAddr.startsWith('G') && recipientAddr.length === 56) {
+        setShowSaveContactPrompt(recipientAddr);
+        setSaveContactName('');
+      } else {
+        navigate('/dashboard');
+      }
     } catch (err) {
       if (err.response?.data?.code === 'MEMO_REQUIRED') {
         setMemoError(true);
@@ -834,15 +853,15 @@ export default function SendMoney() {
               >
                 <Camera size={16} />
               </button>
-              {contacts.length > 0 && (
-                <button
+              <button
                   type="button"
                   onClick={() => setShowContacts(!showContacts)}
-                  className="text-primary-500 text-xs flex items-center gap-1"
+                  className="text-primary-500 hover:text-primary-400 p-1.5 rounded-lg hover:bg-primary-500/10 transition-colors"
+                  title="Contacts"
+                  aria-label="Open contact picker"
                 >
-                  <Users size={12} /> {t('send.contacts')}
+                  <BookUser size={16} />
                 </button>
-              )}
             </div>
           </div>
           <input
@@ -854,6 +873,7 @@ export default function SendMoney() {
               setForm({ ...form, recipient_address: e.target.value });
               setMemoRequired(false);
               setAddressError(false);
+              setSelectedContactName('');
             }}
             onBlur={(e) => {
               const val = e.target.value.trim();
@@ -881,10 +901,15 @@ export default function SendMoney() {
                 <CheckCircle size={12} aria-hidden="true" /> Valid address
               </p>
             )}
-          {showContacts && contacts.length > 0 && (
+          {selectedContactName && (
+            <p className="mt-1 text-xs text-primary-400 font-medium">
+              Sending to: {selectedContactName}
+            </p>
+          )}
+          {showContacts && (
             <div
               ref={contactsDropdownRef}
-              className="mt-1 bg-gray-800 border border-gray-700 rounded-xl overflow-hidden"
+              className="mt-1 bg-gray-800 border border-gray-700 rounded-xl overflow-hidden shadow-lg"
               onKeyDown={handleContactKeyDown}
             >
               {/* Search input */}
@@ -902,33 +927,51 @@ export default function SendMoney() {
 
               {/* Contact list */}
               <div ref={contactListRef} className="max-h-60 overflow-y-auto">
-                {filteredContacts.length > 0 ? (
-                  filteredContacts.map((c, index) => (
-                    <button
-                      key={c.id}
-                      type="button"
-                      onClick={() => {
-                        setForm({
-                          ...form,
-                          recipient_address: c.wallet_address,
-                          memo: c.default_memo || form.memo,
-                        });
-                        if (c.memo_required) setMemoRequired(true);
-                        setShowContacts(false);
-                        setContactSearch('');
-                      }}
-                      className={`w-full px-4 py-2.5 text-left transition-colors ${
-                        index === selectedContactIndex
-                          ? 'bg-primary-500/20 text-primary-400'
-                          : 'hover:bg-gray-700'
-                      }`}
-                    >
-                      <p className="text-sm text-white">{c.name}</p>
-                      <p className="text-xs text-gray-500 font-mono">
-                        {c.wallet_address.slice(0, 20)}...
-                      </p>
-                    </button>
-                  ))
+                {contacts.length === 0 ? (
+                  <div className="px-4 py-6 text-center text-gray-400">
+                    <p className="text-sm mb-1">No contacts saved yet.</p>
+                    <Link to="/profile" className="text-xs text-primary-400 hover:underline" onClick={() => setShowContacts(false)}>
+                      Save a contact
+                    </Link>
+                  </div>
+                ) : filteredContacts.length > 0 ? (
+                  filteredContacts.map((c, index) => {
+                    const initials = c.name ? c.name.charAt(0).toUpperCase() : '?';
+                    const avatarColors = ['bg-purple-500', 'bg-blue-500', 'bg-green-500', 'bg-yellow-500', 'bg-pink-500'];
+                    const avatarColor = avatarColors[(c.name || '').charCodeAt(0) % avatarColors.length];
+                    return (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={() => {
+                          setForm({
+                            ...form,
+                            recipient_address: c.wallet_address,
+                            memo: c.default_memo || form.memo,
+                          });
+                          setSelectedContactName(c.name);
+                          if (c.memo_required) setMemoRequired(true);
+                          setShowContacts(false);
+                          setContactSearch('');
+                        }}
+                        className={`w-full px-4 py-2.5 text-left flex items-center gap-3 transition-colors ${
+                          index === selectedContactIndex
+                            ? 'bg-primary-500/20 text-primary-400'
+                            : 'hover:bg-gray-700'
+                        }`}
+                      >
+                        <div className={`w-8 h-8 rounded-full ${avatarColor} flex items-center justify-center text-white text-sm font-bold flex-shrink-0`}>
+                          {initials}
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-sm text-white font-medium">{c.name}</p>
+                          <p className="text-xs text-gray-500 font-mono truncate">
+                            {c.wallet_address.slice(0, 12)}…{c.wallet_address.slice(-6)}
+                          </p>
+                        </div>
+                      </button>
+                    );
+                  })
                 ) : (
                   <div className="px-4 py-6 text-center text-gray-400">
                     <p className="text-sm">No contacts match</p>
@@ -1613,6 +1656,60 @@ export default function SendMoney() {
         onClose={() => setShowXDRInspector(false)}
         xdr={transactionXDR}
       />
+
+      {showPushPrompt && (
+        <PushNotificationPrompt onDismiss={() => setShowPushPrompt(false)} />
+      )}
+
+      {/* Save contact prompt after successful payment */}
+      {showSaveContactPrompt && (
+        <div className="fixed inset-0 bg-black/60 flex items-end sm:items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-2xl w-full max-w-sm p-6">
+            <h3 className="text-white font-semibold text-base mb-1">Save as a contact?</h3>
+            <p className="text-gray-400 text-xs font-mono mb-4 break-all">
+              {showSaveContactPrompt.slice(0, 16)}…{showSaveContactPrompt.slice(-8)}
+            </p>
+            <input
+              type="text"
+              placeholder="Contact name"
+              value={saveContactName}
+              onChange={(e) => setSaveContactName(e.target.value)}
+              className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-2.5 text-white text-sm placeholder-gray-500 focus:outline-none focus:border-primary-500 mb-4"
+              autoFocus
+            />
+            <div className="flex gap-3">
+              <button
+                type="button"
+                disabled={saveContactLoading}
+                onClick={async () => {
+                  if (!saveContactName.trim()) return;
+                  setSaveContactLoading(true);
+                  try {
+                    await api.post('/wallet/contacts', { name: saveContactName.trim(), wallet_address: showSaveContactPrompt });
+                    toast.success('Contact saved!');
+                  } catch {
+                    toast.error('Could not save contact');
+                  } finally {
+                    setSaveContactLoading(false);
+                    setShowSaveContactPrompt(null);
+                    navigate('/dashboard');
+                  }
+                }}
+                className="flex-1 bg-primary-500 hover:bg-primary-400 disabled:opacity-50 text-white font-semibold py-2.5 rounded-xl text-sm transition-colors"
+              >
+                {saveContactLoading ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowSaveContactPrompt(null); navigate('/dashboard'); }}
+                className="flex-1 bg-gray-700 hover:bg-gray-600 text-white font-semibold py-2.5 rounded-xl text-sm transition-colors"
+              >
+                Skip
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Issue #671 — Notifications: Push Notification Permission Request Flow
  
  AfriPay has a webpush.js backend service and a serviceWorker.js on the
  frontend, but the browser's native permission prompt fires immediately on
  login — a pattern that causes nearly all users to deny it. Replace the
  immediate prompt with an in-app pre-prompt shown only after the user's
  first successful payment. The card slides in from the bottom: "Get
  notified when your payments are confirmed. Enable notifications?" with
  "Enable" and "Not now" buttons. "Enable" calls
  Notification.requestPermission(); on grant, the service worker registers a
  push subscription and POSTs it to POST /api/notifications/subscribe. "Not
  now" dismisses the card and stores a notifications_deferred flag in
  localStorage; the prompt re-appears after 7 days. The native prompt must
  never fire on app load or login. If permission is already granted, the
  card is never shown. If permission is permanently denied, display a hint:
  "Enable notifications in your browser settings to get payment alerts."
  Notification preferences (payment confirmed, payment received, KYC
  approved) are toggled per-type in Profile.jsx.
  
  Closes #671 
  Closes #672 