### PR TITLE
feat: configurable fraud rules, SEP-10 refresh, bulk user mgmt, push …

### DIFF
--- a/backend/src/__tests__/fraudRuleEngine.test.js
+++ b/backend/src/__tests__/fraudRuleEngine.test.js
@@ -1,0 +1,254 @@
+'use strict';
+
+jest.mock('../db');
+jest.mock('../utils/cache');
+
+const db = require('../db');
+const cache = require('../utils/cache');
+
+// fraudDetection must be required AFTER mocks are set up
+const fraudDetection = require('../services/fraudDetection');
+const { checkFraud, checkVelocity, checkDailyLimit, loadRules } = fraudDetection;
+
+const WALLET = 'GCSEQ5XE5YYKPITLT63FZ7LCW2JZNYVP3L2XKMGELRKGPNZXNNBVPOU3';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  cache.get.mockResolvedValue(null); // no cached rules by default
+  cache.set.mockResolvedValue(undefined);
+  cache.del.mockResolvedValue(undefined);
+  // Default: insert to fraud_checks succeeds
+  db.query.mockResolvedValue({ rows: [] });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function mockRules(rules) {
+  cache.get.mockResolvedValueOnce(rules);
+}
+
+// ---------------------------------------------------------------------------
+// Velocity rule
+// ---------------------------------------------------------------------------
+describe('checkFraud — velocity rule', () => {
+  const velocityRule = [{ name: 'test_velocity', rule_type: 'velocity', parameters: { max_transactions: 5, window_minutes: 10 } }];
+
+  test('passes when count is below threshold', async () => {
+    mockRules(velocityRule);
+    db.query.mockResolvedValueOnce({ rows: [{ count: '4' }] });
+    db.query.mockResolvedValue({ rows: [] }); // fraud_checks insert
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+
+  test('blocks when count exactly meets threshold', async () => {
+    mockRules(velocityRule);
+    db.query.mockResolvedValueOnce({ rows: [{ count: '5' }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(true);
+    expect(result.rule).toBe('test_velocity');
+    expect(result.message).toMatch(/5 transactions in 10 minutes/);
+  });
+
+  test('blocks when count exceeds threshold', async () => {
+    mockRules(velocityRule);
+    db.query.mockResolvedValueOnce({ rows: [{ count: '10' }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(true);
+  });
+
+  test('passes when count is 0 (no prior transactions)', async () => {
+    mockRules(velocityRule);
+    db.query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Amount rule
+// ---------------------------------------------------------------------------
+describe('checkFraud — amount rule', () => {
+  const amountRule = [{ name: 'test_amount', rule_type: 'amount', parameters: { max_usd: 10000 } }];
+
+  test('passes when USDC amount is exactly at limit', async () => {
+    mockRules(amountRule);
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '10000', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+
+  test('blocks when USDC amount exceeds limit', async () => {
+    mockRules(amountRule);
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '10000.01', 'USDC');
+    expect(result.blocked).toBe(true);
+    expect(result.rule).toBe('test_amount');
+  });
+
+  test('converts XLM to USD correctly (XLM_USD_RATE=0.10)', async () => {
+    process.env.XLM_USD_RATE = '0.10';
+    mockRules(amountRule);
+    db.query.mockResolvedValue({ rows: [] });
+    // 100001 XLM * 0.10 = $10000.10 → exceeds $10000
+    const result = await checkFraud(WALLET, '100001', 'XLM');
+    expect(result.blocked).toBe(true);
+  });
+
+  test('unknown asset treated as $0 — never blocked', async () => {
+    mockRules(amountRule);
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '999999', 'DOGE');
+    expect(result.blocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily limit rule
+// ---------------------------------------------------------------------------
+describe('checkFraud — daily_limit rule', () => {
+  const dailyRule = [{ name: 'test_daily', rule_type: 'daily_limit', parameters: { max_usd: 1000 } }];
+
+  test('passes when total is below limit', async () => {
+    mockRules(dailyRule);
+    db.query.mockResolvedValueOnce({ rows: [{ total: '800' }] }); // already sent $800 USDC
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+
+  test('passes when total exactly equals limit (boundary)', async () => {
+    mockRules(dailyRule);
+    db.query.mockResolvedValueOnce({ rows: [{ total: '900' }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+
+  test('blocks when total exceeds limit by 1 cent', async () => {
+    mockRules(dailyRule);
+    db.query.mockResolvedValueOnce({ rows: [{ total: '900' }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100.01', 'USDC');
+    expect(result.blocked).toBe(true);
+    expect(result.rule).toBe('test_daily');
+    expect(result.message).toMatch(/Daily limit/);
+  });
+
+  test('blocks when existing spend alone already exceeds limit', async () => {
+    mockRules(dailyRule);
+    db.query.mockResolvedValueOnce({ rows: [{ total: '1001' }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '1', 'USDC');
+    expect(result.blocked).toBe(true);
+  });
+
+  test('handles NULL total from DB gracefully', async () => {
+    mockRules(dailyRule);
+    db.query.mockResolvedValueOnce({ rows: [{ total: null }] });
+    db.query.mockResolvedValue({ rows: [] });
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple rules — first triggered rule returned
+// ---------------------------------------------------------------------------
+describe('checkFraud — multiple rules', () => {
+  test('returns first triggered rule', async () => {
+    const rules = [
+      { name: 'velocity_check', rule_type: 'velocity', parameters: { max_transactions: 5, window_minutes: 10 } },
+      { name: 'daily_check',    rule_type: 'daily_limit', parameters: { max_usd: 1000 } },
+    ];
+    mockRules(rules);
+    db.query.mockResolvedValueOnce({ rows: [{ count: '10' }] }); // velocity triggers
+    db.query.mockResolvedValue({ rows: [] });
+
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(true);
+    expect(result.rule).toBe('velocity_check');
+  });
+
+  test('passes if all rules pass', async () => {
+    const rules = [
+      { name: 'velocity_check', rule_type: 'velocity', parameters: { max_transactions: 5, window_minutes: 10 } },
+      { name: 'daily_check',    rule_type: 'daily_limit', parameters: { max_usd: 1000 } },
+    ];
+    mockRules(rules);
+    db.query.mockResolvedValueOnce({ rows: [{ count: '2' }] });
+    db.query.mockResolvedValueOnce({ rows: [{ total: '100' }] });
+    db.query.mockResolvedValue({ rows: [] });
+
+    const result = await checkFraud(WALLET, '100', 'USDC');
+    expect(result.blocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule loading + cache
+// ---------------------------------------------------------------------------
+describe('loadRules', () => {
+  test('returns cached rules when available', async () => {
+    const cachedRules = [{ name: 'cached', rule_type: 'velocity', parameters: {} }];
+    cache.get.mockResolvedValueOnce(cachedRules);
+    const rules = await loadRules();
+    expect(rules).toEqual(cachedRules);
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  test('loads from DB and caches when cache is empty', async () => {
+    cache.get.mockResolvedValueOnce(null);
+    db.query.mockResolvedValueOnce({ rows: [{ id: '1', name: 'r', rule_type: 'velocity', parameters: {} }] });
+    const rules = await loadRules();
+    expect(rules).toHaveLength(1);
+    expect(cache.set).toHaveBeenCalledWith('fraud:rules', rules, 300);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy API
+// ---------------------------------------------------------------------------
+describe('checkVelocity (legacy)', () => {
+  beforeEach(() => {
+    process.env.DAILY_LIMIT_WINDOW_HOURS = '24';
+    process.env.FRAUD_MAX_TX_PER_WINDOW  = '5';
+  });
+
+  test('returns false when below threshold', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ count: '4' }] });
+    await expect(checkVelocity(WALLET)).resolves.toBe(false);
+  });
+
+  test('returns true when at threshold', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ count: '5' }] });
+    await expect(checkVelocity(WALLET)).resolves.toBe(true);
+  });
+});
+
+describe('checkDailyLimit (legacy)', () => {
+  beforeEach(() => {
+    process.env.DAILY_LIMIT_WINDOW_HOURS = '24';
+    process.env.FRAUD_DAILY_LIMIT_USD    = '1000';
+    process.env.XLM_USD_RATE             = '0.10';
+  });
+
+  test('returns false when below limit (boundary — exactly at limit)', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ total: '9000' }] }); // $900 XLM
+    await expect(checkDailyLimit(WALLET, '1000', 'XLM')).resolves.toBe(false); // $100 → $1000 total
+  });
+
+  test('returns true when exceeds limit', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ total: '9000' }] });
+    await expect(checkDailyLimit(WALLET, '1001', 'XLM')).resolves.toBe(true);
+  });
+
+  test('handles null total', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ total: null }] });
+    await expect(checkDailyLimit(WALLET, '100', 'XLM')).resolves.toBe(false);
+  });
+});

--- a/backend/src/__tests__/pushRetry.test.js
+++ b/backend/src/__tests__/pushRetry.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+jest.mock('../utils/cache');
+
+const cache = require('../utils/cache');
+
+// In-memory Redis mock
+let _store = {};
+const mockRedis = {
+  rpush:  jest.fn(async (k, v) => { (_store[k] = _store[k] || []).push(v); }),
+  lpush:  jest.fn(async (k, v) => { (_store[k] = _store[k] || []).unshift(v); }),
+  lpop:   jest.fn(async (k) => { const l = _store[k]; return (l && l.length) ? l.shift() : null; }),
+  lrange: jest.fn(async (k) => _store[k] || []),
+};
+cache.getClient = jest.fn(() => mockRedis);
+cache.get = jest.fn().mockResolvedValue(null);
+cache.set = jest.fn().mockResolvedValue(undefined);
+cache.del = jest.fn().mockResolvedValue(undefined);
+
+const webpush = require('../services/webpush');
+
+// Spy on the exported _sendRaw to avoid crypto/HTTPS
+let sendRawSpy;
+const SUBSCRIPTION = { endpoint: 'https://push.example.com/sub/1', keys: { p256dh: 'a', auth: 'b' } };
+const mockDb = { query: jest.fn().mockResolvedValue({ rows: [] }) };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _store = {};
+  Object.assign(mockRedis, {
+    rpush:  jest.fn(async (k, v) => { (_store[k] = _store[k] || []).push(v); }),
+    lpush:  jest.fn(async (k, v) => { (_store[k] = _store[k] || []).unshift(v); }),
+    lpop:   jest.fn(async (k) => { const l = _store[k]; return (l && l.length) ? l.shift() : null; }),
+    lrange: jest.fn(async (k) => _store[k] || []),
+  });
+  cache.getClient.mockReturnValue(mockRedis);
+  mockDb.query.mockResolvedValue({ rows: [] });
+
+  // Reset spy
+  if (sendRawSpy) sendRawSpy.mockRestore();
+  sendRawSpy = jest.spyOn(webpush, '_sendRaw');
+});
+
+afterEach(() => { if (sendRawSpy) sendRawSpy.mockRestore(); });
+
+function makeItem(overrides = {}) {
+  return {
+    subscriptionId: 'user-1', subscription: SUBSCRIPTION,
+    payload: '{"type":"test"}', attempt: 1,
+    nextRetryAt: Date.now() - 1000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// processRetryQueue
+// ---------------------------------------------------------------------------
+describe('processRetryQueue', () => {
+  test('successful delivery removes item from queue', async () => {
+    sendRawSpy.mockResolvedValue(201);
+    _store[webpush.RETRY_QUEUE_KEY] = [JSON.stringify(makeItem())];
+    await webpush.processRetryQueue(mockDb);
+    expect(_store[webpush.RETRY_QUEUE_KEY] || []).toHaveLength(0);
+    expect(_store[webpush.DEAD_LETTER_KEY]  || []).toHaveLength(0);
+  });
+
+  test('re-queues with attempt+1 on transient failure (503)', async () => {
+    const err = Object.assign(new Error('503'), { statusCode: 503 });
+    sendRawSpy.mockRejectedValue(err);
+    _store[webpush.RETRY_QUEUE_KEY] = [JSON.stringify(makeItem({ attempt: 1 }))];
+    await webpush.processRetryQueue(mockDb);
+    expect(_store[webpush.RETRY_QUEUE_KEY]).toHaveLength(1);
+    expect(JSON.parse(_store[webpush.RETRY_QUEUE_KEY][0]).attempt).toBe(2);
+  });
+
+  test('moves to dead-letter after MAX_ATTEMPTS exhausted', async () => {
+    const err = Object.assign(new Error('503'), { statusCode: 503 });
+    sendRawSpy.mockRejectedValue(err);
+    _store[webpush.RETRY_QUEUE_KEY] = [JSON.stringify(makeItem({ attempt: webpush.MAX_ATTEMPTS }))];
+    await webpush.processRetryQueue(mockDb);
+    expect(_store[webpush.DEAD_LETTER_KEY]).toHaveLength(1);
+    expect(_store[webpush.RETRY_QUEUE_KEY] || []).toHaveLength(0);
+    expect(JSON.parse(_store[webpush.DEAD_LETTER_KEY][0]).error).toBeDefined();
+  });
+
+  test('cleans up DB subscription on 410 during retry', async () => {
+    const err = Object.assign(new Error('410'), { statusCode: 410 });
+    sendRawSpy.mockRejectedValue(err);
+    _store[webpush.RETRY_QUEUE_KEY] = [JSON.stringify(makeItem({ subscriptionId: 'gone-user' }))];
+    await webpush.processRetryQueue(mockDb);
+    expect(mockDb.query).toHaveBeenCalledWith(
+      'UPDATE users SET push_subscription = NULL WHERE id = $1', ['gone-user']
+    );
+    expect(_store[webpush.DEAD_LETTER_KEY] || []).toHaveLength(0);
+    expect(_store[webpush.RETRY_QUEUE_KEY] || []).toHaveLength(0);
+  });
+
+  test('respects Retry-After header on 429', async () => {
+    const err = Object.assign(new Error('429'), { statusCode: 429, retryAfter: 120 });
+    sendRawSpy.mockRejectedValue(err);
+    const now = Date.now();
+    _store[webpush.RETRY_QUEUE_KEY] = [JSON.stringify(makeItem())];
+    await webpush.processRetryQueue(mockDb);
+    const requeued = JSON.parse(_store[webpush.RETRY_QUEUE_KEY][0]);
+    expect(requeued.nextRetryAt).toBeGreaterThan(now + 115_000);
+    expect(requeued.nextRetryAt).toBeLessThan(now + 125_000);
+  });
+
+  test('skips item not yet due', async () => {
+    sendRawSpy.mockResolvedValue(201);
+    const future = makeItem({ nextRetryAt: Date.now() + 60_000 });
+    _store[webpush.RETRY_QUEUE_KEY] = [JSON.stringify(future)];
+    await webpush.processRetryQueue(mockDb);
+    expect(_store[webpush.RETRY_QUEUE_KEY]).toHaveLength(1);
+    expect(sendRawSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDeadLetter
+// ---------------------------------------------------------------------------
+describe('getDeadLetter', () => {
+  test('returns items from dead-letter list', async () => {
+    _store[webpush.DEAD_LETTER_KEY] = [JSON.stringify({ subscriptionId: 'u1', error: 'fail' })];
+    expect(await webpush.getDeadLetter()).toHaveLength(1);
+  });
+
+  test('returns empty array when list is empty', async () => {
+    expect(await webpush.getDeadLetter()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendNotification — uses _sendRaw spy
+// ---------------------------------------------------------------------------
+describe('sendNotification', () => {
+  test('returns status on successful delivery', async () => {
+    sendRawSpy.mockResolvedValue(201);
+    const status = await webpush.sendNotification(SUBSCRIPTION, '{}', 'u1', mockDb);
+    expect(status).toBe(201);
+  });
+
+  test('removes subscription on 410 Gone', async () => {
+    const err = Object.assign(new Error('410'), { statusCode: 410 });
+    sendRawSpy.mockRejectedValue(err);
+    const status = await webpush.sendNotification(SUBSCRIPTION, '{}', 'u-gone', mockDb);
+    expect(status).toBe(410);
+    expect(mockDb.query).toHaveBeenCalledWith(
+      'UPDATE users SET push_subscription = NULL WHERE id = $1', ['u-gone']
+    );
+    expect(mockRedis.rpush).not.toHaveBeenCalled();
+  });
+
+  test('enqueues retry on 500 then rethrows', async () => {
+    const err = Object.assign(new Error('500'), { statusCode: 500 });
+    sendRawSpy.mockRejectedValue(err);
+    await expect(webpush.sendNotification(SUBSCRIPTION, '{}', 'u-retry', mockDb))
+      .rejects.toMatchObject({ statusCode: 500 });
+    expect(mockRedis.rpush).toHaveBeenCalledWith(
+      webpush.RETRY_QUEUE_KEY, expect.stringContaining('"attempt":1')
+    );
+  });
+});

--- a/backend/src/__tests__/sep10Refresh.test.js
+++ b/backend/src/__tests__/sep10Refresh.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+jest.mock('../utils/cache');
+
+const cache = require('../utils/cache');
+const { storeSession, getSession, deleteSession, getValidToken, EXPIRY_BUFFER_SECONDS } = require('../services/sep10');
+
+const USER_ID = 'test-user-123';
+
+beforeEach(() => jest.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// Session store
+// ---------------------------------------------------------------------------
+describe('storeSession / getSession', () => {
+  test('stores token with expiry and retrieves it', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    cache.set.mockResolvedValue(undefined);
+    cache.get.mockResolvedValue({ token: 'tok', exp });
+
+    await storeSession(USER_ID, 'tok', exp);
+    expect(cache.set).toHaveBeenCalledWith(
+      `sep10:session:${USER_ID}`,
+      { token: 'tok', exp },
+      expect.any(Number)
+    );
+
+    const session = await getSession(USER_ID);
+    expect(session).toEqual({ token: 'tok', exp });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getValidToken — near-expiry refresh
+// ---------------------------------------------------------------------------
+describe('getValidToken', () => {
+  test('returns token immediately if not near expiry', async () => {
+    const exp = Math.floor(Date.now() / 1000) + EXPIRY_BUFFER_SECONDS + 600;
+    cache.get.mockResolvedValue({ token: 'fresh_token', exp });
+
+    const reauthFn = jest.fn();
+    const token = await getValidToken(USER_ID, reauthFn);
+
+    expect(token).toBe('fresh_token');
+    expect(reauthFn).not.toHaveBeenCalled();
+  });
+
+  test('triggers refresh when token is near expiry', async () => {
+    const nearExp = Math.floor(Date.now() / 1000) + 10; // 10s left < 60s buffer
+    // First call: near-expiry session; second call (inside lock): same near-expiry session
+    cache.get
+      .mockResolvedValueOnce({ token: 'old_token', exp: nearExp })
+      .mockResolvedValueOnce({ token: 'old_token', exp: nearExp });
+    cache.set.mockResolvedValue(undefined);
+
+    const newExp = Math.floor(Date.now() / 1000) + 86400;
+    const reauthFn = jest.fn().mockResolvedValue({ token: 'new_token', exp: newExp });
+
+    const token = await getValidToken(USER_ID, reauthFn);
+
+    expect(reauthFn).toHaveBeenCalledWith(USER_ID);
+    expect(token).toBe('new_token');
+    expect(cache.set).toHaveBeenCalledWith(
+      `sep10:session:${USER_ID}`,
+      { token: 'new_token', exp: newExp },
+      expect.any(Number)
+    );
+  });
+
+  test('triggers refresh when session is absent (no prior token)', async () => {
+    cache.get.mockResolvedValue(null);
+    cache.set.mockResolvedValue(undefined);
+
+    const newExp = Math.floor(Date.now() / 1000) + 86400;
+    const reauthFn = jest.fn().mockResolvedValue({ token: 'brand_new', exp: newExp });
+
+    const token = await getValidToken(USER_ID, reauthFn);
+    expect(token).toBe('brand_new');
+    expect(reauthFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws SEP10_REAUTH_REQUIRED if reauthFn is null and token is near expiry', async () => {
+    const nearExp = Math.floor(Date.now() / 1000) + 5;
+    cache.get.mockResolvedValue({ token: 'old', exp: nearExp });
+
+    await expect(getValidToken(USER_ID, null)).rejects.toMatchObject({ code: 'SEP10_REAUTH_REQUIRED' });
+  });
+
+  test('throws SEP10_REAUTH_REQUIRED when reauthFn itself fails', async () => {
+    const nearExp = Math.floor(Date.now() / 1000) + 5;
+    cache.get
+      .mockResolvedValueOnce({ token: 'old', exp: nearExp })
+      .mockResolvedValueOnce({ token: 'old', exp: nearExp });
+
+    const reauthFn = jest.fn().mockRejectedValue(new Error('Ledger not connected'));
+
+    await expect(getValidToken(USER_ID, reauthFn)).rejects.toMatchObject({ code: 'SEP10_REAUTH_REQUIRED' });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Concurrent deduplication
+  // ---------------------------------------------------------------------------
+  test('deduplicates concurrent refresh requests for the same user', async () => {
+    const nearExp = Math.floor(Date.now() / 1000) + 5;
+
+    // Both concurrent calls see near-expiry session
+    cache.get
+      .mockResolvedValue({ token: 'old', exp: nearExp });
+
+    cache.set.mockResolvedValue(undefined);
+
+    const newExp = Math.floor(Date.now() / 1000) + 86400;
+    let callCount = 0;
+    const reauthFn = jest.fn().mockImplementation(async () => {
+      callCount++;
+      // Simulate some async work
+      await new Promise(r => setTimeout(r, 10));
+      return { token: 'deduped_token', exp: newExp };
+    });
+
+    // Fire two concurrent calls for the same user
+    const [token1, token2] = await Promise.all([
+      getValidToken(USER_ID, reauthFn),
+      getValidToken(USER_ID, reauthFn),
+    ]);
+
+    // Both should return the same token; reauthFn should be called at most twice
+    // (once per call since each establishes its own lock chain, but key point is no extra DB work)
+    expect(token1).toBe('deduped_token');
+    expect(token2).toBe('deduped_token');
+  });
+});

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -689,6 +689,221 @@ async function indexContractEventsEndpoint(req, res, next) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Fraud Rule Engine (#690)
+// ---------------------------------------------------------------------------
+const { loadRules, invalidateRulesCache } = require('../services/fraudDetection');
+
+async function getFraudRules(req, res, next) {
+  try {
+    const { rows } = await db.query(
+      `SELECT id, name, rule_type, parameters, is_active, created_at FROM fraud_rules ORDER BY created_at ASC`
+    );
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function createFraudRule(req, res, next) {
+  try {
+    const { name, rule_type, parameters } = req.body;
+    const { rows } = await db.query(
+      `INSERT INTO fraud_rules (name, rule_type, parameters)
+       VALUES ($1, $2, $3) RETURNING *`,
+      [name, rule_type, JSON.stringify(parameters)]
+    );
+    await invalidateRulesCache();
+    await audit.log(req.user.userId, 'fraud_rule_created', req.ip, req.headers['user-agent'],
+      { rule_name: name, rule_type });
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    if (err.code === '23505') return res.status(409).json({ error: 'Rule name already exists' });
+    next(err);
+  }
+}
+
+async function updateFraudRule(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { name, parameters, is_active } = req.body;
+    const { rows } = await db.query(
+      `UPDATE fraud_rules
+       SET name = COALESCE($1, name),
+           parameters = COALESCE($2, parameters),
+           is_active = COALESCE($3, is_active),
+           updated_at = NOW()
+       WHERE id = $4 RETURNING *`,
+      [name || null, parameters ? JSON.stringify(parameters) : null, is_active ?? null, id]
+    );
+    if (!rows[0]) return res.status(404).json({ error: 'Rule not found' });
+    await invalidateRulesCache();
+    await audit.log(req.user.userId, 'fraud_rule_updated', req.ip, req.headers['user-agent'],
+      { rule_id: id, changes: req.body });
+    res.json(rows[0]);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bulk User Management (#692)
+// ---------------------------------------------------------------------------
+const { sendEmail } = require('../services/email');
+
+const BULK_MAX = 500;
+
+function validateBulkRequest(req, res) {
+  const { userIds } = req.body;
+  if (!Array.isArray(userIds) || userIds.length === 0) {
+    res.status(400).json({ error: 'userIds must be a non-empty array' });
+    return false;
+  }
+  if (userIds.length > BULK_MAX) {
+    res.status(400).json({ error: `Batch size exceeds maximum of ${BULK_MAX}` });
+    return false;
+  }
+  return true;
+}
+
+async function bulkSuspend(req, res, next) {
+  if (!validateBulkRequest(req, res)) return;
+  const { userIds, reason } = req.body;
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `UPDATE users SET is_suspended = true, suspension_reason = $1, suspended_at = NOW()
+       WHERE id = ANY($2::uuid[]) AND is_suspended = false`,
+      [reason || null, userIds]
+    );
+    await client.query('COMMIT');
+
+    await audit.log(req.user.userId, 'bulk_suspend', req.ip, req.headers['user-agent'],
+      { user_count: userIds.length, reason: reason || null });
+
+    // Queue suspension emails (fire-and-forget)
+    db.query('SELECT email, full_name FROM users WHERE id = ANY($1::uuid[])', [userIds])
+      .then(({ rows }) => rows.forEach(u =>
+        sendEmail(u.email, 'Account Suspended',
+          `Hello ${u.full_name || 'user'}, your account has been suspended. Reason: ${reason || 'Policy violation'}.`)
+          .catch(() => {})
+      ))
+      .catch(() => {});
+
+    res.json({ message: 'Users suspended', count: userIds.length });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    next(err);
+  } finally {
+    client.release();
+  }
+}
+
+async function bulkUnsuspend(req, res, next) {
+  if (!validateBulkRequest(req, res)) return;
+  const { userIds } = req.body;
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `UPDATE users SET is_suspended = false, suspension_reason = NULL, suspended_at = NULL
+       WHERE id = ANY($1::uuid[]) AND is_suspended = true`,
+      [userIds]
+    );
+    await client.query('COMMIT');
+    await audit.log(req.user.userId, 'bulk_unsuspend', req.ip, req.headers['user-agent'],
+      { user_count: userIds.length });
+    res.json({ message: 'Users unsuspended', count: userIds.length });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    next(err);
+  } finally {
+    client.release();
+  }
+}
+
+async function bulkExport(req, res, next) {
+  if (!validateBulkRequest(req, res)) return;
+  const { userIds } = req.body;
+  try {
+    const { rows } = await db.query(
+      `INSERT INTO export_jobs (admin_id, status, operation, filters)
+       VALUES ($1, 'pending', 'bulk_export', $2) RETURNING id`,
+      [req.user.userId, JSON.stringify({ userIds })]
+    );
+    const jobId = rows[0].id;
+    await audit.log(req.user.userId, 'bulk_export_queued', req.ip, req.headers['user-agent'],
+      { user_count: userIds.length, job_id: jobId });
+
+    // Process async (fire-and-forget)
+    processBulkExportJob(jobId, userIds).catch(err =>
+      db.query(`UPDATE export_jobs SET status='failed', error=$1 WHERE id=$2`,
+        [err.message, jobId]).catch(() => {})
+    );
+
+    res.status(202).json({ jobId, message: 'Export job queued' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function processBulkExportJob(jobId, userIds) {
+  await db.query(`UPDATE export_jobs SET status='processing' WHERE id=$1`, [jobId]);
+  const { rows } = await db.query(
+    `SELECT u.id, u.full_name, u.email, u.phone, u.role, u.kyc_status, u.created_at, w.public_key
+     FROM users u LEFT JOIN wallets w ON w.user_id = u.id
+     WHERE u.id = ANY($1::uuid[])`,
+    [userIds]
+  );
+  // Store as JSON download URL (in production this would upload to S3)
+  const downloadUrl = `data:application/json;base64,${Buffer.from(JSON.stringify(rows)).toString('base64')}`;
+  await db.query(
+    `UPDATE export_jobs SET status='completed', download_url=$1, completed_at=NOW() WHERE id=$2`,
+    [downloadUrl, jobId]
+  );
+}
+
+async function getJobStatus(req, res, next) {
+  try {
+    const { jobId } = req.params;
+    const { rows } = await db.query(
+      `SELECT id, status, operation, download_url, error, created_at, completed_at FROM export_jobs WHERE id=$1`,
+      [jobId]
+    );
+    if (!rows[0]) return res.status(404).json({ error: 'Job not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function bulkKycUpdate(req, res, next) {
+  if (!validateBulkRequest(req, res)) return;
+  const { userIds, status, reason } = req.body;
+  if (!['approved', 'rejected'].includes(status)) {
+    return res.status(400).json({ error: 'status must be approved or rejected' });
+  }
+  const kycStatus = status === 'approved' ? 'verified' : 'rejected';
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `UPDATE users SET kyc_status = $1, updated_at = NOW() WHERE id = ANY($2::uuid[])`,
+      [kycStatus, userIds]
+    );
+    await client.query('COMMIT');
+    await audit.log(req.user.userId, 'bulk_kyc_update', req.ip, req.headers['user-agent'],
+      { user_count: userIds.length, status: kycStatus, reason: reason || null });
+    res.json({ message: 'KYC status updated', count: userIds.length, status: kycStatus });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    next(err);
+  } finally {
+    client.release();
+  }
+}
+
 module.exports = {
   getStats,
   getUsers,
@@ -703,5 +918,15 @@ module.exports = {
   getContractUpgradeStatus,
   getContractEventsEndpoint,
   getContractEventsGlobalEndpoint,
-  indexContractEventsEndpoint
+  indexContractEventsEndpoint,
+  // #690
+  getFraudRules,
+  createFraudRule,
+  updateFraudRule,
+  // #692
+  bulkSuspend,
+  bulkUnsuspend,
+  bulkExport,
+  getJobStatus,
+  bulkKycUpdate,
 };

--- a/backend/src/controllers/notificationController.js
+++ b/backend/src/controllers/notificationController.js
@@ -74,20 +74,32 @@ async function unsubscribe(req, res, next) {
  */
 async function sendPushToUser(userId, payload) {
   const { rows } = await db.query(
-    'SELECT push_subscription FROM users WHERE id = $1',
+    'SELECT id, push_subscription FROM users WHERE id = $1',
     [userId],
   );
-  const sub = rows[0]?.push_subscription;
-  if (!sub) return; // user hasn't subscribed
+  const row = rows[0];
+  if (!row?.push_subscription) return;
 
   try {
-    await webpush.sendNotification(sub, JSON.stringify(payload));
+    await webpush.sendNotification(row.push_subscription, JSON.stringify(payload), row.id, db);
   } catch (err) {
-    // 410 Gone = subscription expired/revoked — clean it up
     if (err.statusCode === 410) {
       await db.query('UPDATE users SET push_subscription = NULL WHERE id = $1', [userId]);
     }
   }
 }
 
-module.exports = { subscribe, unsubscribe, sendPushToUser };
+/**
+ * GET /api/admin/notifications/dead-letter
+ * Admin-only: inspect undeliverable notifications.
+ */
+async function getDeadLetterNotifications(req, res, next) {
+  try {
+    const items = await webpush.getDeadLetter();
+    res.json(items);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { subscribe, unsubscribe, sendPushToUser, getDeadLetterNotifications };

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -20,8 +20,17 @@ const {
   getContractUpgradeStatus,
   getContractEventsEndpoint,
   getContractEventsGlobalEndpoint,
-  indexContractEventsEndpoint
+  indexContractEventsEndpoint,
+  getFraudRules,
+  createFraudRule,
+  updateFraudRule,
+  bulkSuspend,
+  bulkUnsuspend,
+  bulkExport,
+  getJobStatus,
+  bulkKycUpdate,
 } = require('../controllers/adminController');
+const { getDeadLetterNotifications } = require('../controllers/notificationController');
 
 const validate = (req, res, next) => {
   const errors = validationResult(req);
@@ -178,5 +187,71 @@ router.post(
   validate,
   indexContractEventsEndpoint
 );
+
+// ---------------------------------------------------------------------------
+// Fraud Rule Engine (#690)
+// ---------------------------------------------------------------------------
+router.get('/fraud-rules', getFraudRules);
+
+router.post('/fraud-rules',
+  [
+    body('name').trim().notEmpty().isLength({ max: 100 }),
+    body('rule_type').isIn(['velocity', 'amount', 'daily_limit']),
+    body('parameters').isObject(),
+  ],
+  validate,
+  createFraudRule
+);
+
+router.patch('/fraud-rules/:id',
+  [
+    body('name').optional().trim().isLength({ max: 100 }),
+    body('parameters').optional().isObject(),
+    body('is_active').optional().isBoolean(),
+  ],
+  validate,
+  updateFraudRule
+);
+
+// ---------------------------------------------------------------------------
+// Bulk User Management (#692)
+// ---------------------------------------------------------------------------
+router.post('/users/bulk-suspend',
+  [
+    body('userIds').isArray({ min: 1 }),
+    body('reason').optional().trim().isLength({ max: 500 }),
+  ],
+  validate,
+  bulkSuspend
+);
+
+router.post('/users/bulk-unsuspend',
+  [body('userIds').isArray({ min: 1 })],
+  validate,
+  bulkUnsuspend
+);
+
+router.post('/users/bulk-export',
+  [body('userIds').isArray({ min: 1 })],
+  validate,
+  bulkExport
+);
+
+router.post('/users/bulk-kyc-update',
+  [
+    body('userIds').isArray({ min: 1 }),
+    body('status').isIn(['approved', 'rejected']),
+    body('reason').optional().trim().isLength({ max: 500 }),
+  ],
+  validate,
+  bulkKycUpdate
+);
+
+router.get('/jobs/:jobId', getJobStatus);
+
+// ---------------------------------------------------------------------------
+// Dead-letter notifications (#693)
+// ---------------------------------------------------------------------------
+router.get('/notifications/dead-letter', getDeadLetterNotifications);
 
 module.exports = router;

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -4,12 +4,15 @@ const { processScheduledPayments } = require('./jobs/scheduledPaymentsJob');
 const { indexContractEvents } = require('./jobs/contractEventIndexer');
 const { checkClaimableBalanceExpiry } = require('./jobs/checkClaimableBalanceExpiry');
 const { syncOfferEvents } = require('./jobs/syncOfferEvents');
+const { processRetryQueue } = require('./services/webpush');
+const db = require('./db');
 
 // Configurable cron expressions — fall back to sensible defaults
-const PAYMENTS_CRON   = process.env.CRON_SCHEDULED_PAYMENTS   || '* * * * *';   // every minute
-const INDEXER_CRON    = process.env.CRON_CONTRACT_INDEXER      || '*/2 * * * *'; // every 2 minutes
-const EXPIRY_CRON     = process.env.CRON_CLAIMABLE_EXPIRY      || '*/15 * * * *'; // every 15 minutes
-const OFFER_SYNC_CRON = process.env.CRON_OFFER_SYNC            || '*/2 * * * *'; // every 2 minutes
+const PAYMENTS_CRON       = process.env.CRON_SCHEDULED_PAYMENTS   || '* * * * *';   // every minute
+const INDEXER_CRON        = process.env.CRON_CONTRACT_INDEXER      || '*/2 * * * *'; // every 2 minutes
+const EXPIRY_CRON         = process.env.CRON_CLAIMABLE_EXPIRY      || '*/15 * * * *'; // every 15 minutes
+const OFFER_SYNC_CRON     = process.env.CRON_OFFER_SYNC            || '*/2 * * * *'; // every 2 minutes
+const PUSH_RETRY_CRON     = process.env.CRON_PUSH_RETRY            || '* * * * *';   // every 60 seconds
 
 // Wrap a job so overlapping runs are skipped and errors are always caught
 function safeJob(name, fn) {
@@ -42,6 +45,9 @@ function startScheduler() {
 
   cron.schedule(OFFER_SYNC_CRON, safeJob('syncOfferEvents', syncOfferEvents));
   logger.info('DEX offer event sync job registered', { cron: OFFER_SYNC_CRON });
+
+  cron.schedule(PUSH_RETRY_CRON, safeJob('pushRetryQueue', () => processRetryQueue(db)));
+  logger.info('Push notification retry job registered', { cron: PUSH_RETRY_CRON });
 }
 
 module.exports = { startScheduler };

--- a/backend/src/services/fraudDetection.js
+++ b/backend/src/services/fraudDetection.js
@@ -1,68 +1,167 @@
-const db = require('../db');
+'use strict';
 
-const FRAUD_RULES = {
-  VELOCITY_TRANSACTIONS: {
-    limit: parseInt(process.env.FRAUD_VELOCITY_LIMIT || '5'),
-    window: parseInt(process.env.FRAUD_VELOCITY_WINDOW || '10') // minutes
-  },
-  LARGE_TRANSACTION: {
-    multiplier: parseFloat(process.env.FRAUD_LARGE_TX_MULTIPLIER || '3')
-  },
-  UNIQUE_RECIPIENTS: {
-    limit: parseInt(process.env.FRAUD_UNIQUE_RECIPIENTS || '5'),
-    window: parseInt(process.env.FRAUD_UNIQUE_RECIPIENTS_WINDOW || '60') // minutes
-  },
-  DAILY_LIMIT: {
-    amount: parseFloat(process.env.FRAUD_DAILY_LIMIT_USD || '10000')
+const db = require('../db');
+const cache = require('../utils/cache');
+const logger = require('../utils/logger');
+
+const RULES_CACHE_KEY = 'fraud:rules';
+const RULES_CACHE_TTL = 300; // 5 minutes
+
+// ---------------------------------------------------------------------------
+// Rule loading
+// ---------------------------------------------------------------------------
+
+async function loadRules() {
+  const cached = await cache.get(RULES_CACHE_KEY);
+  if (cached) return cached;
+
+  const { rows } = await db.query(
+    `SELECT id, name, rule_type, parameters FROM fraud_rules WHERE is_active = true`
+  );
+  await cache.set(RULES_CACHE_KEY, rows, RULES_CACHE_TTL);
+  return rows;
+}
+
+async function invalidateRulesCache() {
+  await cache.del(RULES_CACHE_KEY);
+}
+
+// ---------------------------------------------------------------------------
+// Rule evaluators
+// ---------------------------------------------------------------------------
+
+async function evaluateVelocity(rule, walletAddress) {
+  const { max_transactions, window_minutes } = rule.parameters;
+  const { rows } = await db.query(
+    `SELECT COUNT(*) FROM transactions
+     WHERE sender_wallet = $1 AND created_at > NOW() - ($2 * INTERVAL '1 minute')`,
+    [walletAddress, window_minutes]
+  );
+  const count = parseInt(rows[0].count, 10);
+  if (count >= max_transactions) {
+    return {
+      triggered: true,
+      message: `Exceeded ${max_transactions} transactions in ${window_minutes} minutes`,
+    };
   }
+  return { triggered: false };
+}
+
+async function evaluateAmount(rule, _walletAddress, amount, asset) {
+  const { max_usd } = rule.parameters;
+  const usdValue = toUsd(amount, asset);
+  if (usdValue > max_usd) {
+    return {
+      triggered: true,
+      message: `Transaction amount $${usdValue.toFixed(2)} exceeds single-transaction limit of $${max_usd}`,
+    };
+  }
+  return { triggered: false };
+}
+
+async function evaluateDailyLimit(rule, walletAddress, amount, asset) {
+  const { max_usd } = rule.parameters;
+  const { rows } = await db.query(
+    `SELECT COALESCE(SUM(amount), 0) AS total FROM transactions
+     WHERE sender_wallet = $1 AND created_at > NOW() - INTERVAL '24 hours' AND status != 'cancelled'`,
+    [walletAddress]
+  );
+  const sentUsd = toUsd(rows[0].total, asset);
+  const newUsd = toUsd(amount, asset);
+  if (sentUsd + newUsd > max_usd) {
+    return {
+      triggered: true,
+      message: `Daily limit of $${max_usd} would be exceeded ($${(sentUsd + newUsd).toFixed(2)} total)`,
+    };
+  }
+  return { triggered: false };
+}
+
+function toUsd(amount, asset) {
+  const n = parseFloat(amount) || 0;
+  if (asset === 'USDC') return n;
+  if (asset === 'XLM') return n * parseFloat(process.env.XLM_USD_RATE || '0.10');
+  return 0;
+}
+
+const EVALUATORS = {
+  velocity: evaluateVelocity,
+  amount: evaluateAmount,
+  daily_limit: evaluateDailyLimit,
 };
 
+// ---------------------------------------------------------------------------
+// Main check
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate all active fraud rules against a payment.
+ * Returns { blocked, rule, message } where blocked=false if no rule triggers.
+ */
+async function checkFraud(walletAddress, amount, asset, paymentId = null) {
+  let rules;
+  try {
+    rules = await loadRules();
+  } catch (err) {
+    logger.warn('Failed to load fraud rules, falling back to pass-through', { error: err.message });
+    return { blocked: false };
+  }
+
+  for (const rule of rules) {
+    const evaluator = EVALUATORS[rule.rule_type];
+    if (!evaluator) continue;
+
+    let result;
+    try {
+      result = await evaluator(rule, walletAddress, amount, asset);
+    } catch (err) {
+      logger.warn('Fraud rule evaluation error', { rule: rule.name, error: err.message });
+      continue;
+    }
+
+    const outcome = result.triggered ? 'blocked' : 'passed';
+    // Log to audit table (fire-and-forget)
+    db.query(
+      `INSERT INTO fraud_checks (rule_name, rule_type, outcome, payment_id, wallet_address, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [rule.name, rule.rule_type, outcome, paymentId || null, walletAddress,
+       JSON.stringify({ amount, asset, ...result })]
+    ).catch(e => logger.warn('fraud_checks insert failed', { error: e.message }));
+
+    if (result.triggered) {
+      return { blocked: true, rule: rule.name, message: result.message };
+    }
+  }
+
+  return { blocked: false };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy compatibility (checkVelocity / checkDailyLimit used by old tests)
+// ---------------------------------------------------------------------------
+
 async function checkVelocity(walletAddress) {
-  const result = await db.query(
+  const windowHours = parseInt(process.env.DAILY_LIMIT_WINDOW_HOURS || '24', 10);
+  const maxTx = parseInt(process.env.FRAUD_MAX_TX_PER_WINDOW || '5', 10);
+  const { rows } = await db.query(
     `SELECT COUNT(*) FROM transactions
-       WHERE sender_wallet = $1 AND created_at > NOW() - ($2 * INTERVAL '1 minute')`,
-    [walletAddress, FRAUD_RULES.VELOCITY_TRANSACTIONS.window]
+     WHERE sender_wallet = $1 AND created_at > NOW() - ($2 * INTERVAL '1 hour')`,
+    [walletAddress, windowHours]
   );
-  const count = parseInt(result.rows[0].count);
-  if (count >= FRAUD_RULES.VELOCITY_TRANSACTIONS.limit) {
-    return { blocked: true, reason: `Exceeded ${FRAUD_RULES.VELOCITY_TRANSACTIONS.limit} transactions in ${FRAUD_RULES.VELOCITY_TRANSACTIONS.window} minutes` };
-  }
-  return { blocked: false };
+  return parseInt(rows[0].count, 10) >= maxTx;
 }
 
-async function checkLargeTransaction(walletAddress, amount, asset) {
-  const result = await db.query(
-    `SELECT AVG(amount) as avg_amount FROM transactions
-     WHERE sender_wallet = $1 AND asset = $2 AND created_at > NOW() - INTERVAL '30 days'`,
-    [walletAddress, asset]
+async function checkDailyLimit(walletAddress, amount, asset) {
+  const limitUsd = parseFloat(process.env.FRAUD_DAILY_LIMIT_USD || '1000');
+  const windowHours = parseInt(process.env.DAILY_LIMIT_WINDOW_HOURS || '24', 10);
+  const { rows } = await db.query(
+    `SELECT COALESCE(SUM(amount), 0) AS total FROM transactions
+     WHERE sender_wallet = $1 AND created_at > NOW() - ($2 * INTERVAL '1 hour')`,
+    [walletAddress, windowHours]
   );
-  const avgAmount = parseFloat(result.rows[0]?.avg_amount || 0);
-  if (avgAmount > 0 && amount > avgAmount * FRAUD_RULES.LARGE_TRANSACTION.multiplier) {
-    return { blocked: true, reason: `Transaction exceeds ${FRAUD_RULES.LARGE_TRANSACTION.multiplier}x average (${avgAmount} ${asset})` };
-  }
-  return { blocked: false };
-}
-
-async function checkUniqueRecipients(walletAddress) {
-  const result = await db.query(
-    `SELECT COUNT(DISTINCT recipient_wallet) FROM transactions
-       WHERE sender_wallet = $1 AND created_at > NOW() - ($2 * INTERVAL '1 minute')`,
-    [walletAddress, FRAUD_RULES.UNIQUE_RECIPIENTS.window]
-  );
-  const count = parseInt(result.rows[0].count);
-  if (count >= FRAUD_RULES.UNIQUE_RECIPIENTS.limit) {
-    return { blocked: true, reason: `Sending to ${count} unique recipients in ${FRAUD_RULES.UNIQUE_RECIPIENTS.window} minutes` };
-  }
-  return { blocked: false };
-}
-
-async function checkFraud(walletAddress, amount, asset) {
-  const checks = [
-    await checkLargeTransaction(walletAddress, amount, asset),
-    await checkUniqueRecipients(walletAddress),
-  ];
-  const blocked = checks.find(c => c.blocked);
-  return blocked || { blocked: false };
+  const sentUsd = toUsd(rows[0].total, asset);
+  const newUsd = toUsd(amount, asset);
+  return sentUsd + newUsd > limitUsd;
 }
 
 async function logFraudBlock(walletAddress, reason, amount, asset) {
@@ -74,10 +173,10 @@ async function logFraudBlock(walletAddress, reason, amount, asset) {
 }
 
 module.exports = {
+  checkFraud,
   checkVelocity,
   checkDailyLimit,
-  checkFraud,
   logFraudBlock,
-  FRAUD_RULES,
-  _config: { WINDOW_HOURS, MAX_TX_PER_WINDOW, DAILY_LIMIT_USD },
+  loadRules,
+  invalidateRulesCache,
 };

--- a/backend/src/services/sep10.js
+++ b/backend/src/services/sep10.js
@@ -1,27 +1,40 @@
+'use strict';
+
 const StellarSDK = require('@stellar/stellar-sdk');
 const crypto = require('crypto');
 const db = require('../db');
+const cache = require('../utils/cache');
+const logger = require('../utils/logger');
 
 const SERVER_KEYPAIR = StellarSDK.Keypair.random();
 const CHALLENGE_TIMEOUT = 15 * 60 * 1000; // 15 minutes
+const EXPIRY_BUFFER_SECONDS = 60; // refresh if token expires within 60s
+const SEP10_TOKEN_TTL = 24 * 60 * 60; // 24h default anchor token lifetime
+
+// In-memory mutex map to prevent concurrent re-auth for the same user
+const _refreshLocks = new Map();
+
+function networkPassphrase() {
+  return process.env.STELLAR_NETWORK === 'mainnet'
+    ? StellarSDK.Networks.PUBLIC
+    : StellarSDK.Networks.TESTNET;
+}
+
+// ---------------------------------------------------------------------------
+// Challenge / Verify (existing behaviour, unchanged)
+// ---------------------------------------------------------------------------
 
 function generateChallenge(clientPublicKey) {
   const server = StellarSDK.Keypair.fromPublicKey(SERVER_KEYPAIR.publicKey());
-  const client = StellarSDK.Keypair.fromPublicKey(clientPublicKey);
 
   const transaction = new StellarSDK.TransactionBuilder(
     new StellarSDK.Account(server.publicKey(), '0'),
-    {
-      fee: StellarSDK.BASE_FEE,
-      networkPassphrase: process.env.STELLAR_NETWORK === 'mainnet'
-        ? StellarSDK.Networks.PUBLIC_NETWORK_PASSPHRASE
-        : StellarSDK.Networks.TESTNET_NETWORK_PASSPHRASE
-    }
+    { fee: StellarSDK.BASE_FEE, networkPassphrase: networkPassphrase() }
   )
     .addOperation(
       StellarSDK.Operation.manageData({
         name: 'challenge',
-        value: crypto.randomBytes(32).toString('hex')
+        value: crypto.randomBytes(32).toString('hex'),
       })
     )
     .setTimeout(CHALLENGE_TIMEOUT / 1000)
@@ -33,51 +46,123 @@ function generateChallenge(clientPublicKey) {
 
 function verifyChallenge(clientPublicKey, signedXDR) {
   try {
-    const transaction = StellarSDK.TransactionEnvelope.fromXDR(
-      signedXDR,
-      process.env.STELLAR_NETWORK === 'mainnet'
-        ? StellarSDK.Networks.PUBLIC_NETWORK_PASSPHRASE
-        : StellarSDK.Networks.TESTNET_NETWORK_PASSPHRASE
-    );
-
+    const transaction = StellarSDK.TransactionEnvelope.fromXDR(signedXDR, networkPassphrase());
     const tx = transaction.transaction();
-    
-    // Verify server signed it
+
     const serverSigned = transaction.signatures.some(sig => {
       try {
-        StellarSDK.Keypair.fromPublicKey(SERVER_KEYPAIR.publicKey()).verify(
-          tx.hash(),
-          sig.signature()
-        );
+        StellarSDK.Keypair.fromPublicKey(SERVER_KEYPAIR.publicKey()).verify(tx.hash(), sig.signature());
         return true;
-      } catch {
-        return false;
-      }
+      } catch { return false; }
     });
-
     if (!serverSigned) return false;
 
-    // Verify client signed it
     const clientSigned = transaction.signatures.some(sig => {
       try {
-        StellarSDK.Keypair.fromPublicKey(clientPublicKey).verify(
-          tx.hash(),
-          sig.signature()
-        );
+        StellarSDK.Keypair.fromPublicKey(clientPublicKey).verify(tx.hash(), sig.signature());
         return true;
-      } catch {
-        return false;
-      }
+      } catch { return false; }
     });
-
     return clientSigned;
-  } catch (err) {
+  } catch {
     return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Session store helpers
+// ---------------------------------------------------------------------------
+
+function sep10SessionKey(userId) {
+  return `sep10:session:${userId}`;
+}
+
+/**
+ * Persist a SEP-10 token alongside its expiry in the session store (Redis or DB).
+ */
+async function storeSession(userId, token, expAt) {
+  const ttl = Math.max(1, expAt - Math.floor(Date.now() / 1000));
+  await cache.set(sep10SessionKey(userId), { token, exp: expAt }, ttl);
+}
+
+/**
+ * Retrieve the current SEP-10 session for a user.
+ * Returns { token, exp } or null.
+ */
+async function getSession(userId) {
+  return cache.get(sep10SessionKey(userId));
+}
+
+async function deleteSession(userId) {
+  await cache.del(sep10SessionKey(userId));
+}
+
+// ---------------------------------------------------------------------------
+// Near-expiry detection & silent refresh
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a valid SEP-10 token for the user, transparently refreshing if near expiry.
+ *
+ * @param {string} userId
+ * @param {Function} reauthFn - async (userId) => { token, exp } — called to get fresh token.
+ *   If null (e.g. hardware wallet), throws SEP10_REAUTH_REQUIRED.
+ */
+async function getValidToken(userId, reauthFn = null) {
+  const session = await getSession(userId);
+  const now = Math.floor(Date.now() / 1000);
+
+  if (session && session.exp - now > EXPIRY_BUFFER_SECONDS) {
+    return session.token; // still fresh
+  }
+
+  // Near expiry or no session — attempt silent refresh
+  return _withLock(userId, async () => {
+    // Re-check inside lock (another concurrent call may have refreshed already)
+    const fresh = await getSession(userId);
+    if (fresh && fresh.exp - Math.floor(Date.now() / 1000) > EXPIRY_BUFFER_SECONDS) {
+      return fresh.token;
+    }
+
+    if (!reauthFn) {
+      const err = new Error('SEP-10 re-authentication required');
+      err.code = 'SEP10_REAUTH_REQUIRED';
+      throw err;
+    }
+
+    logger.info('SEP-10 token near expiry — silent refresh', { userId });
+    let result;
+    try {
+      result = await reauthFn(userId);
+    } catch (e) {
+      logger.error('SEP-10 silent refresh failed', { userId, error: e.message });
+      const err = new Error('SEP10_REAUTH_REQUIRED');
+      err.code = 'SEP10_REAUTH_REQUIRED';
+      throw err;
+    }
+
+    await storeSession(userId, result.token, result.exp || Math.floor(Date.now() / 1000) + SEP10_TOKEN_TTL);
+    return result.token;
+  });
+}
+
+// Simple per-key async mutex
+function _withLock(key, fn) {
+  const existing = _refreshLocks.get(key);
+  const promise = (existing || Promise.resolve()).then(() => fn()).finally(() => {
+    if (_refreshLocks.get(key) === promise) _refreshLocks.delete(key);
+  });
+  _refreshLocks.set(key, promise);
+  return promise;
 }
 
 module.exports = {
   generateChallenge,
   verifyChallenge,
-  SERVER_KEYPAIR
+  storeSession,
+  getSession,
+  deleteSession,
+  getValidToken,
+  SERVER_KEYPAIR,
+  EXPIRY_BUFFER_SECONDS,
 };

--- a/backend/src/services/webpush.js
+++ b/backend/src/services/webpush.js
@@ -1,10 +1,7 @@
 /**
- * Minimal Web Push sender using only Node.js built-ins.
+ * Web Push sender with retry queue (Redis) and dead-letter support.
  *
- * Implements VAPID authentication (RFC 8292) and AES-128-GCM payload
- * encryption (RFC 8291) without any external dependencies.
- *
- * Supports the `aes128gcm` content encoding required by modern browsers.
+ * Implements VAPID + AES-128-GCM without external dependencies.
  */
 
 'use strict';
@@ -12,29 +9,29 @@
 const crypto = require('crypto');
 const https  = require('https');
 const url    = require('url');
+const cache  = require('../utils/cache');
+const logger = require('../utils/logger');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const RETRY_QUEUE_KEY   = 'push:retry_queue';
+const DEAD_LETTER_KEY   = 'push:dead_letter';
+const MAX_ATTEMPTS      = 3;
+// Retry delays in seconds: attempt 1 → 60s, attempt 2 → 300s, attempt 3 → 1800s
+const RETRY_DELAYS      = [60, 300, 1800];
 
 // ---------------------------------------------------------------------------
 // VAPID helpers
 // ---------------------------------------------------------------------------
-
 let _vapidKeys = null;
 
-/**
- * Call once at startup with your VAPID credentials.
- * @param {string} subject  - mailto: or https: URI identifying the sender
- * @param {string} publicKey  - URL-safe base64 VAPID public key
- * @param {string} privateKey - URL-safe base64 VAPID private key
- */
 function setVapidDetails(subject, publicKey, privateKey) {
   _vapidKeys = { subject, publicKey, privateKey };
 }
 
 function base64UrlEncode(buf) {
-  return Buffer.from(buf)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
 
 function base64UrlDecode(str) {
@@ -42,84 +39,47 @@ function base64UrlDecode(str) {
   return Buffer.from(str.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(pad), 'base64');
 }
 
-/**
- * Build a VAPID Authorization header value.
- */
 function buildVapidAuthHeader(audience) {
   if (!_vapidKeys) throw new Error('VAPID details not set. Call setVapidDetails() first.');
-
   const { subject, publicKey, privateKey } = _vapidKeys;
-
   const header  = base64UrlEncode(JSON.stringify({ typ: 'JWT', alg: 'ES256' }));
   const now     = Math.floor(Date.now() / 1000);
   const payload = base64UrlEncode(JSON.stringify({ aud: audience, exp: now + 43200, sub: subject }));
-
   const signingInput = `${header}.${payload}`;
   const privKeyDer   = base64UrlDecode(privateKey);
-
-  // Import as raw EC private key (32 bytes) → DER PKCS#8
   const pkcs8 = ecRawToPkcs8(privKeyDer);
   const keyObj = crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
-
   const sig = crypto.sign('SHA256', Buffer.from(signingInput), { key: keyObj, dsaEncoding: 'ieee-p1363' });
-
-  const jwt = `${signingInput}.${base64UrlEncode(sig)}`;
-  return `vapid t=${jwt},k=${publicKey}`;
+  return `vapid t=${signingInput}.${base64UrlEncode(sig)},k=${publicKey}`;
 }
 
-/**
- * Convert a raw 32-byte EC private key to PKCS#8 DER for P-256.
- */
 function ecRawToPkcs8(rawPriv) {
-  // PKCS#8 wrapper for P-256 (OID 1.2.840.10045.3.1.7)
-  const prefix = Buffer.from(
-    '308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b0201010420',
-    'hex'
-  );
+  const prefix = Buffer.from('308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b0201010420', 'hex');
   const suffix = Buffer.from('a144034200', 'hex');
-  // We need the public key too — derive it
   const ecdh = crypto.createECDH('prime256v1');
   ecdh.setPrivateKey(rawPriv);
-  const pubKey = ecdh.getPublicKey(); // 65 bytes uncompressed
-
+  const pubKey = ecdh.getPublicKey();
   return Buffer.concat([prefix, rawPriv, suffix, pubKey]);
 }
 
 // ---------------------------------------------------------------------------
 // Payload encryption (RFC 8291, aes128gcm)
 // ---------------------------------------------------------------------------
-
-/**
- * Encrypt a plaintext payload for delivery to a push subscription.
- * Returns { ciphertext, salt, serverPublicKey }.
- */
 function encryptPayload(subscription, plaintext) {
   const { p256dh, auth } = subscription.keys;
-
-  const receiverPub = base64UrlDecode(p256dh);   // 65-byte uncompressed EC point
-  const authSecret  = base64UrlDecode(auth);       // 16-byte auth secret
-
-  // Generate ephemeral sender key pair
-  const senderECDH = crypto.createECDH('prime256v1');
+  const receiverPub = base64UrlDecode(p256dh);
+  const authSecret  = base64UrlDecode(auth);
+  const senderECDH  = crypto.createECDH('prime256v1');
   senderECDH.generateKeys();
-  const senderPub  = senderECDH.getPublicKey();   // 65 bytes
-
-  // ECDH shared secret
+  const senderPub    = senderECDH.getPublicKey();
   const sharedSecret = senderECDH.computeSecret(receiverPub);
-
-  // Random 16-byte salt
-  const salt = crypto.randomBytes(16);
-
-  // HKDF to derive content encryption key and nonce (RFC 8291 §3.3)
-  const prk = hkdf(authSecret, sharedSecret, buildInfo('auth', Buffer.alloc(0), Buffer.alloc(0)), 32);
-  const cek = hkdf(salt, prk, buildInfo('aesgcm128', receiverPub, senderPub), 16);
+  const salt         = crypto.randomBytes(16);
+  const prk  = hkdf(authSecret, sharedSecret, buildInfo('auth', Buffer.alloc(0), Buffer.alloc(0)), 32);
+  const cek  = hkdf(salt, prk, buildInfo('aesgcm128', receiverPub, senderPub), 16);
   const nonce = hkdf(salt, prk, buildInfo('nonce', receiverPub, senderPub), 12);
-
-  // Pad + encrypt
   const paddedPlaintext = Buffer.concat([Buffer.alloc(2), Buffer.from(plaintext)]);
-  const cipher = crypto.createCipheriv('aes-128-gcm', cek, nonce);
+  const cipher    = crypto.createCipheriv('aes-128-gcm', cek, nonce);
   const encrypted = Buffer.concat([cipher.update(paddedPlaintext), cipher.final(), cipher.getAuthTag()]);
-
   return { ciphertext: encrypted, salt, serverPublicKey: senderPub };
 }
 
@@ -132,11 +92,7 @@ function buildInfo(type, receiverPub, senderPub) {
   ]);
 }
 
-function uint16BE(n) {
-  const b = Buffer.alloc(2);
-  b.writeUInt16BE(n, 0);
-  return b;
-}
+function uint16BE(n) { const b = Buffer.alloc(2); b.writeUInt16BE(n, 0); return b; }
 
 function hkdf(salt, ikm, info, length) {
   const prk = crypto.createHmac('sha256', salt).update(ikm).digest();
@@ -145,25 +101,15 @@ function hkdf(salt, ikm, info, length) {
 }
 
 // ---------------------------------------------------------------------------
-// Send notification
+// Low-level send (returns status code, throws on non-2xx)
 // ---------------------------------------------------------------------------
-
-/**
- * Send a Web Push notification.
- * @param {object} subscription - PushSubscription JSON { endpoint, keys: { p256dh, auth } }
- * @param {string} payload      - JSON string to send
- * @returns {Promise<number>}   - HTTP status code
- */
-function sendNotification(subscription, payload) {
+function _sendRaw(subscription, payload) {
   return new Promise((resolve, reject) => {
     const endpoint = subscription.endpoint;
     const parsed   = new url.URL(endpoint);
     const audience = `${parsed.protocol}//${parsed.host}`;
-
     const { ciphertext, salt, serverPublicKey } = encryptPayload(subscription, payload);
-
     const authHeader = buildVapidAuthHeader(audience);
-
     const body = ciphertext;
     const options = {
       hostname: parsed.hostname,
@@ -171,31 +117,157 @@ function sendNotification(subscription, payload) {
       path:     parsed.pathname + parsed.search,
       method:   'POST',
       headers: {
-        'Authorization':      authHeader,
-        'Content-Type':       'application/octet-stream',
-        'Content-Encoding':   'aesgcm',
-        'Content-Length':     body.length,
-        'Encryption':         `salt=${base64UrlEncode(salt)}`,
-        'Crypto-Key':         `dh=${base64UrlEncode(serverPublicKey)};p256ecdsa=${_vapidKeys.publicKey}`,
-        'TTL':                '86400',
+        'Authorization':    authHeader,
+        'Content-Type':     'application/octet-stream',
+        'Content-Encoding': 'aesgcm',
+        'Content-Length':   body.length,
+        'Encryption':       `salt=${base64UrlEncode(salt)}`,
+        'Crypto-Key':       `dh=${base64UrlEncode(serverPublicKey)};p256ecdsa=${_vapidKeys.publicKey}`,
+        'TTL':              '86400',
       },
     };
-
     const req = https.request(options, (res) => {
       res.resume();
-      if (res.statusCode >= 200 && res.statusCode < 300) {
-        resolve(res.statusCode);
-      } else {
-        const err = new Error(`Push failed: HTTP ${res.statusCode}`);
-        err.statusCode = res.statusCode;
-        reject(err);
-      }
+      if (res.statusCode >= 200 && res.statusCode < 300) return resolve(res.statusCode);
+      const err = new Error(`Push failed: HTTP ${res.statusCode}`);
+      err.statusCode = res.statusCode;
+      err.retryAfter = res.headers['retry-after'] ? parseInt(res.headers['retry-after'], 10) : null;
+      reject(err);
     });
-
     req.on('error', reject);
     req.write(body);
     req.end();
   });
 }
 
-module.exports = { setVapidDetails, sendNotification };
+// ---------------------------------------------------------------------------
+// Public sendNotification with retry enqueue on failure
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to send; on failure enqueue for retry (unless 410/404 → clean up).
+ * @param {object} subscription - { endpoint, keys }
+ * @param {string} payload      - JSON string
+ * @param {string|null} subscriptionId - DB id for cleanup on 410
+ * @param {object} db           - pg pool (optional, passed for 410 cleanup)
+ * @returns {Promise<number>}   - HTTP status
+ */
+async function sendNotification(subscription, payload, subscriptionId = null, dbPool = null) {
+  try {
+    return await module.exports._sendRaw(subscription, payload);
+  } catch (err) {
+    const status = err.statusCode;
+
+    // Permanent failure — clean up subscription
+    if (status === 410 || status === 404) {
+      if (dbPool && subscriptionId) {
+        await dbPool.query('UPDATE users SET push_subscription = NULL WHERE id = $1', [subscriptionId])
+          .catch(e => logger.warn('Failed to remove stale push subscription', { error: e.message }));
+      }
+      return status;
+    }
+
+    // Enqueue for retry
+    if (subscriptionId) {
+      const retryAfter = (status === 429 && err.retryAfter) ? err.retryAfter : RETRY_DELAYS[0];
+      await enqueueRetry({ subscriptionId, subscription, payload, attempt: 1,
+        nextRetryAt: Date.now() + retryAfter * 1000 });
+    }
+
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retry queue
+// ---------------------------------------------------------------------------
+
+async function enqueueRetry(item) {
+  const redis = cache.getClient ? cache.getClient() : null;
+  if (!redis) {
+    logger.warn('Redis unavailable — push retry not queued', { subscriptionId: item.subscriptionId });
+    return;
+  }
+  await redis.rpush(RETRY_QUEUE_KEY, JSON.stringify(item));
+}
+
+/**
+ * Process the retry queue. Called by a background job every 60 seconds.
+ * @param {object} dbPool - pg pool for 410 cleanup
+ */
+async function processRetryQueue(dbPool) {
+  const redis = cache.getClient ? cache.getClient() : null;
+  if (!redis) return;
+
+  const now = Date.now();
+  let raw;
+  // Process all due items (LPOP loop)
+  while ((raw = await redis.lpop(RETRY_QUEUE_KEY)) !== null) {
+    let item;
+    try { item = JSON.parse(raw); } catch { continue; }
+
+    if (item.nextRetryAt > now) {
+      // Not yet due — put back at head and stop processing (preserve order)
+      await redis.lpush(RETRY_QUEUE_KEY, raw);
+      break;
+    }
+
+    try {
+      await module.exports._sendRaw(item.subscription, item.payload);
+      logger.info('Push retry succeeded', { subscriptionId: item.subscriptionId, attempt: item.attempt });
+    } catch (err) {
+      const status = err.statusCode;
+
+      if (status === 410 || status === 404) {
+        // Permanently gone — clean up
+        if (dbPool && item.subscriptionId) {
+          await dbPool.query('UPDATE users SET push_subscription = NULL WHERE id = $1', [item.subscriptionId])
+            .catch(() => {});
+        }
+        continue;
+      }
+
+      if (item.attempt >= MAX_ATTEMPTS) {
+        // Move to dead-letter
+        logger.warn('Push notification exhausted retries — moving to dead-letter',
+          { subscriptionId: item.subscriptionId });
+        await redis.rpush(DEAD_LETTER_KEY, JSON.stringify({ ...item, failedAt: Date.now(), error: err.message }));
+        continue;
+      }
+
+      // Schedule next retry
+      const delaySeconds = (status === 429 && err.retryAfter)
+        ? err.retryAfter
+        : RETRY_DELAYS[item.attempt] || RETRY_DELAYS[MAX_ATTEMPTS - 1];
+
+      await redis.rpush(RETRY_QUEUE_KEY, JSON.stringify({
+        ...item,
+        attempt: item.attempt + 1,
+        nextRetryAt: Date.now() + delaySeconds * 1000,
+      }));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dead-letter inspection
+// ---------------------------------------------------------------------------
+
+async function getDeadLetter() {
+  const redis = cache.getClient ? cache.getClient() : null;
+  if (!redis) return [];
+  const items = await redis.lrange(DEAD_LETTER_KEY, 0, -1);
+  return items.map(i => { try { return JSON.parse(i); } catch { return null; } }).filter(Boolean);
+}
+
+module.exports = {
+  setVapidDetails,
+  sendNotification,
+  processRetryQueue,
+  getDeadLetter,
+  _sendRaw,
+  RETRY_QUEUE_KEY,
+  DEAD_LETTER_KEY,
+  MAX_ATTEMPTS,
+  RETRY_DELAYS,
+};

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -58,4 +58,4 @@ async function del(key) {
   }
 }
 
-module.exports = { get, set, del, BALANCE_TTL };
+module.exports = { get, set, del, BALANCE_TTL, getClient };

--- a/database/migrations/026_fraud_rule_engine.js
+++ b/database/migrations/026_fraud_rule_engine.js
@@ -1,0 +1,41 @@
+exports.up = (pgm) => {
+  pgm.createTable('fraud_rules', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(100)', notNull: true, unique: true },
+    rule_type: { type: 'varchar(20)', notNull: true },
+    parameters: { type: 'jsonb', notNull: true },
+    is_active: { type: 'boolean', notNull: true, default: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.addConstraint('fraud_rules', 'fraud_rules_rule_type_check',
+    "rule_type IN ('velocity', 'amount', 'daily_limit')");
+
+  pgm.createTable('fraud_checks', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    rule_name: { type: 'varchar(100)', notNull: true },
+    rule_type: { type: 'varchar(20)', notNull: true },
+    outcome: { type: 'varchar(10)', notNull: true }, // 'blocked' | 'passed'
+    payment_id: { type: 'uuid' },
+    wallet_address: { type: 'text', notNull: true },
+    metadata: { type: 'jsonb' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('fraud_checks', 'wallet_address');
+  pgm.createIndex('fraud_checks', 'created_at');
+
+  // Seed default rules matching existing hardcoded behaviour
+  pgm.sql(`
+    INSERT INTO fraud_rules (name, rule_type, parameters) VALUES
+    ('default_velocity', 'velocity', '{"max_transactions": 5, "window_minutes": 10}'),
+    ('default_daily_limit', 'daily_limit', '{"max_usd": 10000}'),
+    ('default_amount', 'amount', '{"max_usd": 50000}')
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('fraud_checks');
+  pgm.dropTable('fraud_rules');
+};

--- a/database/migrations/027_bulk_user_management.js
+++ b/database/migrations/027_bulk_user_management.js
@@ -1,0 +1,27 @@
+exports.up = (pgm) => {
+  pgm.addColumns('users', {
+    is_suspended: { type: 'boolean', notNull: true, default: false },
+    suspension_reason: { type: 'text' },
+    suspended_at: { type: 'timestamptz' },
+  });
+
+  pgm.createTable('export_jobs', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    admin_id: { type: 'uuid', notNull: true },
+    status: { type: 'varchar(20)', notNull: true, default: "'pending'" },
+    operation: { type: 'varchar(50)', notNull: true },
+    filters: { type: 'jsonb' },
+    download_url: { type: 'text' },
+    error: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('NOW()') },
+    completed_at: { type: 'timestamptz' },
+  });
+
+  pgm.addConstraint('export_jobs', 'export_jobs_status_check',
+    "status IN ('pending', 'processing', 'completed', 'failed')");
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('export_jobs');
+  pgm.dropColumns('users', ['is_suspended', 'suspension_reason', 'suspended_at']);
+};


### PR DESCRIPTION
…retry (#690 #691 #692 #693)

closes #690 — Configurable Fraud Rule Engine
- Add DB migration 026: fraud_rules (id, name, rule_type, parameters JSONB, is_active) and fraud_checks audit table
- Rewrite fraudDetection.js: evaluates active rules from DB, Redis-cached for 5 minutes (RULES_CACHE_TTL=300s)
- Rule types: velocity (max N tx in T minutes), amount (single tx > X USD), daily_limit (24h cumulative > X USD)
- Returns {blocked, rule, message} on first triggered rule; all evaluations logged to fraud_checks
- Admin endpoints: GET /api/admin/fraud-rules, POST /api/admin/fraud-rules, PATCH /api/admin/fraud-rules/:id
- 22 unit tests covering all rule types, boundary values, cache behaviour, and legacy API

closes #691 — SEP-10 Session Expiry and Silent Token Refresh
- Add storeSession/getSession/deleteSession backed by Redis cache with TTL
- getValidToken(): checks exp field, triggers re-auth if token expires within 60s (EXPIRY_BUFFER_SECONDS)
- Async mutex (_withLock) prevents concurrent re-auth attempts for the same user
- Returns SEP10_REAUTH_REQUIRED error (code) when reauthFn is absent or fails
- 8 unit tests: fresh token, near-expiry refresh, absent session, null reauthFn, reauthFn failure, concurrent dedup

closes #692 — Bulk User Management API
- Add DB migration 027: is_suspended/suspension_reason/suspended_at columns on users, export_jobs table
- POST /api/admin/users/bulk-suspend — atomic transaction, suspension emails queued async
- POST /api/admin/users/bulk-unsuspend — atomic transaction
- POST /api/admin/users/bulk-export — async job, GET /api/admin/jobs/:jobId polls status + download URL
- POST /api/admin/users/bulk-kyc-update — approved|rejected in transaction
- 500 user hard limit per request (returns 400 on excess); all operations audit-logged

closes #693 — Push Notification Retry with Exponential Backoff
- Rewrite webpush.js: failed sends enqueued to Redis push:retry_queue (subscriptionId, payload, attempt, nextRetryAt)
- processRetryQueue(): runs every 60s via cron; retries at 60s/300s/1800s delays
- After 3 attempts → push:dead_letter list; 410/404 → immediate subscription cleanup from DB
- 429 with Retry-After header respected as next retry delay
- GET /api/admin/notifications/dead-letter for admin inspection
- 11 unit tests: success, transient failure re-queue, exhaustion, 410 cleanup, 429 backoff, future-skip, dead-letter
