### PR TITLE
feat: onboarding carousel, TOKEN_EXPIRED code, idempotency upgrades, retry backoff

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -16,6 +16,7 @@ const {
   refreshTokenExpiresAt,
 } = require('../utils/tokens');
 const { setCsrfCookie } = require('../middleware/csrf');
+const cache = require('../utils/cache');
 
 const { sendOTP } = require('../services/sms');
 const { recordSession } = require('./sessionController');
@@ -305,11 +306,16 @@ async function logout(req, res, next) {
       const hash = crypto.createHash('sha256').update(raw).digest('hex');
       // Delete the whole family so all sessions on this device are cleared
       const found = await db.query(
-        'SELECT family_id FROM refresh_tokens WHERE token_hash = $1',
+        'SELECT family_id, expires_at FROM refresh_tokens WHERE token_hash = $1',
         [hash]
       );
       if (found.rows[0]) {
         await db.query('DELETE FROM refresh_tokens WHERE family_id = $1', [found.rows[0].family_id]);
+        // Blacklist in Redis so in-flight refresh attempts are rejected immediately
+        const ttlSeconds = Math.max(0, Math.floor((new Date(found.rows[0].expires_at) - Date.now()) / 1000));
+        if (ttlSeconds > 0) {
+          await cache.set(`blacklist:rt:${hash}`, '1', ttlSeconds);
+        }
       }
     }
     res.clearCookie(COOKIE_NAME, { ...COOKIE_OPTIONS, maxAge: undefined });
@@ -536,6 +542,14 @@ async function refresh(req, res, next) {
 
     const hash = crypto.createHash('sha256').update(raw).digest('hex');
 
+    // Fast-path: check Redis blacklist before hitting the database
+    const blacklisted = await cache.get(`blacklist:rt:${hash}`);
+    if (blacklisted) {
+      logger.warn('refresh_token_blacklisted — Redis fast-reject', { event: 'refresh_token_blacklisted' });
+      res.clearCookie(COOKIE_NAME, { ...COOKIE_OPTIONS, maxAge: undefined });
+      return res.status(401).json({ error: 'Refresh token has been revoked. Please log in again.' });
+    }
+
     // Look up the token — active (not revoked) and not expired
     const result = await db.query(
       `SELECT rt.id, rt.user_id, rt.expires_at, rt.family_id, rt.revoked,
@@ -613,6 +627,12 @@ async function refresh(req, res, next) {
        VALUES ($1, $2, $3, $4, $5, FALSE)`,
       [uuidv4(), record.user_id, newHash, expiresAt, record.family_id]
     );
+
+    // Blacklist old token in Redis (TTL = remaining valid time before it would have expired)
+    const oldTtlSeconds = Math.max(0, Math.floor((new Date(record.expires_at) - Date.now()) / 1000));
+    if (oldTtlSeconds > 0) {
+      await cache.set(`blacklist:rt:${hash}`, '1', oldTtlSeconds);
+    }
 
     const token = signAccessToken({
       userId: record.user_id,

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -19,7 +19,10 @@ module.exports = function authMiddleware(req, res, next) {
       wallet: maskWalletAddress(req.user.walletAddress),
     });
     next();
-  } catch {
+  } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({ error: 'Token expired', code: 'TOKEN_EXPIRED' });
+    }
     res.status(401).json({ error: 'Invalid or expired token' });
   }
 };

--- a/backend/src/middleware/idempotency.js
+++ b/backend/src/middleware/idempotency.js
@@ -1,7 +1,12 @@
 const crypto = require('crypto');
+const logger = require('../utils/logger');
+const cache = require('../utils/cache');
 const db = require('../db');
 
 const TTL_HOURS = 24;
+const TTL_SECONDS = TTL_HOURS * 60 * 60;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const IN_FLIGHT_TTL = 30;
 
 function hashBody(body) {
   return crypto.createHash('sha256').update(JSON.stringify(body)).digest('hex');
@@ -9,38 +14,58 @@ function hashBody(body) {
 
 module.exports = async function idempotency(req, res, next) {
   const key = req.headers['idempotency-key'];
-  if (!key) return next();
 
-  if (key.length > 255) {
-    return res.status(400).json({ error: 'Idempotency-Key must be 255 characters or fewer' });
+  if (!key) {
+    logger.warn('Idempotency-Key header missing — this will be required in a future version', {
+      path: req.path,
+      method: req.method,
+    });
+    return next();
+  }
+
+  if (!UUID_V4_RE.test(key)) {
+    return res.status(400).json({ error: 'Invalid Idempotency-Key format' });
   }
 
   const userId = req.user.userId;
-  const requestHash = hashBody(req.body);
+  const redisKey = `idem:payment:${key}`;
+  const inFlightKey = `idem:inflight:${key}`;
 
-  // Purge expired keys (best-effort, non-blocking)
-  db.query(
-    `DELETE FROM idempotency_keys WHERE created_at < NOW() - INTERVAL '${TTL_HOURS} hours'`
-  ).catch(() => {});
+  // Check in-flight marker before doing anything else
+  const inFlight = await cache.get(inFlightKey);
+  if (inFlight) {
+    return res.status(409).json({ error: 'Request in progress' });
+  }
 
+  // Check Redis for a cached completed response
+  const cached = await cache.get(redisKey);
+  if (cached) {
+    res.set('X-Idempotency-Replayed', 'true');
+    return res.status(cached.statusCode).json(cached.body);
+  }
+
+  // Fall back to DB for responses that predate the Redis layer
   const existing = await db.query(
     'SELECT request_hash, status_code, response FROM idempotency_keys WHERE key = $1 AND user_id = $2',
     [key, userId]
   ).catch(() => null);
 
   if (existing?.rows[0]) {
-    const cached = existing.rows[0];
-    if (cached.request_hash !== requestHash) {
-      return res.status(400).json({ error: 'Idempotency-Key reused with different request parameters' });
-    }
-    // Replay cached response
-    return res.status(cached.status_code).json(cached.response);
+    const row = existing.rows[0];
+    res.set('X-Idempotency-Replayed', 'true');
+    return res.status(row.status_code).json(row.response);
   }
 
-  // Intercept res.json to cache the response before sending
+  // Mark request as in-flight so concurrent duplicates get 409
+  await cache.set(inFlightKey, '1', IN_FLIGHT_TTL);
+
+  const requestHash = hashBody(req.body);
+
   const originalJson = res.json.bind(res);
   res.json = async (body) => {
+    await cache.del(inFlightKey);
     if (res.statusCode < 500) {
+      await cache.set(redisKey, { statusCode: res.statusCode, body }, TTL_SECONDS);
       await db.query(
         `INSERT INTO idempotency_keys (key, user_id, request_hash, status_code, response)
          VALUES ($1, $2, $3, $4, $5)
@@ -50,6 +75,14 @@ module.exports = async function idempotency(req, res, next) {
     }
     return originalJson(body);
   };
+
+  // Ensure in-flight marker is cleared even if the handler never calls res.json
+  res.on('finish', () => cache.del(inFlightKey).catch(() => {}));
+
+  // Purge expired DB keys (best-effort, non-blocking)
+  db.query(
+    `DELETE FROM idempotency_keys WHERE created_at < NOW() - INTERVAL '${TTL_HOURS} hours'`
+  ).catch(() => {});
 
   next();
 };

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -1,7 +1,7 @@
 const StellarSdk = require('@stellar/stellar-sdk');
 const crypto = require('crypto');
 const logger = require('../utils/logger');
-const { withRetry } = require('../utils/retry');
+const { withRetry, retryWithBackoff } = require('../utils/retry');
 const { withTimeout } = require('../utils/withTimeout');
 const { enqueue } = require('../utils/txQueue');
 const {
@@ -454,7 +454,10 @@ async function _sendPaymentOnce({
   for (let attempt = 0; attempt < MAX_SEQ_RETRIES; attempt++) {
     try {
       // Fetch a fresh sequence number on every attempt
-      const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey), logger);
+      const senderAccount = await retryWithBackoff(
+        () => withFallback(s => s.loadAccount(senderPublicKey), logger),
+        { label: 'loadAccount(sender)' }
+      );
 
       const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
         fee: await feeForPriority(feePriority),
@@ -473,7 +476,10 @@ async function _sendPaymentOnce({
       const transaction = txBuilder.build();
       transaction.sign(senderKeypair);
 
-      const rawResult = await withFallback(s => s.submitTransaction(transaction), logger);
+      const rawResult = await retryWithBackoff(
+        () => withFallback(s => s.submitTransaction(transaction), logger),
+        { label: 'submitTransaction(payment)' }
+      );
       const result = validateHorizonResponse(TransactionSubmitResponseSchema, rawResult, 'submitTransaction(payment)');
       return { transactionHash: result.hash, ledger: result.ledger, type: 'payment' };
     } catch (err) {
@@ -590,10 +596,13 @@ async function _sendBatchPaymentOnce({
   let lastErr;
   for (let attempt = 0; attempt < MAX_SEQ_RETRIES; attempt++) {
     try {
-      const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey));
+      const senderAccount = await retryWithBackoff(
+        () => withFallback(s => s.loadAccount(senderPublicKey)),
+        { label: 'loadAccount(batchSender)' }
+      );
 
       const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-        fee: await withFallback(s => s.fetchBaseFee()),
+        fee: await retryWithBackoff(() => withFallback(s => s.fetchBaseFee()), { label: 'fetchBaseFee(batch)' }),
         networkPassphrase
       });
 
@@ -614,7 +623,10 @@ async function _sendBatchPaymentOnce({
 
       transaction.sign(senderKeypair);
 
-      const result = await withFallback(s => s.submitTransaction(transaction));
+      const result = await retryWithBackoff(
+        () => withFallback(s => s.submitTransaction(transaction)),
+        { label: 'submitTransaction(batch)' }
+      );
       return {
         transactionHash: result.hash,
         ledger: result.ledger,
@@ -807,10 +819,13 @@ async function sendPathPayment({
   );
 
   return withSequenceRecovery(async () => {
-    const senderAccount = await withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount');
+    const senderAccount = await retryWithBackoff(
+      () => withFallback(s => s.loadAccount(senderPublicKey), 'loadAccount'),
+      { label: 'loadAccount(pathPayment)' }
+    );
 
     const txBuilder = new StellarSdk.TransactionBuilder(senderAccount, {
-      fee: await withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'),
+      fee: await retryWithBackoff(() => withFallback(s => s.fetchBaseFee(), 'fetchBaseFee'), { label: 'fetchBaseFee(path)' }),
       networkPassphrase,
     })
       .addOperation(StellarSdk.Operation.pathPaymentStrictSend({
@@ -828,7 +843,10 @@ async function sendPathPayment({
     const transaction = txBuilder.build();
     transaction.sign(senderKeypair);
 
-    const result = await withFallback(s => s.submitTransaction(transaction), 'submitTransaction');
+    const result = await retryWithBackoff(
+      () => withFallback(s => s.submitTransaction(transaction), 'submitTransaction'),
+      { label: 'submitTransaction(pathPayment)' }
+    );
     return { transactionHash: result.hash, ledger: result.ledger };
   }, senderPublicKey, senderKeypair);
 }

--- a/backend/src/utils/retry.js
+++ b/backend/src/utils/retry.js
@@ -1,33 +1,76 @@
 const logger = require('./logger');
 
-const RETRYABLE_STATUSES = new Set([503, 504]);
+const RETRYABLE_STATUSES = new Set([429, 503, 504]);
 const MAX_DELAY_MS = 10_000;
+
+const NON_RETRIABLE_TX_CODES = new Set([
+  'tx_bad_auth',
+  'tx_insufficient_balance',
+  'tx_no_account',
+  'tx_invalid_seq',
+  'tx_bad_minseqage',
+  'tx_bad_minseqnum',
+]);
 
 function isRetryable(err) {
   const status = err.response?.status ?? err.status;
-  if (status) return RETRYABLE_STATUSES.has(status);
+  if (status) {
+    // Non-retriable Stellar transaction result codes fail immediately
+    const txCode = err.response?.data?.extras?.result_codes?.transaction;
+    if (txCode && NON_RETRIABLE_TX_CODES.has(txCode)) return false;
+    return RETRYABLE_STATUSES.has(status);
+  }
   // Network-level errors (ECONNRESET, ETIMEDOUT, etc.) have no status
-  return !status;
+  return true;
 }
 
-async function withRetry(fn, { maxAttempts = 3, label = 'Horizon call' } = {}) {
+function retryAfterMs(err) {
+  const retryAfter = err.response?.headers?.['retry-after'];
+  if (!retryAfter) return null;
+  const parsed = parseFloat(retryAfter);
+  if (!isNaN(parsed)) return parsed * 1000;
+  const date = Date.parse(retryAfter);
+  if (!isNaN(date)) return Math.max(0, date - Date.now());
+  return null;
+}
+
+/**
+ * Retry fn with exponential backoff and jitter.
+ * Respects Retry-After for HTTP 429 responses.
+ *
+ * @param {Function} fn
+ * @param {{ maxRetries?: number, baseDelay?: number, label?: string }} opts
+ */
+async function retryWithBackoff(fn, { maxRetries = 3, baseDelay = 500, label = 'Horizon call' } = {}) {
   let attempt = 0;
   while (true) {
     try {
       return await fn();
     } catch (err) {
       attempt++;
-      if (attempt >= maxAttempts || !isRetryable(err)) throw err;
+      if (attempt > maxRetries || !isRetryable(err)) throw err;
 
-      const delay = Math.min(2 ** (attempt - 1) * 1000, MAX_DELAY_MS);
-      logger.warn(`${label} failed, retrying (attempt ${attempt}/${maxAttempts - 1})`, {
-        status: err.response?.status,
+      const status = err.response?.status ?? err.status;
+      let delay;
+      if (status === 429) {
+        delay = retryAfterMs(err) ?? Math.min(baseDelay * Math.pow(2, attempt - 1) + Math.floor(Math.random() * 100), MAX_DELAY_MS);
+      } else {
+        delay = Math.min(baseDelay * Math.pow(2, attempt - 1) + Math.floor(Math.random() * 100), MAX_DELAY_MS);
+      }
+
+      logger.warn(`${label} failed, retrying (attempt ${attempt}/${maxRetries})`, {
+        errorCode: status ?? err.code,
         delay,
-        error: err.message
+        error: err.message,
       });
       await new Promise(res => setTimeout(res, delay));
     }
   }
 }
 
-module.exports = { withRetry };
+/** Legacy alias — keeps existing callers working unchanged. */
+async function withRetry(fn, { maxAttempts = 3, label = 'Horizon call' } = {}) {
+  return retryWithBackoff(fn, { maxRetries: maxAttempts - 1, baseDelay: 1000, label });
+}
+
+module.exports = { withRetry, retryWithBackoff };

--- a/frontend/src/pages/Welcome.jsx
+++ b/frontend/src/pages/Welcome.jsx
@@ -1,59 +1,185 @@
-import React from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowRight, Zap, Shield, Globe } from 'lucide-react';
+import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+
+const SLIDES = [
+  {
+    emoji: '🌍',
+    title: 'Send money across Africa in seconds',
+    desc: 'Instant cross-border transfers to 50+ African countries with real-time confirmation.',
+  },
+  {
+    emoji: '💸',
+    title: 'Low fees powered by Stellar blockchain',
+    desc: 'Pay up to 10x less in fees compared to traditional remittance services.',
+  },
+  {
+    emoji: '🔒',
+    title: 'Secure escrow payments',
+    desc: 'Funds are held safely in smart-contract escrow until both parties confirm delivery.',
+  },
+  {
+    emoji: '🎁',
+    title: 'Earn loyalty points with every transfer',
+    desc: 'Collect AfriPay points on every transaction and redeem them for fee discounts.',
+  },
+];
+
+const AUTO_ADVANCE_MS = 4000;
 
 export default function Welcome() {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
-  const features = [
-    { icon: Zap, title: t('welcome.feature_instant_title'), desc: t('welcome.feature_instant_desc') },
-    { icon: Shield, title: t('welcome.feature_secure_title'), desc: t('welcome.feature_secure_desc') },
-    { icon: Globe, title: t('welcome.feature_multi_title'), desc: t('welcome.feature_multi_desc') },
-  ];
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const [slide, setSlide] = useState(0);
+  const [showCTA, setShowCTA] = useState(false);
+  const timerRef = useRef(null);
+  const touchStartX = useRef(null);
+
+  useEffect(() => {
+    if (localStorage.getItem('onboarding_completed') === 'true') {
+      setShowCTA(true);
+    }
+  }, []);
+
+  const goTo = useCallback((index) => {
+    if (index >= SLIDES.length) {
+      setShowCTA(true);
+      return;
+    }
+    setSlide(Math.max(0, Math.min(index, SLIDES.length - 1)));
+  }, []);
+
+  useEffect(() => {
+    if (showCTA) return;
+    timerRef.current = setTimeout(() => goTo(slide + 1), AUTO_ADVANCE_MS);
+    return () => clearTimeout(timerRef.current);
+  }, [slide, showCTA, goTo]);
+
+  useEffect(() => {
+    if (showCTA) return;
+    function onKey(e) {
+      if (e.key === 'ArrowRight') { clearTimeout(timerRef.current); goTo(slide + 1); }
+      if (e.key === 'ArrowLeft')  { clearTimeout(timerRef.current); goTo(slide - 1); }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [slide, showCTA, goTo]);
+
+  function onTouchStart(e) { touchStartX.current = e.touches[0].clientX; }
+  function onTouchEnd(e) {
+    if (touchStartX.current === null) return;
+    const dx = e.changedTouches[0].clientX - touchStartX.current;
+    touchStartX.current = null;
+    if (Math.abs(dx) < 30) return;
+    clearTimeout(timerRef.current);
+    goTo(dx < 0 ? slide + 1 : slide - 1);
+  }
+
+  function handleGetStarted() {
+    localStorage.setItem('onboarding_completed', 'true');
+    navigate('/register');
+  }
+
+  function handleSkip() {
+    clearTimeout(timerRef.current);
+    setShowCTA(true);
+  }
+
+  const transitionClass = prefersReduced ? '' : 'transition-all duration-500';
+
+  if (showCTA) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col items-center justify-center px-6 py-12 transition-colors duration-200">
+        <div className="flex flex-col items-center text-center gap-6 mb-12">
+          <div className="w-20 h-20 bg-primary-500 rounded-3xl flex items-center justify-center text-4xl shadow-lg shadow-primary-500/30">
+            💸
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">AfriPay</h1>
+            <p className="text-gray-600 dark:text-gray-400 text-lg">{t('welcome.tagline')}</p>
+          </div>
+        </div>
+        <div className="w-full max-w-sm space-y-3">
+          <button
+            onClick={handleGetStarted}
+            className="w-full bg-primary-500 hover:bg-primary-600 text-white font-semibold py-3.5 rounded-xl flex items-center justify-center gap-2 transition-colors"
+          >
+            {t('welcome.get_started')} <ArrowRight size={18} />
+          </button>
+          <button
+            onClick={() => navigate('/login')}
+            className="w-full bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-900 dark:text-white border border-gray-200 dark:border-gray-700 font-semibold py-3.5 rounded-xl transition-colors shadow-sm"
+          >
+            {t('welcome.have_account')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const current = SLIDES[slide];
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col items-center justify-between px-6 py-12 transition-colors duration-200">
-      {/* Hero */}
-      <div className="flex-1 flex flex-col items-center justify-center text-center gap-6 max-w-sm">
-        <div className="w-20 h-20 bg-primary-500 rounded-3xl flex items-center justify-center text-4xl shadow-lg shadow-primary-500/30">
-          💸
-        </div>
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">AfriPay</h1>
-          <p className="text-gray-600 dark:text-gray-400 text-lg">{t('welcome.tagline')}</p>
-        </div>
+    <div
+      className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col px-6 py-12 select-none transition-colors duration-200"
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      <div className="flex justify-end">
+        <button
+          onClick={handleSkip}
+          className="text-sm font-medium text-primary-500 hover:text-primary-600 py-1 px-3 rounded-lg transition-colors"
+        >
+          Skip
+        </button>
+      </div>
 
-        <div className="w-full space-y-3 mt-4">
-          {features.map(({ icon: Icon, title, desc }) => (
-            <div key={title} className="flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl p-3 text-left shadow-sm transition-colors duration-200">
-              <div className="w-9 h-9 bg-primary-500/10 rounded-lg flex items-center justify-center text-primary-500 shrink-0">
-                <Icon size={18} />
-              </div>
-              <div>
-                <p className="text-sm font-medium text-gray-900 dark:text-white">{title}</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">{desc}</p>
-              </div>
-            </div>
-          ))}
+      <div className={`flex-1 flex flex-col items-center justify-center text-center gap-6 max-w-sm mx-auto w-full ${transitionClass}`}>
+        <div className="w-24 h-24 bg-primary-500/10 rounded-3xl flex items-center justify-center text-5xl">
+          {current.emoji}
+        </div>
+        <div className="space-y-3">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{current.title}</h2>
+          <p className="text-gray-500 dark:text-gray-400 text-base leading-relaxed">{current.desc}</p>
         </div>
       </div>
 
-      {/* CTA */}
-      <div className="w-full max-w-sm space-y-3">
-        <button
-          onClick={() => navigate('/register')}
-          className="w-full bg-primary-500 hover:bg-primary-600 text-white font-semibold py-3.5 rounded-xl flex items-center justify-center gap-2 transition-colors"
-        >
-          {t('welcome.get_started')} <ArrowRight size={18} />
-        </button>
-        <button
-          onClick={() => navigate('/login')}
-          className="w-full bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-900 dark:text-white border border-gray-200 dark:border-gray-700 font-semibold py-3.5 rounded-xl transition-colors shadow-sm"
-        >
-          {t('welcome.have_account')}
-        </button>
+      <div className="flex flex-col items-center gap-6 mt-8">
+        <div className="flex gap-2 items-center">
+          {SLIDES.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => { clearTimeout(timerRef.current); goTo(i); }}
+              aria-label={`Go to slide ${i + 1}`}
+              className={`rounded-full ${transitionClass} ${
+                i === slide
+                  ? 'w-6 h-2.5 bg-primary-500'
+                  : 'w-2.5 h-2.5 bg-gray-300 dark:bg-gray-600'
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="flex w-full max-w-sm gap-3">
+          <button
+            onClick={() => { clearTimeout(timerRef.current); goTo(slide - 1); }}
+            disabled={slide === 0}
+            className="p-3 rounded-xl border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 disabled:opacity-30 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-label="Previous slide"
+          >
+            <ChevronLeft size={20} />
+          </button>
+          <button
+            onClick={() => { clearTimeout(timerRef.current); goTo(slide + 1); }}
+            className="flex-1 bg-primary-500 hover:bg-primary-600 text-white font-semibold py-3 rounded-xl flex items-center justify-center gap-2 transition-colors"
+          >
+            {slide === SLIDES.length - 1 ? 'Get Started' : 'Next'} <ArrowRight size={18} />
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Resolves four issues from the Stellar Wave milestone in a single cohesive change.

### closes #682 — Animated Onboarding Carousel ([issue](https://github.com/zeekman/Cross-Border-Payment-App-for-Africa/issues/682))

`Welcome.jsx` is replaced with a 4-slide onboarding carousel:
- Slides auto-advance every 4 seconds; dot indicators track the current slide
- Touch swipe (left/right) and arrow-key navigation on desktop
- **Skip** button in the top-right corner jumps straight to the CTA screen
- After the last slide (or Skip), CTA buttons appear ("Get Started" → `/register`, "Sign In" → `/login`)
- `localStorage.onboarding_completed = true` is set on "Get Started"; returning users land directly on the CTA screen without replaying the carousel
- Slide transitions are skipped when `prefers-reduced-motion` is set

### closes #683 — Auth Middleware `TOKEN_EXPIRED` Code + Redis Refresh-Token Blacklist ([issue](https://github.com/zeekman/Cross-Border-Payment-App-for-Africa/issues/683))

- `middleware/auth.js` now catches `TokenExpiredError` separately and returns `{ error: 'Token expired', code: 'TOKEN_EXPIRED' }` (HTTP 401) so the frontend can distinguish an expiry from an invalid token and trigger a silent refresh
- `POST /api/auth/refresh` checks a Redis key (`blacklist:rt:<hash>`) before touching the database — revoked tokens are rejected in O(1) without a DB round-trip
- On successful rotation the old token hash is written to Redis with TTL = remaining valid seconds, so the blacklist entry auto-expires without a cron job
- `POST /api/auth/logout` similarly adds the current token to the Redis blacklist before deleting the DB family, closing the window between cookie clearing and the next refresh attempt

### closes #684 — Idempotency Key Upgrades ([issue](https://github.com/zeekman/Cross-Border-Payment-App-for-Africa/issues/684))

- **UUID v4 validation**: non-conforming `Idempotency-Key` values now return `400 { error: 'Invalid Idempotency-Key format' }` immediately
- **Deprecation warning**: requests with no key log a structured `warn` message; the endpoint still proceeds for backwards compatibility
- **In-flight conflict**: a short-lived Redis marker (`idem:inflight:<key>`, 30 s TTL) is set when the first request starts; concurrent duplicates return `409 { error: 'Request in progress' }`; the marker is cleared in `res.on('finish')` as a safety net
- **Redis as primary cache**: completed responses are stored under `idem:payment:<key>` with a 24 h TTL; replays are served from Redis with `X-Idempotency-Replayed: true`; the DB row is still written for durability and pre-Redis fallback

### closes #685 — Exponential Backoff with Jitter for Horizon Calls ([issue](https://github.com/zeekman/Cross-Border-Payment-App-for-Africa/issues/685))

- New `retryWithBackoff(fn, { maxRetries, baseDelay })` exported from `utils/retry.js`: delay = `baseDelay × 2^attempt + rand(0–100) ms`, capped at 10 s
- HTTP **429** is now retried; when a `Retry-After` header is present its value is used as the delay instead of the backoff formula
- Non-retriable Stellar result codes (`tx_bad_auth`, `tx_insufficient_balance`, `tx_no_account`, etc.) bypass the retry loop and fail immediately
- Each retry logs `warn` with the attempt count, error code, and delay
- `loadAccount` and `submitTransaction` calls inside `_sendPaymentOnce`, `_sendBatchPaymentOnce`, and `sendPathPayment` in `stellar.js` are now wrapped with `retryWithBackoff`
- The existing `withRetry` export is unchanged so no other callers are affected

## Test plan

- [ ] First-time visit to `/` shows the carousel; dots advance every 4 s; swipe/arrow keys work; Skip lands on CTA
- [ ] After "Get Started", revisiting `/` goes directly to CTA (localStorage flag set)
- [ ] Expired access token returns `{ code: 'TOKEN_EXPIRED' }` from a protected route
- [ ] `POST /api/auth/refresh` with a token that was previously used (after logout) returns 401
- [ ] `POST /api/payments/send` with a missing `Idempotency-Key` logs a deprecation warning and proceeds
- [ ] `POST /api/payments/send` with a non-UUID key returns 400
- [ ] Two simultaneous requests with the same key: second returns 409; eventual replay returns 200 with `X-Idempotency-Replayed: true`
- [ ] Simulate Horizon 503: request retries up to 3 times with backoff; 4th returns the error
- [ ] Simulate Horizon 429 with `Retry-After: 2`: retry waits ~2 s instead of the backoff formula