### PR TITLE
test: add independence, supply-consistency, and expiry-boundary tests

### DIFF
--- a/contracts/loyalty-token/src/test.rs
+++ b/contracts/loyalty-token/src/test.rs
@@ -432,3 +432,27 @@ fn test_mint_one_point_per_xlm_volume() {
     client.mint(&admin, &user, &xlm_amount);
     assert_eq!(client.balance(&user), 50);
 }
+
+// ── total_supply consistency ──────────────────────────────────────────────────
+
+#[test]
+fn test_total_supply_consistency_after_mint_transfer_burn_redeem() {
+    let (env, client, admin) = setup();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    client.mint(&admin, &user1, &200);
+    assert_eq!(client.total_supply(), client.balance(&user1) + client.balance(&user2));
+
+    client.mint(&admin, &user2, &100);
+    assert_eq!(client.total_supply(), client.balance(&user1) + client.balance(&user2));
+
+    client.transfer(&user1, &user2, &50);
+    assert_eq!(client.total_supply(), client.balance(&user1) + client.balance(&user2));
+
+    client.burn(&user1, &30);
+    assert_eq!(client.total_supply(), client.balance(&user1) + client.balance(&user2));
+
+    assert!(client.redeem(&user2)); // burns 100 from user2
+    assert_eq!(client.total_supply(), client.balance(&user1) + client.balance(&user2));
+}

--- a/contracts/multisig-approval/src/test.rs
+++ b/contracts/multisig-approval/src/test.rs
@@ -269,6 +269,28 @@ fn test_reject_after_expiry_panics() {
     client.reject(&approvers.get(0).unwrap(), &tx_id);
 }
 
+// ── expiry boundary conditions ────────────────────────────────────────────────
+
+#[test]
+fn test_approve_at_expiry_minus_one_succeeds() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let tx_id = propose(&env, &contract_id, &approvers.get(0).unwrap());
+    env.ledger().with_mut(|l| l.timestamp += 86_399);
+    client.approve(&approvers.get(0).unwrap(), &tx_id);
+    assert_eq!(client.get_proposal(&tx_id).status, TxStatus::Pending);
+}
+
+#[test]
+#[should_panic(expected = "proposal expired")]
+fn test_approve_at_expiry_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let tx_id = propose(&env, &contract_id, &approvers.get(0).unwrap());
+    env.ledger().with_mut(|l| l.timestamp += 86_400);
+    client.approve(&approvers.get(0).unwrap(), &tx_id);
+}
+
 // ── get_proposal ──────────────────────────────────────────────────────────────
 
 #[test]

--- a/contracts/savings-vault/src/test.rs
+++ b/contracts/savings-vault/src/test.rs
@@ -261,3 +261,25 @@ fn test_accrue_interest_non_admin_panics() {
     env.ledger().with_mut(|li| li.timestamp += 86400);
     client.accrue_interest(&impostor, &user);
 }
+
+#[test]
+fn test_two_depositors_independent() {
+    let (env, client, admin, usdc_id) = setup();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let amount1 = 1_000_0000000i128;
+    let amount2 = 500_0000000i128;
+    let unlock_time1 = env.ledger().timestamp() + 3600;
+    let unlock_time2 = env.ledger().timestamp() + 7200;
+
+    mint_usdc(&env, &usdc_id, &admin, &user1, amount1);
+    mint_usdc(&env, &usdc_id, &admin, &user2, amount2);
+
+    client.deposit(&user1, &amount1, &unlock_time1);
+    client.deposit(&user2, &amount2, &unlock_time2);
+
+    assert_eq!(client.get_balance(&user1), amount1);
+    assert_eq!(client.get_unlock_time(&user1), unlock_time1);
+    assert_eq!(client.get_balance(&user2), amount2);
+    assert_eq!(client.get_unlock_time(&user2), unlock_time2);
+}


### PR DESCRIPTION
Summary
This PR closes three open test issues across the smart-contract suite. Each addition targets a specific behavioral gap identified in the issue descriptions.

Issue 1 — savings-vault: Multiple depositor independence
File: contracts/savings-vault/src/test.rs

Added: test_two_depositors_independent

The existing test suite only ever deposited from a single address. This test provisions two independent users (user1, user2), mints separate USDC balances for each, and calls deposit with distinct amounts and unlock timestamps. After both deposits, it asserts:

get_balance(user1) returns only user1's deposited amount
get_unlock_time(user1) returns only user1's unlock time
get_balance(user2) returns only user2's deposited amount
get_unlock_time(user2) returns only user2's unlock time
This guards against storage key collisions or shared-state bugs that would cause one depositor's vault to bleed into another's.

Issue 2 — loyalty-token: total_supply consistency across the full operation sequence
File: contracts/loyalty-token/src/test.rs

Added: test_total_supply_consistency_after_mint_transfer_burn_redeem

Individual operations (mint, transfer, burn, redeem) each had their own supply assertions in isolation. No test exercised them in sequence and verified the invariant at every step. This test runs:

Step	Operation	user1 balance	user2 balance	total_supply
1	mint(user1, 200)	200	0	200
2	mint(user2, 100)	200	100	300
3	transfer(user1 → user2, 50)	150	150	300
4	burn(user1, 30)	120	150	270
5	redeem(user2) (burns 100)	120	50	170
After every step, total_supply == balance(user1) + balance(user2) is asserted. This pins the conservation law and catches any accounting drift introduced by future changes.

Issue 3 — multisig-approval: Proposal expiry boundary conditions
File: contracts/multisig-approval/src/test.rs

Added: test_approve_at_expiry_minus_one_succeeds and test_approve_at_expiry_panics

The existing expiry tests only checked timestamp + 86_401 (well past expiry). The exact boundary at expiry = created_at + 86_400 was untested, leaving ambiguity about whether the check is >= or >. These two tests pin the boundary precisely:

test_approve_at_expiry_minus_one_succeeds — advances the ledger by 86_399 seconds (one second before expiry) and calls approve; asserts the proposal stays Pending, confirming the window is still open.
test_approve_at_expiry_panics — advances the ledger by exactly 86_400 seconds and calls approve; asserts a panic with "proposal expired", confirming the boundary is inclusive (expired at == expiry, not only after it).
Test plan
 cargo test -p savings-vault — test_two_depositors_independent passes
 cargo test -p loyalty-token — test_total_supply_consistency_after_mint_transfer_burn_redeem passes
 cargo test -p multisig-approval — test_approve_at_expiry_minus_one_succeeds passes, test_approve_at_expiry_panics passes
 Full test suite (cargo test --workspace) shows no regressions
 
 closes #561 
 closes #562 
 closes #563 