### PR TITLE
feat: SW update banner, 2FA manual key, reset countdown, remember device (#674–677)

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -14,6 +14,8 @@ const {
   signAccessToken,
   generateRefreshToken,
   refreshTokenExpiresAt,
+  signDeviceToken,
+  verifyDeviceToken,
 } = require('../utils/tokens');
 const { setCsrfCookie } = require('../middleware/csrf');
 
@@ -163,7 +165,8 @@ async function register(req, res, next) {
 
 async function login(req, res, next) {
   try {
-    const { email, password, totp_code } = req.body;
+    const { email, password, totp_code, rememberDevice } = req.body;
+    const incomingDeviceToken = req.headers['x-device-token'];
 
     const result = await db.query(
       `SELECT u.id, u.full_name, u.email, u.password_hash, u.email_verified, u.role,
@@ -245,15 +248,25 @@ async function login(req, res, next) {
       return res.status(403).json({ error: 'Please verify your email before logging in.' });
     }
 
-    // Short-lived access token
     // 2FA check — must happen before issuing tokens
     if (user.totp_enabled) {
-      if (!totp_code) {
-        return res.status(403).json({ error: 'TOTP code required', requires_2fa: true });
+      // Check if the incoming device trust token allows skipping TOTP
+      let deviceTrusted = false;
+      if (incomingDeviceToken) {
+        try {
+          const payload = verifyDeviceToken(incomingDeviceToken);
+          deviceTrusted = String(payload.userId) === String(user.id);
+        } catch { /* expired or invalid — fall through to TOTP */ }
       }
-      const isValid = verifyToken(user.totp_secret, totp_code);
-      if (!isValid) {
-        return res.status(401).json({ error: 'Invalid TOTP code' });
+
+      if (!deviceTrusted) {
+        if (!totp_code) {
+          return res.status(403).json({ error: 'TOTP code required', requires_2fa: true });
+        }
+        const isValid = verifyToken(user.totp_secret, totp_code);
+        if (!isValid) {
+          return res.status(401).json({ error: 'Invalid TOTP code' });
+        }
       }
     }
 
@@ -280,6 +293,8 @@ async function login(req, res, next) {
     // Record session for remote logout support
     await recordSession(user.id, token, req).catch(() => {});
 
+    const device_token = rememberDevice ? signDeviceToken({ userId: user.id }) : undefined;
+
     res.cookie(COOKIE_NAME, raw, COOKIE_OPTIONS);
     setCsrfCookie(res);
     audit.log(user.id, 'login_success', req.ip, req.headers['user-agent']);
@@ -292,6 +307,7 @@ async function login(req, res, next) {
         wallet_address: user.public_key,
         phone_verified: user.phone_verified,
       },
+      ...(device_token && { device_token }),
     });
   } catch (err) {
     next(err);
@@ -417,7 +433,7 @@ async function setup2FA(req, res, next) {
     const user = await db.query('SELECT email FROM users WHERE id = $1', [userId]);
     if (!user.rows[0]) return res.status(404).json({ error: 'User not found' });
 
-    const { secret, qrCode } = await generateSecret(user.rows[0].email);
+    const { secret, qrCode, otpauthUri } = await generateSecret(user.rows[0].email);
     const backupCodes = generateBackupCodes();
 
     // Store temporarily (not enabled yet)
@@ -426,7 +442,7 @@ async function setup2FA(req, res, next) {
       [secret, backupCodes, userId]
     );
 
-    res.json({ qrCode, backupCodes, secret });
+    res.json({ qrCode, backupCodes, secret, otpauthUri });
   } catch (err) {
     next(err);
   }
@@ -699,6 +715,30 @@ async function resetPassword(req, res, next) {
   }
 }
 
+async function validateResetToken(req, res, next) {
+  try {
+    const { token } = req.query;
+    if (!token) {
+      return res.status(400).json({ error: 'Token is required' });
+    }
+
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const found = await db.query(
+      `SELECT expires_at FROM password_reset_tokens
+       WHERE token_hash = $1 AND used_at IS NULL AND expires_at > NOW()`,
+      [tokenHash]
+    );
+
+    if (found.rows.length === 0) {
+      return res.status(401).json({ error: 'Invalid or expired reset token' });
+    }
+
+    res.json({ expires_at: found.rows[0].expires_at });
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function updateProfile(req, res, next) {
   try {
     const { full_name, phone } = req.body;
@@ -890,4 +930,5 @@ module.exports = {
   disable2FA,
   forgotPassword,
   resetPassword,
+  validateResetToken,
 };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const { body, validationResult } = require('express-validator');
 const multer = require('multer');
-const { register, login, verifyEmail, getMe, setPIN, verifyPIN } = require('../controllers/authController');
 const {
   register,
   login,
@@ -9,16 +8,20 @@ const {
   logout,
   verifyEmail,
   verifyPhone,
+  getMe,
   updateProfile,
   changeEmail,
   verifyEmailChange,
   getActivity,
   uploadAvatar,
+  setPIN,
+  verifyPIN,
   setup2FA,
   verify2FA,
   disable2FA,
   forgotPassword,
   resetPassword,
+  validateResetToken,
 } = require('../controllers/authController');
 const authMiddleware = require('../middleware/auth');
 const geoRestriction = require('../middleware/geoRestriction');
@@ -90,6 +93,8 @@ router.post(
   validate,
   resetPassword
 );
+
+router.get('/reset-password/validate', validateResetToken);
 
 router.post('/refresh', verifyCsrf, refresh);
 router.post('/logout', verifyCsrf, logout);

--- a/backend/src/services/twofa.js
+++ b/backend/src/services/twofa.js
@@ -10,7 +10,7 @@ async function generateSecret(email) {
   });
 
   const qrCode = await QRCode.toDataURL(secret.otpauth_url);
-  return { secret: secret.base32, qrCode };
+  return { secret: secret.base32, qrCode, otpauthUri: secret.otpauth_url };
 }
 
 function verifyToken(secret, token) {

--- a/backend/src/utils/tokens.js
+++ b/backend/src/utils/tokens.js
@@ -4,6 +4,9 @@ const jwt = require('jsonwebtoken');
 /** Short-lived access token (default 15m). Override with JWT_EXPIRES_IN e.g. "15m". */
 const ACCESS_TOKEN_TTL = process.env.JWT_EXPIRES_IN || '15m';
 
+/** Device trust token lifetime: 30 days. */
+const DEVICE_TOKEN_TTL = '30d';
+
 /** Refresh token lifetime in days (default 30). */
 const REFRESH_TOKEN_DAYS = Math.max(
   1,
@@ -39,12 +42,29 @@ function refreshTokenExpiresAt() {
   return new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
 }
 
+/** Issue a 30-day device trust token (stored client-side in localStorage). */
+function signDeviceToken(payload) {
+  return jwt.sign({ ...payload, type: 'device_trust' }, process.env.JWT_SECRET, { expiresIn: DEVICE_TOKEN_TTL });
+}
+
+/**
+ * Verify a device trust token. Throws if invalid, expired, or wrong type.
+ * Returns the decoded payload.
+ */
+function verifyDeviceToken(token) {
+  const payload = jwt.verify(token, process.env.JWT_SECRET);
+  if (payload.type !== 'device_trust') throw new Error('Not a device trust token');
+  return payload;
+}
+
 module.exports = {
   COOKIE_NAME,
   COOKIE_OPTIONS,
   signAccessToken,
   generateRefreshToken,
   refreshTokenExpiresAt,
+  signDeviceToken,
+  verifyDeviceToken,
   ACCESS_TOKEN_TTL,
   REFRESH_TOKEN_DAYS,
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import Sessions from "./pages/Sessions";
 import Escrow from "./pages/Escrow";
 import Layout from "./components/Layout";
 import ErrorBoundary from "./components/ErrorBoundary";
+import UpdateBanner from "./components/UpdateBanner";
 
 // Code-split large pages
 const Analytics = React.lazy(() => import("./pages/Analytics"));
@@ -193,6 +194,7 @@ export default function App() {
               }}
             />
             <AppRoutes />
+            <UpdateBanner />
           </BrowserRouter>
           </CurrencyProvider>
         </ThemeProvider>

--- a/frontend/src/components/UpdateBanner.jsx
+++ b/frontend/src/components/UpdateBanner.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import { skipWaiting } from '../serviceWorker';
+
+const SNOOZE_KEY = 'afripay_sw_update_snoozed_until';
+const SNOOZE_MS = 30 * 60 * 1000;
+
+export default function UpdateBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleUpdateAvailable = () => setVisible(true);
+    window.addEventListener('swUpdateAvailable', handleUpdateAvailable);
+    return () => window.removeEventListener('swUpdateAvailable', handleUpdateAvailable);
+  }, []);
+
+  if (!visible) return null;
+
+  const handleUpdate = () => {
+    skipWaiting();
+  };
+
+  const handleLater = () => {
+    localStorage.setItem(SNOOZE_KEY, String(Date.now() + SNOOZE_MS));
+    setVisible(false);
+    setTimeout(() => setVisible(true), SNOOZE_MS);
+  };
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 border-t border-gray-700 px-4 py-3 flex items-center justify-between gap-3 shadow-lg"
+    >
+      <p className="text-sm text-white">A new version of AfriPay is available.</p>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          onClick={handleLater}
+          className="text-sm text-gray-400 hover:text-white px-3 py-1.5 rounded-lg transition-colors"
+        >
+          Later
+        </button>
+        <button
+          onClick={handleUpdate}
+          className="text-sm bg-primary-500 hover:bg-primary-600 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+        >
+          Update Now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -35,8 +35,9 @@ export function AuthProvider({ children }) {
       .finally(() => setLoading(false));
   }, []);
 
-  const login = async (email, password) => {
-    const res = await api.post('/auth/login', { email, password });
+  const login = async (email, password, options = {}, deviceToken = null) => {
+    const headers = deviceToken ? { 'x-device-token': deviceToken } : {};
+    const res = await api.post('/auth/login', { email, password, ...options }, { headers });
     tokenStore.set(res.data.token);
     setUser(res.data.user);
     Sentry.setUser({
@@ -59,6 +60,7 @@ export function AuthProvider({ children }) {
     }
     tokenStore.clear();
     localStorage.removeItem('afripay_slippage');
+    localStorage.removeItem('afripay_device_token');
     setUser(null);
     Sentry.setUser(null);
   };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -14,9 +14,7 @@ export default function Login() {
   const [form, setForm] = useState({ email: '', password: '' });
   const [showPass, setShowPass] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [rememberMe, setRememberMe] = useState(() => {
-    return localStorage.getItem('afripay_remember_me') === 'true';
-  });
+  const [rememberDevice, setRememberDevice] = useState(false);
 
   // Rate-limit cooldown (issue #655) — persisted across refreshes via sessionStorage
   const COOLDOWN_KEY = 'afripay_login_cooldown_until';
@@ -65,9 +63,16 @@ export default function Login() {
     e.preventDefault();
     setLoading(true);
     try {
-      await login(form.email, form.password);
-      // Persist remember-me preference
-      localStorage.setItem('afripay_remember_me', rememberMe.toString());
+      const existingDeviceToken = localStorage.getItem('afripay_device_token');
+      const result = await login(
+        form.email,
+        form.password,
+        rememberDevice ? { rememberDevice: true } : {},
+        existingDeviceToken
+      );
+      if (result?.device_token) {
+        localStorage.setItem('afripay_device_token', result.device_token);
+      }
       const redirectParam = searchParams.get('redirect');
       const redirect = redirectParam || sessionStorage.getItem('afripay_redirect');
       sessionStorage.removeItem('afripay_redirect');
@@ -98,11 +103,15 @@ export default function Login() {
     if (digits.length === 6) {
       setLoading(true);
       try {
-        const res = await api.post('/auth/login', {
-          email: form.email,
-          password: form.password,
-          totp_code: digits,
-        });
+        const deviceToken = localStorage.getItem('afripay_device_token');
+        const res = await api.post(
+          '/auth/login',
+          { email: form.email, password: form.password, totp_code: digits, ...(rememberDevice && { rememberDevice: true }) },
+          deviceToken ? { headers: { 'x-device-token': deviceToken } } : {}
+        );
+        if (res.data.device_token) {
+          localStorage.setItem('afripay_device_token', res.data.device_token);
+        }
         // Manually set token + user via the same path login() uses
         const { tokenStore } = await import('../context/AuthContext');
         tokenStore.set(res.data.token);
@@ -215,11 +224,11 @@ export default function Login() {
                 <label className="flex items-center gap-2 cursor-pointer">
                   <input
                     type="checkbox"
-                    checked={rememberMe}
-                    onChange={(e) => setRememberMe(e.target.checked)}
+                    checked={rememberDevice}
+                    onChange={(e) => setRememberDevice(e.target.checked)}
                     className="w-4 h-4 rounded border-gray-300 text-primary-500 focus:ring-primary-500 cursor-pointer"
                   />
-                  <span className="text-sm text-gray-600 dark:text-gray-400">{t('login.remember_me', 'Remember me')}</span>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">{t('login.remember_device', 'Remember this device for 30 days')}</span>
                 </label>
                 <Link to="/forgot-password" className="text-sm text-primary-500 hover:underline">
                   {t('login.forgot_password')}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
 import { useNavigate, Link } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -1267,7 +1268,20 @@ export default function Profile() {
               <p className="text-sm text-gray-300 text-center">
                 Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)
               </p>
-              <img src={twoFAData.qrCode} alt="2FA QR Code" className="w-44 h-44 rounded-lg" />
+              <div className="bg-white p-2 rounded-lg">
+                <QRCodeSVG
+                  value={twoFAData.otpauthUri || twoFAData.qrCode}
+                  size={176}
+                />
+              </div>
+              {twoFAData.secret && (
+                <div className="w-full text-center">
+                  <p className="text-xs text-gray-400 mb-1">Or enter this key manually:</p>
+                  <p className="font-mono text-xs text-white bg-gray-900 px-3 py-2 rounded-lg break-all tracking-widest select-all">
+                    {twoFAData.secret}
+                  </p>
+                </div>
+              )}
             </div>
 
             <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl p-4">

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import toast from 'react-hot-toast';
-import { Eye, EyeOff, ArrowLeft, Check, X, AlertCircle } from 'lucide-react';
+import { Eye, EyeOff, ArrowLeft, Check, X, AlertCircle, Clock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import api from '../utils/api';
 import { getPasswordStrength, getPasswordError } from '../utils/passwordValidator';
@@ -17,6 +17,52 @@ export default function ResetPassword() {
   const [loading, setLoading] = useState(false);
   const [touched, setTouched] = useState(false);
 
+  // Token validation state
+  const [tokenStatus, setTokenStatus] = useState('checking'); // 'checking' | 'valid' | 'expired'
+  const [expiresAt, setExpiresAt] = useState(null);
+  const [countdown, setCountdown] = useState('');
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Validate token on mount
+  useEffect(() => {
+    if (!tokenFromUrl.trim()) {
+      setTokenStatus('expired');
+      return;
+    }
+    api
+      .get(`/auth/reset-password/validate?token=${encodeURIComponent(tokenFromUrl)}`)
+      .then((res) => {
+        setExpiresAt(new Date(res.data.expires_at).getTime());
+        setTokenStatus('valid');
+      })
+      .catch(() => {
+        setTokenStatus('expired');
+      });
+  }, [tokenFromUrl]);
+
+  // Countdown tick
+  useEffect(() => {
+    if (tokenStatus !== 'valid' || !expiresAt) return;
+
+    const tick = () => {
+      const remaining = Math.ceil((expiresAt - Date.now()) / 1000);
+      if (remaining <= 0) {
+        setTokenStatus('expired');
+        return;
+      }
+      const mins = Math.floor(remaining / 60);
+      const secs = remaining % 60;
+      setCountdown(`${mins}m ${String(secs).padStart(2, '0')}s`);
+    };
+
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [tokenStatus, expiresAt]);
+
   const strength = getPasswordStrength(password);
   const passwordError = touched ? getPasswordError(password) : '';
 
@@ -29,14 +75,10 @@ export default function ResetPassword() {
       return;
     }
 
-    if (!tokenFromUrl.trim()) {
-      toast.error(t('passwordReset.missing_token'));
-      return;
-    }
     setLoading(true);
     try {
       await api.post('/auth/reset-password', { token: tokenFromUrl, password });
-      toast.success(t('passwordReset.reset_success_toast'));
+      toast.success('Password reset successfully. Please log in.');
       navigate('/login');
     } catch (err) {
       const msg =
@@ -60,71 +102,104 @@ export default function ResetPassword() {
         <h2 className="text-2xl font-bold text-white mb-1">{t('passwordReset.reset_title')}</h2>
         <p className="text-gray-400 mb-8">{t('passwordReset.reset_subtitle')}</p>
 
-        {!tokenFromUrl.trim() ? (
-          <p className="text-amber-400 text-sm mb-4">{t('passwordReset.missing_token')}</p>
-        ) : null}
+        {tokenStatus === 'checking' && (
+          <div className="flex items-center justify-center py-8">
+            <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="text-sm text-gray-400 mb-1 block">{t('passwordReset.new_password')}</label>
-            <div className="relative">
-              <input
-                type={showPass ? 'text' : 'password'}
-                required
-                minLength={8}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                onBlur={() => setTouched(true)}
-                className={`w-full bg-gray-800 border rounded-xl px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors pr-12 ${
-                  passwordError ? 'border-red-500' : 'border-gray-700'
-                }`}
-                placeholder={t('login.password_placeholder')}
-              />
-              <button
-                type="button"
-                onClick={() => setShowPass(!showPass)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
-              >
-                {showPass ? <EyeOff size={18} /> : <Eye size={18} />}
-              </button>
+        {tokenStatus === 'expired' && (
+          <div className="text-center space-y-4">
+            <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-5">
+              <AlertCircle size={32} className="text-red-400 mx-auto mb-3" />
+              <p className="text-white font-semibold mb-1">This reset link has expired.</p>
+              <p className="text-gray-400 text-sm">Reset links are only valid for 1 hour.</p>
             </div>
-            {passwordError && (
-              <p className="text-xs text-red-500 mt-1 flex items-center gap-1">
-                <AlertCircle size={12} /> {passwordError}
-              </p>
-            )}
-            {password && (
-              <div className="mt-2 space-y-2">
-                <div className="flex gap-1">
-                  {[1, 2, 3, 4, 5].map(i => (
-                    <div key={i} className={`h-1 flex-1 rounded-full transition-colors ${i <= strength.score ? strength.barColor : 'bg-gray-700'}`} />
-                  ))}
-                </div>
-                <p className={`text-xs font-medium capitalize ${strength.textColor}`}>{strength.label}</p>
-                <ul className="space-y-1">
-                  {[
-                    { key: 'length', label: 'At least 8 characters' },
-                    { key: 'uppercase', label: 'One uppercase letter' },
-                    { key: 'lowercase', label: 'One lowercase letter' },
-                    { key: 'number', label: 'One number' },
-                    { key: 'special', label: 'One special character' },
-                  ].map(({ key, label }) => (
-                    <li key={key} className={`flex items-center gap-1.5 text-xs ${strength.checks[key] ? 'text-green-500' : 'text-gray-500'}`}>
-                      {strength.checks[key] ? <Check size={12} /> : <X size={12} />} {label}
-                    </li>
-                  ))}
-                </ul>
+            <Link
+              to="/forgot-password"
+              className="block w-full bg-primary-500 hover:bg-primary-600 text-white font-semibold py-3.5 rounded-xl text-center transition-colors"
+            >
+              Request a new link
+            </Link>
+          </div>
+        )}
+
+        {tokenStatus === 'valid' && (
+          <>
+            {countdown && (
+              <div className="flex items-center gap-2 text-sm text-gray-400 mb-6">
+                <Clock size={14} className="shrink-0" />
+                {prefersReducedMotion ? (
+                  <span>This link expires soon.</span>
+                ) : (
+                  <span>This link expires in <span className="text-white font-mono">{countdown}</span></span>
+                )}
               </div>
             )}
-          </div>
-          <button
-            type="submit"
-            disabled={loading || !tokenFromUrl.trim() || passwordError}
-            className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold py-3.5 rounded-xl transition-colors"
-          >
-            {loading ? t('passwordReset.reset_submitting') : t('passwordReset.reset_submit')}
-          </button>
-        </form>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="text-sm text-gray-400 mb-1 block">{t('passwordReset.new_password')}</label>
+                <div className="relative">
+                  <input
+                    type={showPass ? 'text' : 'password'}
+                    required
+                    minLength={8}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    onBlur={() => setTouched(true)}
+                    className={`w-full bg-gray-800 border rounded-xl px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-primary-500 transition-colors pr-12 ${
+                      passwordError ? 'border-red-500' : 'border-gray-700'
+                    }`}
+                    placeholder={t('login.password_placeholder')}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPass(!showPass)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
+                  >
+                    {showPass ? <EyeOff size={18} /> : <Eye size={18} />}
+                  </button>
+                </div>
+                {passwordError && (
+                  <p className="text-xs text-red-500 mt-1 flex items-center gap-1">
+                    <AlertCircle size={12} /> {passwordError}
+                  </p>
+                )}
+                {password && (
+                  <div className="mt-2 space-y-2">
+                    <div className="flex gap-1">
+                      {[1, 2, 3, 4, 5].map(i => (
+                        <div key={i} className={`h-1 flex-1 rounded-full transition-colors ${i <= strength.score ? strength.barColor : 'bg-gray-700'}`} />
+                      ))}
+                    </div>
+                    <p className={`text-xs font-medium capitalize ${strength.textColor}`}>{strength.label}</p>
+                    <ul className="space-y-1">
+                      {[
+                        { key: 'length', label: 'At least 8 characters' },
+                        { key: 'uppercase', label: 'One uppercase letter' },
+                        { key: 'lowercase', label: 'One lowercase letter' },
+                        { key: 'number', label: 'One number' },
+                        { key: 'special', label: 'One special character' },
+                      ].map(({ key, label }) => (
+                        <li key={key} className={`flex items-center gap-1.5 text-xs ${strength.checks[key] ? 'text-green-500' : 'text-gray-500'}`}>
+                          {strength.checks[key] ? <Check size={12} /> : <X size={12} />} {label}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+              <button
+                type="submit"
+                disabled={loading || !!passwordError}
+                className="w-full bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-semibold py-3.5 rounded-xl transition-colors"
+              >
+                {loading ? t('passwordReset.reset_submitting') : t('passwordReset.reset_submit')}
+              </button>
+            </form>
+          </>
+        )}
 
         <p className="text-center text-gray-500 mt-6 text-sm">
           <Link to="/login" className="text-primary-500 hover:underline">{t('passwordReset.back_to_login')}</Link>

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Monitor, Trash2, LogOut } from 'lucide-react';
+import { ArrowLeft, Monitor, Trash2, LogOut, ShieldCheck } from 'lucide-react';
 import api from '../utils/api';
 import toast from 'react-hot-toast';
 import ConfirmModal from '../components/ConfirmModal';
@@ -12,6 +12,7 @@ export default function Sessions() {
   const [revoking, setRevoking] = useState(null);
   const [confirmAll, setConfirmAll] = useState(false);
   const [confirmSingle, setConfirmSingle] = useState(null);
+  const [trustedDevice, setTrustedDevice] = useState(null); // { expiry: Date } | null
 
   const load = async () => {
     try {
@@ -24,7 +25,22 @@ export default function Sessions() {
     }
   };
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+    const raw = localStorage.getItem('afripay_device_token');
+    if (raw) {
+      try {
+        const payload = JSON.parse(atob(raw.split('.')[1]));
+        if (payload.exp * 1000 > Date.now()) {
+          setTrustedDevice({ expiry: new Date(payload.exp * 1000) });
+        } else {
+          localStorage.removeItem('afripay_device_token');
+        }
+      } catch {
+        localStorage.removeItem('afripay_device_token');
+      }
+    }
+  }, []);
 
   const revoke = async (id) => {
     setRevoking(id);
@@ -38,6 +54,12 @@ export default function Sessions() {
       setRevoking(null);
       setConfirmSingle(null);
     }
+  };
+
+  const revokeTrustedDevice = () => {
+    localStorage.removeItem('afripay_device_token');
+    setTrustedDevice(null);
+    toast.success('Device trust removed');
   };
 
   const revokeAll = async () => {
@@ -130,6 +152,32 @@ export default function Sessions() {
         </div>
       )}
     </div>
+
+      {trustedDevice && (
+        <div className="mt-6">
+          <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">Trusted Device</h3>
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <div className="w-9 h-9 bg-primary-500/20 rounded-lg flex items-center justify-center shrink-0">
+                <ShieldCheck size={16} className="text-primary-400" />
+              </div>
+              <div>
+                <p className="text-sm text-white font-medium">This device</p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Trusted until {trustedDevice.expiry.toLocaleDateString()}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={revokeTrustedDevice}
+              className="text-red-400 hover:text-red-300 shrink-0"
+              aria-label="Remove device trust"
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
+        </div>
+      )}
 
       <ConfirmModal
         isOpen={confirmAll}

--- a/frontend/src/serviceWorker.js
+++ b/frontend/src/serviceWorker.js
@@ -2,20 +2,27 @@
  * serviceWorker.js
  *
  * Registers the AfriPay service worker (public/sw.js) using workbox-window.
- * workbox-window handles:
- *  - Waiting for the SW to be installed before prompting
- *  - Detecting when a new SW is waiting (for future update prompts)
- *  - Logging in development
+ * When a new SW is waiting to activate, a custom DOM event `swUpdateAvailable`
+ * is dispatched so the UpdateBanner component can prompt the user.
  *
  * Call register() once from src/index.js.
  */
 
 import { Workbox } from 'workbox-window';
 
+const SNOOZE_KEY = 'afripay_sw_update_snoozed_until';
+
+let _wb = null;
+
+/** Called by UpdateBanner when the user clicks "Update Now". */
+export function skipWaiting() {
+  if (_wb) {
+    _wb.messageSkipWaiting();
+    window.location.reload();
+  }
+}
+
 export function register() {
-  // Only register in production and when the browser supports service workers.
-  // In development CRA serves files from memory, so the SW would intercept
-  // hot-reload requests and break the dev experience.
   if (
     process.env.NODE_ENV !== 'production' ||
     !('serviceWorker' in navigator)
@@ -23,23 +30,22 @@ export function register() {
     return;
   }
 
-  const wb = new Workbox(`${process.env.PUBLIC_URL}/sw.js`);
+  _wb = new Workbox(`${process.env.PUBLIC_URL}/sw.js`);
 
-  // When a new SW has installed and is waiting to activate, you could show
-  // an "Update available — reload?" prompt here. For now we skip-wait
-  // automatically so users always get the latest SW without manual action.
-  wb.addEventListener('waiting', () => {
-    wb.messageSkipWaiting();
+  _wb.addEventListener('waiting', () => {
+    const snoozedUntil = parseInt(localStorage.getItem(SNOOZE_KEY) || '0', 10);
+    if (Date.now() > snoozedUntil) {
+      window.dispatchEvent(new Event('swUpdateAvailable'));
+    }
   });
 
-  wb.addEventListener('activated', (event) => {
-    // On first activation claim all open clients immediately
+  _wb.addEventListener('activated', (event) => {
     if (!event.isUpdate) {
       console.log('[SW] Service worker activated for the first time.');
     }
   });
 
-  wb.register().catch((err) => {
+  _wb.register().catch((err) => {
     console.error('[SW] Registration failed:', err);
   });
 }


### PR DESCRIPTION
## Summary

Implements four related auth/UX improvements across frontend and backend.

### closes #674 — ServiceWorker cache invalidation on app update
- `serviceWorker.js` no longer silently calls `skipWaiting()`. Instead it dispatches a `swUpdateAvailable` DOM event when a new SW is waiting (respecting a 30-minute snooze stored in `localStorage`).
- New `UpdateBanner` component renders a fixed banner at the bottom of the screen: *"A new version of AfriPay is available."* with **Update Now** and **Later** buttons.
- **Update Now** calls `skipWaiting()` and reloads. **Later** snoozes the banner for 30 minutes.

### closes #675 — 2FA QR code rendered via qrcode.react with manual key
- Backend `twofa.js` now returns the raw `otpauth://` URI (`otpauthUri`) alongside the existing base64 PNG.
- `POST /auth/2fa/setup` response includes `otpauthUri` and `secret`.
- `Profile.jsx` replaces the `<img>` with `<QRCodeSVG value={otpauthUri}>` from `qrcode.react`, and shows the base32 secret below for users who cannot scan.

### closes #676 — Reset password token expiry countdown
- New `GET /auth/reset-password/validate?token=TOKEN` endpoint returns `{ expires_at }` or 401 if invalid/expired.
- `ResetPassword.jsx` calls the endpoint on mount; shows a live countdown (*"This link expires in 14m 32s"*) while valid, and immediately replaces the form with an expiry notice and a *"Request a new link"* button when expired.
- Respects `prefers-reduced-motion` (static text instead of live counter).
- Success toast now reads *"Password reset successfully. Please log in."*

### closes #677 — Remember this device across sessions
- Login checkbox renamed to **"Remember this device for 30 days"** and defaults to unchecked.
- When checked, `{ rememberDevice: true }` is included in the login body; the backend issues a signed 30-day device-trust JWT returned as `device_token` and stored in `localStorage` under `afripay_device_token`.
- On all subsequent login attempts the stored `device_token` is sent via `X-Device-Token`; the backend verifies it and skips the TOTP challenge when valid — implementing the 2FA skip for trusted devices.
- `AuthContext.login()` now accepts `options` and `deviceToken` parameters; `logout()` clears `afripay_device_token`.
- `Sessions.jsx` gains a **Trusted Devices** section that decodes the local device token and shows the trust expiry with a revoke (remove from localStorage) button.

### Housekeeping
- Fixed a pre-existing duplicate `require()` on line 4 of `backend/src/routes/auth.js` that would have caused a `SyntaxError` (`Identifier 'register' has already been declared`). The two conflicting declarations were merged into one.

## Test plan
- [ ] Deploy behind a CDN / serve a new build; verify the update banner appears and "Update Now" activates the SW and reloads.
- [ ] "Later" dismisses the banner; it reappears after 30 minutes.
- [ ] Open Profile → Two-Factor Authentication → Enable; confirm QR code is rendered as SVG and the base32 secret is shown below.
- [ ] Open `/reset-password?token=VALID_TOKEN`; confirm countdown displays and counts down. Let it expire — form should disable and show re-request link.
- [ ] Open `/reset-password?token=EXPIRED_OR_INVALID`; confirm expired state appears immediately without showing the form.
- [ ] Log in with "Remember this device for 30 days" checked; confirm `afripay_device_token` appears in localStorage.
- [ ] Log out (token cleared) then log in again without checking the box; send existing `device_token` header — if 2FA is enabled, TOTP step should be skipped.
- [ ] Open Sessions page; confirm "Trusted Devices" section shows the device with its expiry date and a revoke button.
- [ ] Clicking revoke removes the entry and clears localStorage.

