### PR TITLE
feat: support attachments, immutable audit trail, multi-asset balance…

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -243,7 +243,11 @@ async function approveKYC(req, res, next) {
       [userId]
     );
 
-    await audit.log(req.user.userId, "kyc_approved", { target_user: userId, tx_hash: txHash });
+    await audit.auditLog(req, 'kyc_approved', {
+      type: 'user',
+      id: userId,
+      newValue: { kyc_status: 'verified', tx_hash: txHash },
+    });
 
     res.json({ message: "KYC approved", tx_hash: txHash });
   } catch (err) {
@@ -290,7 +294,12 @@ async function revokeKYC(req, res, next) {
       [userId]
     );
 
-    await audit.log(req.user.userId, "kyc_revoked", { target_user: userId, tx_hash: txHash });
+    await audit.auditLog(req, 'kyc_revoked', {
+      type: 'user',
+      id: userId,
+      oldValue: { kyc_status: 'verified' },
+      newValue: { kyc_status: 'unverified', tx_hash: txHash },
+    });
 
     res.json({ message: "KYC revoked", tx_hash: txHash });
   } catch (err) {
@@ -779,8 +788,10 @@ async function bulkSuspend(req, res, next) {
     );
     await client.query('COMMIT');
 
-    await audit.log(req.user.userId, 'bulk_suspend', req.ip, req.headers['user-agent'],
-      { user_count: userIds.length, reason: reason || null });
+    await audit.auditLog(req, 'user_suspension', {
+      type: 'bulk_user',
+      newValue: { user_ids: userIds, reason: reason || null },
+    });
 
     // Queue suspension emails (fire-and-forget)
     db.query('SELECT email, full_name FROM users WHERE id = ANY($1::uuid[])', [userIds])
@@ -812,8 +823,10 @@ async function bulkUnsuspend(req, res, next) {
       [userIds]
     );
     await client.query('COMMIT');
-    await audit.log(req.user.userId, 'bulk_unsuspend', req.ip, req.headers['user-agent'],
-      { user_count: userIds.length });
+    await audit.auditLog(req, 'user_unsuspend', {
+      type: 'bulk_user',
+      newValue: { user_ids: userIds },
+    });
     res.json({ message: 'Users unsuspended', count: userIds.length });
   } catch (err) {
     await client.query('ROLLBACK');
@@ -904,11 +917,72 @@ async function bulkKycUpdate(req, res, next) {
   }
 }
 
+/**
+ * GET /api/admin/audit-logs
+ * Cursor-based paginated audit log viewer.
+ * Supports filtering by actor, action, resource_type, and date range.
+ */
+async function getAuditLogs(req, res, next) {
+  try {
+    const { actor, action, resource_type, from, to, cursor } = req.query;
+    const limit = Math.min(100, parseInt(req.query.limit, 10) || 20);
+
+    const conditions = [];
+    const params = [];
+
+    if (actor) {
+      params.push(actor);
+      conditions.push(`user_id = $${params.length}`);
+    }
+    if (action) {
+      params.push(action);
+      conditions.push(`action = $${params.length}`);
+    }
+    if (resource_type) {
+      params.push(resource_type);
+      conditions.push(`resource_type = $${params.length}`);
+    }
+    if (from) {
+      params.push(from);
+      conditions.push(`created_at >= $${params.length}`);
+    }
+    if (to) {
+      params.push(to);
+      conditions.push(`created_at <= $${params.length}`);
+    }
+    if (cursor) {
+      params.push(cursor);
+      conditions.push(`created_at < $${params.length}`);
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    params.push(limit + 1);
+
+    const { rows } = await db.query(
+      `SELECT id, user_id AS actor_id, actor_role, action, resource_type, resource_id,
+              old_value, new_value, ip_address, user_agent, created_at
+       FROM audit_logs ${where}
+       ORDER BY created_at DESC
+       LIMIT $${params.length}`,
+      params
+    );
+
+    const hasMore = rows.length > limit;
+    const data = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? data[data.length - 1].created_at.toISOString() : null;
+
+    res.json({ data, next_cursor: nextCursor, has_more: hasMore });
+  } catch (err) {
+    next(err);
+  }
+}
+
 module.exports = {
   getStats,
   getUsers,
   getTransactions,
   getDailyTransactionStats,
+  getStellarNetworkStats,
   clawback,
   approveKYC,
   revokeKYC,
@@ -929,4 +1003,6 @@ module.exports = {
   bulkExport,
   getJobStatus,
   bulkKycUpdate,
+  // #698
+  getAuditLogs,
 };

--- a/backend/src/controllers/supportController.js
+++ b/backend/src/controllers/supportController.js
@@ -1,16 +1,25 @@
+const fs = require('fs');
+const path = require('path');
 const db = require('../db');
 
 const VALID_TYPES = ['wrong_address', 'wrong_amount', 'failed_deducted', 'other'];
+
+function cleanupFiles(files) {
+  if (!files) return;
+  for (const f of files) {
+    try { fs.unlinkSync(f.path); } catch {}
+  }
+}
 
 async function createTicket(req, res, next) {
   try {
     const { transaction_id, type, description } = req.body;
 
     if (!VALID_TYPES.includes(type)) {
+      cleanupFiles(req.files);
       return res.status(400).json({ error: `type must be one of: ${VALID_TYPES.join(', ')}` });
     }
 
-    // If a transaction_id is provided, verify it belongs to this user
     if (transaction_id) {
       const txCheck = await db.query(
         `SELECT id FROM transactions
@@ -21,6 +30,7 @@ async function createTicket(req, res, next) {
         [transaction_id, req.user.userId]
       );
       if (!txCheck.rows[0]) {
+        cleanupFiles(req.files);
         return res.status(404).json({ error: 'Transaction not found or does not belong to you' });
       }
     }
@@ -32,8 +42,27 @@ async function createTicket(req, res, next) {
       [req.user.userId, transaction_id || null, type, description]
     );
 
-    res.status(201).json({ ticket: result.rows[0] });
+    const ticket = result.rows[0];
+
+    if (req.files && req.files.length > 0) {
+      for (const file of req.files) {
+        await db.query(
+          `INSERT INTO support_attachments (ticket_id, filename, original_name, mime_type, size_bytes, storage_path)
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [ticket.id, file.filename, file.originalname, file.mimetype, file.size, file.path]
+        );
+      }
+    }
+
+    const attachmentsResult = await db.query(
+      `SELECT id, filename, original_name, mime_type, size_bytes, uploaded_at
+       FROM support_attachments WHERE ticket_id = $1 ORDER BY uploaded_at ASC`,
+      [ticket.id]
+    );
+
+    res.status(201).json({ ticket: { ...ticket, attachments: attachmentsResult.rows } });
   } catch (err) {
+    cleanupFiles(req.files);
     next(err);
   }
 }
@@ -50,4 +79,47 @@ async function listTickets(req, res, next) {
   }
 }
 
-module.exports = { createTicket, listTickets };
+async function getAttachment(req, res, next) {
+  try {
+    const { id, filename } = req.params;
+    const safeFilename = path.basename(filename);
+    const isAdmin = req.user.role === 'admin';
+
+    const { rows } = isAdmin
+      ? await db.query(
+          `SELECT a.* FROM support_attachments a
+           WHERE a.ticket_id = $1 AND a.filename = $2`,
+          [id, safeFilename]
+        )
+      : await db.query(
+          `SELECT a.* FROM support_attachments a
+           JOIN support_tickets t ON t.id = a.ticket_id
+           WHERE a.ticket_id = $1 AND a.filename = $2 AND t.user_id = $3`,
+          [id, safeFilename, req.user.userId]
+        );
+
+    if (!rows[0]) {
+      return res.status(404).json({ error: 'Attachment not found' });
+    }
+
+    const attachment = rows[0];
+
+    if (!fs.existsSync(attachment.storage_path)) {
+      return res.status(404).json({ error: 'File not found on server' });
+    }
+
+    res.setHeader('Content-Type', attachment.mime_type);
+    res.setHeader(
+      'Content-Disposition',
+      `inline; filename="${attachment.original_name.replace(/"/g, '\\"')}"`
+    );
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Content-Length', attachment.size_bytes);
+
+    fs.createReadStream(attachment.storage_path).pipe(res);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { createTicket, listTickets, getAttachment };

--- a/backend/src/controllers/walletController.js
+++ b/backend/src/controllers/walletController.js
@@ -51,27 +51,76 @@ async function resolveWallet(userId, walletId) {
   return result.rows[0] || null;
 }
 
+// Balance cache TTL for multi-asset endpoint: 10 seconds per spec
+const MULTI_ASSET_TTL = 10;
+
+async function fetchSupportedAssets() {
+  const { rows } = await db.query(
+    `SELECT asset_code, asset_issuer, display_name, icon_url, decimal_precision
+     FROM supported_assets WHERE is_active = true`
+  );
+  const map = new Map();
+  for (const row of rows) {
+    const key = row.asset_issuer
+      ? `${row.asset_code}:${row.asset_issuer}`
+      : row.asset_code;
+    map.set(key, row);
+  }
+  return map;
+}
+
 // ---------------------------------------------------------------------------
-// GET /wallet/balance  (optionally ?wallet_id=<uuid>)
+// GET /wallet/balance  (optionally ?wallet_id=<uuid>, ?refresh=true)
+// Returns all asset balances with whitelist metadata and XLM reserve info.
 // ---------------------------------------------------------------------------
 async function getWallet(req, res, next) {
   try {
     const walletId = req.query.wallet_id || null;
+    const forceRefresh = req.query.refresh === 'true';
     const wallet = await resolveWallet(req.user.userId, walletId);
     if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
 
     const { public_key } = wallet;
     const cacheKey = `balance:${public_key}`;
 
-    const cached = await cache.get(cacheKey);
-    if (cached) {
-      return res.json({ id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default, ...cached, cached: true });
+    if (!forceRefresh) {
+      const cached = await cache.get(cacheKey);
+      if (cached) {
+        return res.json({
+          id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default,
+          ...cached,
+          cached: true,
+        });
+      }
     }
 
-    const balanceData = await getBalance(public_key);
-    await cache.set(cacheKey, balanceData, cache.BALANCE_TTL);
+    const [horizonData, assetMap] = await Promise.all([
+      getBalance(public_key),
+      fetchSupportedAssets(),
+    ]);
 
-    res.json({ id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default, ...balanceData, cached: false });
+    const enrichedBalances = horizonData.balances.map(b => {
+      const key = b.asset_issuer
+        ? `${b.asset_code}:${b.asset_issuer}`
+        : b.asset_code;
+      const meta = assetMap.get(key);
+      return {
+        ...b,
+        display_name: meta?.display_name || b.asset_code,
+        icon_url: meta?.icon_url || null,
+        decimal_precision: meta?.decimal_precision ?? 7,
+        is_whitelisted: !!meta,
+      };
+    });
+
+    const balanceData = { ...horizonData, balances: enrichedBalances };
+    await cache.set(cacheKey, balanceData, MULTI_ASSET_TTL);
+
+    res.json({
+      id: wallet.id, public_key, label: wallet.label, is_default: wallet.is_default,
+      ...balanceData,
+      cached: false,
+    });
   } catch (err) {
     next(err);
   }
@@ -349,8 +398,25 @@ async function listTrustlines(req, res, next) {
 async function addTrustlineHandler(req, res, next) {
   try {
     const { asset, asset_issuer, limit, wallet_id } = req.body;
+
+    // Validate asset against the supported_assets whitelist
+    const assetCheck = await db.query(
+      `SELECT id FROM supported_assets
+       WHERE asset_code = $1
+         AND (asset_issuer = $2 OR ($2 IS NULL AND asset_issuer IS NULL))
+         AND is_active = true`,
+      [asset, asset_issuer || null]
+    );
+    if (!assetCheck.rows[0]) {
+      return res.status(400).json({
+        error: `Asset ${asset} is not on the supported assets whitelist. Contact support to request it.`,
+        code: 'ASSET_NOT_WHITELISTED',
+      });
+    }
+
     const wallet = await resolveWallet(req.user.userId, wallet_id || null);
     if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
+
     const { transactionHash } = await addTrustline({
       publicKey: wallet.public_key,
       encryptedSecretKey: wallet.encrypted_secret_key,

--- a/backend/src/middleware/supportUpload.js
+++ b/backend/src/middleware/supportUpload.js
@@ -1,0 +1,132 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const { v4: uuidv4 } = require('uuid');
+const logger = require('../utils/logger');
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'application/pdf'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const MAX_FILES = 3;
+
+// Magic-byte signatures for supported MIME types
+const MAGIC_SIGNATURES = {
+  'image/jpeg': [[0xFF, 0xD8, 0xFF]],
+  'image/png':  [[0x89, 0x50, 0x4E, 0x47]],
+  'image/gif':  [[0x47, 0x49, 0x46, 0x38, 0x37, 0x61], [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]],
+  'application/pdf': [[0x25, 0x50, 0x44, 0x46]],
+};
+
+const uploadDir = path.resolve(__dirname, '../../../uploads/support');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const MIME_EXTENSIONS = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'application/pdf': '.pdf',
+};
+
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (_req, file, cb) => {
+    const ext = MIME_EXTENSIONS[file.mimetype] || path.extname(file.originalname).toLowerCase();
+    cb(null, `${uuidv4()}${ext}`);
+  },
+});
+
+const fileFilter = (_req, file, cb) => {
+  if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(Object.assign(
+      new Error('Only JPEG, PNG, GIF, and PDF files are allowed'),
+      { status: 400 }
+    ));
+  }
+};
+
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: MAX_FILE_SIZE, files: MAX_FILES },
+}).array('attachments', MAX_FILES);
+
+function matchesMagicBytes(filePath, mimeType) {
+  const signatures = MAGIC_SIGNATURES[mimeType];
+  if (!signatures) return false;
+
+  const maxLen = Math.max(...signatures.map(s => s.length));
+  const buf = Buffer.alloc(maxLen);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    fs.readSync(fd, buf, 0, maxLen, 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  return signatures.some(sig =>
+    sig.every((byte, i) => buf[i] === byte)
+  );
+}
+
+async function tryClamScan(filePath) {
+  try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    const NodeClam = require('clamscan');
+    const scanner = await new NodeClam().init();
+    const { isInfected } = await scanner.scanFile(filePath);
+    return isInfected;
+  } catch {
+    logger.warn('ClamAV not configured — skipping malware scan', { filePath });
+    return false;
+  }
+}
+
+function cleanup(files) {
+  if (!files) return;
+  for (const f of files) {
+    try { fs.unlinkSync(f.path); } catch {}
+  }
+}
+
+async function supportUploadMiddleware(req, res, next) {
+  upload(req, res, async (err) => {
+    if (err) {
+      cleanup(req.files);
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(400).json({ error: 'Each file must be 5 MB or smaller' });
+      }
+      if (err.code === 'LIMIT_FILE_COUNT') {
+        return res.status(400).json({ error: 'Maximum 3 attachments allowed per ticket' });
+      }
+      return res.status(400).json({ error: err.message || 'File upload error' });
+    }
+
+    if (!req.files || req.files.length === 0) {
+      return next();
+    }
+
+    for (const file of req.files) {
+      if (!matchesMagicBytes(file.path, file.mimetype)) {
+        cleanup(req.files);
+        return res.status(400).json({
+          error: `File "${file.originalname}" failed content validation — file content does not match declared type`,
+        });
+      }
+
+      const isInfected = await tryClamScan(file.path);
+      if (isInfected) {
+        cleanup(req.files);
+        return res.status(400).json({
+          error: `File "${file.originalname}" was rejected by the malware scanner`,
+        });
+      }
+    }
+
+    next();
+  });
+}
+
+module.exports = supportUploadMiddleware;

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -29,6 +29,7 @@ const {
   bulkExport,
   getJobStatus,
   bulkKycUpdate,
+  getAuditLogs,
 } = require('../controllers/adminController');
 const { getDeadLetterNotifications } = require('../controllers/notificationController');
 
@@ -253,5 +254,10 @@ router.get('/jobs/:jobId', getJobStatus);
 // Dead-letter notifications (#693)
 // ---------------------------------------------------------------------------
 router.get('/notifications/dead-letter', getDeadLetterNotifications);
+
+// ---------------------------------------------------------------------------
+// Immutable Audit Log (#698)
+// ---------------------------------------------------------------------------
+router.get('/audit-logs', getAuditLogs);
 
 module.exports = router;

--- a/backend/src/routes/support.js
+++ b/backend/src/routes/support.js
@@ -1,25 +1,26 @@
+const fs = require('fs');
 const router = require('express').Router();
-const { body, validationResult } = require('express-validator');
+const { body, param, validationResult } = require('express-validator');
 const rateLimit = require('express-rate-limit');
 const authMiddleware = require('../middleware/auth');
-const { createTicket, listTickets } = require('../controllers/supportController');
+const supportUpload = require('../middleware/supportUpload');
+const { createTicket, listTickets, getAttachment } = require('../controllers/supportController');
 
 const validate = (req, res, next) => {
   const errors = validationResult(req);
-  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  if (!errors.isEmpty()) {
+    // Clean up any uploaded files if body validation fails
+    if (req.files) req.files.forEach(f => { try { fs.unlinkSync(f.path); } catch {} });
+    return res.status(400).json({ errors: errors.array() });
+  }
   next();
 };
 
-/**
- * Per-user rate limiter for support ticket creation.
- * Allows a maximum of 5 tickets per hour per authenticated user.
- * Returns 429 Too Many Requests with a Retry-After header when exceeded.
- */
 const ticketCreationLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour
+  windowMs: 60 * 60 * 1000,
   max: 5,
   keyGenerator: (req) => req.user.userId,
-  standardHeaders: true,   // sends RateLimit-* headers
+  standardHeaders: true,
   legacyHeaders: false,
   message: {
     error: 'Too many support tickets created. You may submit up to 5 tickets per hour.',
@@ -32,14 +33,14 @@ router.use(authMiddleware);
  * @swagger
  * /api/support/tickets:
  *   post:
- *     summary: Create a support ticket
+ *     summary: Create a support ticket (multipart/form-data, up to 3 attachments)
  *     tags: [Support]
  *     security:
  *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
- *         application/json:
+ *         multipart/form-data:
  *           schema:
  *             type: object
  *             required: [type, description]
@@ -51,11 +52,16 @@ router.use(authMiddleware);
  *                 enum: [wrong_address, wrong_amount, failed_deducted, other]
  *               description:
  *                 type: string
+ *               attachments:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: binary
  *     responses:
  *       201:
  *         description: Ticket created
  *       429:
- *         description: Too many requests – per-user limit of 5 tickets/hour exceeded
+ *         description: Rate limit exceeded
  *   get:
  *     summary: List user's support tickets
  *     tags: [Support]
@@ -64,19 +70,61 @@ router.use(authMiddleware);
  *     responses:
  *       200:
  *         description: List of tickets
+ *
+ * /api/support/tickets/{id}/attachments/{filename}:
+ *   get:
+ *     summary: Serve a support ticket attachment
+ *     tags: [Support]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - in: path
+ *         name: filename
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: File content
+ *       404:
+ *         description: Attachment not found
  */
-router.post('/tickets',
+router.post(
+  '/tickets',
   ticketCreationLimiter,
+  supportUpload,
   [
     body('type').notEmpty().withMessage('type is required'),
-    body('description').trim().notEmpty().withMessage('description is required')
-      .isLength({ max: 2000 }).withMessage('description must be under 2000 characters'),
-    body('transaction_id').optional().isInt({ min: 1 }).withMessage('transaction_id must be a positive integer'),
+    body('description')
+      .trim()
+      .notEmpty()
+      .withMessage('description is required')
+      .isLength({ max: 2000 })
+      .withMessage('description must be under 2000 characters'),
+    body('transaction_id')
+      .optional()
+      .isInt({ min: 1 })
+      .withMessage('transaction_id must be a positive integer'),
   ],
   validate,
   createTicket
 );
 
 router.get('/tickets', listTickets);
+
+router.get(
+  '/tickets/:id/attachments/:filename',
+  [
+    param('id').isInt({ min: 1 }).withMessage('id must be a positive integer'),
+    param('filename').notEmpty().withMessage('filename is required'),
+  ],
+  validate,
+  getAttachment
+);
 
 module.exports = router;

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -2,15 +2,14 @@ const db = require('../db');
 
 function anonymizeIp(ip) {
   if (!ip) return null;
-  // IPv4: mask last octet
   const v4 = ip.match(/^(\d+\.\d+\.\d+)\.\d+$/);
   if (v4) return `${v4[1]}.0`;
-  // IPv6: mask last group
   const v6 = ip.match(/^(.*):[\da-fA-F]+$/);
   if (v6) return `${v6[1]}:0`;
   return ip;
 }
 
+// Legacy helper — kept for backward compatibility with existing callers.
 async function log(userId, action, ipAddress, userAgent, metadata = null) {
   try {
     await db.query(
@@ -23,4 +22,40 @@ async function log(userId, action, ipAddress, userAgent, metadata = null) {
   }
 }
 
-module.exports = { log };
+/**
+ * Structured audit log entry used by all admin and auth controller actions.
+ *
+ * @param {object} ctx         - Express request (or object with user, ip, headers)
+ * @param {string} action      - Machine-readable action name, e.g. 'kyc_approved'
+ * @param {object} [resource]  - { type, id, oldValue, newValue }
+ */
+async function auditLog(ctx, action, resource = {}) {
+  try {
+    const userId = ctx.user?.userId || ctx.user?.id || null;
+    const role = ctx.user?.role || null;
+    const ip = anonymizeIp(ctx.ip || ctx.connection?.remoteAddress || null);
+    const userAgent = ctx.headers?.['user-agent'] || null;
+
+    await db.query(
+      `INSERT INTO audit_logs
+         (user_id, actor_role, action, resource_type, resource_id,
+          old_value, new_value, ip_address, user_agent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        userId,
+        role,
+        action,
+        resource.type || null,
+        resource.id != null ? String(resource.id) : null,
+        resource.oldValue != null ? JSON.stringify(resource.oldValue) : null,
+        resource.newValue != null ? JSON.stringify(resource.newValue) : null,
+        ip,
+        userAgent,
+      ]
+    );
+  } catch {
+    // fail silently
+  }
+}
+
+module.exports = { log, auditLog };

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -159,18 +159,31 @@ async function getBalance(publicKey) {
 
     return {
       account_exists: true,
+      num_subentries: numSubentries,
       balances: account.balances.map(b => {
         if (b.asset_type === 'native') {
           const total = parseFloat(b.balance);
           const available = Math.max(0, total - minBalance);
           return {
+            asset_type: 'native',
+            asset_code: 'XLM',
+            asset_issuer: null,
             asset: 'XLM',
             balance: b.balance,
             available_balance: available.toFixed(7),
             min_balance: minBalance.toFixed(7),
+            minimum_balance_reserve: minBalance.toFixed(7),
           };
         }
-        return { asset: b.asset_code, balance: b.balance };
+        return {
+          asset_type: b.asset_type,
+          asset_code: b.asset_code,
+          asset_issuer: b.asset_issuer || null,
+          asset: b.asset_code,
+          balance: b.balance,
+          limit: b.limit || null,
+          is_authorized: b.is_authorized ?? true,
+        };
       }),
     };
   } catch (e) {

--- a/database/migrations/028_add_support_attachments.js
+++ b/database/migrations/028_add_support_attachments.js
@@ -1,0 +1,28 @@
+exports.up = (pgm) => {
+  pgm.createTable('support_attachments', {
+    id: {
+      type: 'uuid',
+      primaryKey: true,
+      default: pgm.func('uuid_generate_v4()'),
+    },
+    ticket_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"support_tickets"',
+      onDelete: 'CASCADE',
+    },
+    filename: { type: 'varchar(255)', notNull: true },
+    original_name: { type: 'varchar(255)', notNull: true },
+    mime_type: { type: 'varchar(100)', notNull: true },
+    size_bytes: { type: 'integer', notNull: true },
+    storage_path: { type: 'text', notNull: true },
+    uploaded_at: { type: 'timestamptz', default: pgm.func('NOW()') },
+  });
+
+  pgm.createIndex('support_attachments', 'ticket_id', { name: 'idx_support_attachments_ticket' });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('support_attachments', 'ticket_id', { name: 'idx_support_attachments_ticket' });
+  pgm.dropTable('support_attachments');
+};

--- a/database/migrations/029_enhance_audit_logs.js
+++ b/database/migrations/029_enhance_audit_logs.js
@@ -1,0 +1,48 @@
+exports.up = async (pgm) => {
+  // Add extended columns for full structured audit trail
+  pgm.addColumns('audit_logs', {
+    actor_role: { type: 'varchar(50)' },
+    resource_type: { type: 'varchar(100)' },
+    resource_id: { type: 'varchar(255)' },
+    old_value: { type: 'jsonb' },
+    new_value: { type: 'jsonb' },
+  });
+
+  pgm.createIndex('audit_logs', 'action', { name: 'idx_audit_logs_action' });
+  pgm.createIndex('audit_logs', 'resource_type', { name: 'idx_audit_logs_resource_type' });
+  pgm.createIndex('audit_logs', 'actor_role', { name: 'idx_audit_logs_actor_role' });
+
+  // Enable RLS to make the log tamper-evident.
+  // FORCE ROW LEVEL SECURITY ensures even roles with BYPASSRLS are subject to policies.
+  // We create SELECT and INSERT policies only — DELETE and UPDATE have no policies,
+  // so they are implicitly denied. We also REVOKE the privileges at the table level.
+  pgm.sql(`
+    ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE audit_logs FORCE ROW LEVEL SECURITY;
+
+    CREATE POLICY audit_logs_select ON audit_logs
+      AS PERMISSIVE FOR SELECT
+      USING (true);
+
+    CREATE POLICY audit_logs_insert ON audit_logs
+      AS PERMISSIVE FOR INSERT
+      WITH CHECK (true);
+
+    REVOKE UPDATE, DELETE ON audit_logs FROM PUBLIC;
+  `);
+};
+
+exports.down = async (pgm) => {
+  pgm.sql(`
+    GRANT UPDATE, DELETE ON audit_logs TO PUBLIC;
+    DROP POLICY IF EXISTS audit_logs_insert ON audit_logs;
+    DROP POLICY IF EXISTS audit_logs_select ON audit_logs;
+    ALTER TABLE audit_logs DISABLE ROW LEVEL SECURITY;
+  `);
+
+  pgm.dropIndex('audit_logs', 'actor_role', { name: 'idx_audit_logs_actor_role', ifExists: true });
+  pgm.dropIndex('audit_logs', 'resource_type', { name: 'idx_audit_logs_resource_type', ifExists: true });
+  pgm.dropIndex('audit_logs', 'action', { name: 'idx_audit_logs_action', ifExists: true });
+
+  pgm.dropColumns('audit_logs', ['actor_role', 'resource_type', 'resource_id', 'old_value', 'new_value']);
+};

--- a/database/migrations/030_add_supported_assets.js
+++ b/database/migrations/030_add_supported_assets.js
@@ -1,0 +1,37 @@
+exports.up = (pgm) => {
+  pgm.createTable('supported_assets', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    asset_code: { type: 'varchar(12)', notNull: true },
+    // NULL for native XLM
+    asset_issuer: { type: 'varchar(56)' },
+    display_name: { type: 'varchar(100)', notNull: true },
+    icon_url: { type: 'text' },
+    decimal_precision: { type: 'integer', notNull: true, default: 7 },
+    is_active: { type: 'boolean', notNull: true, default: true },
+    created_at: { type: 'timestamptz', default: pgm.func('NOW()') },
+  });
+
+  // Uniqueness scoped to (code, issuer) — COALESCE handles the NULL case
+  pgm.sql(`
+    ALTER TABLE supported_assets
+      ADD CONSTRAINT supported_assets_asset_unique
+      UNIQUE (asset_code, asset_issuer);
+  `);
+
+  pgm.createIndex('supported_assets', 'asset_code', { name: 'idx_supported_assets_code' });
+
+  // Seed well-known assets. Issuer addresses may be overridden by admins after deployment.
+  pgm.sql(`
+    INSERT INTO supported_assets (asset_code, asset_issuer, display_name, decimal_precision) VALUES
+      ('XLM',  NULL,                                                          'Stellar Lumens', 7),
+      ('USDC', 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5', 'USD Coin',        2)
+    ON CONFLICT DO NOTHING;
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('supported_assets');
+};

--- a/frontend/src/components/XDRInspectorModal.jsx
+++ b/frontend/src/components/XDRInspectorModal.jsx
@@ -1,43 +1,242 @@
-import React, { useState } from 'react';
-import { X, Code } from 'lucide-react';
-import api from '../utils/api';
-import toast from 'react-hot-toast';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { X, Code, Copy, Check, ExternalLink } from 'lucide-react';
+import { TransactionBuilder, Networks } from '@stellar/stellar-sdk';
 
-export default function XDRInspectorModal({ isOpen, onClose, xdr }) {
+const NETWORK = process.env.REACT_APP_STELLAR_NETWORK === 'mainnet'
+  ? 'public'
+  : 'testnet';
+
+const NETWORK_PASSPHRASE = NETWORK === 'public'
+  ? Networks.PUBLIC
+  : Networks.TESTNET;
+
+function formatMemo(memo) {
+  if (!memo || memo.type === 'none') return null;
+  if (memo.type === 'text') return `Text: ${memo.value}`;
+  if (memo.type === 'id') return `ID: ${memo.value}`;
+  if (memo.type === 'hash') return `Hash: ${Buffer.from(memo.value).toString('hex')}`;
+  if (memo.type === 'return') return `Return: ${Buffer.from(memo.value).toString('hex')}`;
+  return String(memo.value);
+}
+
+function describeOperation(op) {
+  switch (op.type) {
+    case 'payment':
+      return `Payment — To: ${op.destination}, Amount: ${op.amount} ${
+        op.asset.isNative() ? 'XLM' : op.asset.code
+      }`;
+    case 'pathPaymentStrictReceive':
+      return `Path Payment (receive) — To: ${op.destination}, Dest Amount: ${op.destAmount} ${
+        op.destAsset.isNative() ? 'XLM' : op.destAsset.code
+      }`;
+    case 'pathPaymentStrictSend':
+      return `Path Payment (send) — From: ${op.sendAmount} ${
+        op.sendAsset.isNative() ? 'XLM' : op.sendAsset.code
+      }, To: ${op.destination}`;
+    case 'changeTrust':
+      return `Change Trust — Asset: ${op.line.isNative() ? 'XLM' : `${op.line.code}/${op.line.issuer}`}, Limit: ${op.limit}`;
+    case 'allowTrust':
+      return `Allow Trust — Trustor: ${op.trustor}, Asset: ${op.assetCode}`;
+    case 'accountMerge':
+      return `Account Merge — Destination: ${op.destination}`;
+    case 'manageOffer':
+    case 'manageSellOffer':
+      return `Manage Sell Offer — ${op.amount} ${op.selling.isNative() ? 'XLM' : op.selling.code} @ ${op.price}`;
+    case 'manageBuyOffer':
+      return `Manage Buy Offer — ${op.buyAmount} ${op.buying.isNative() ? 'XLM' : op.buying.code} @ ${op.price}`;
+    case 'createAccount':
+      return `Create Account — Destination: ${op.destination}, Starting Balance: ${op.startingBalance} XLM`;
+    case 'setOptions':
+      return `Set Options`;
+    case 'inflation':
+      return `Inflation`;
+    case 'manageData':
+      return `Manage Data — Key: "${op.name}"`;
+    case 'bumpSequence':
+      return `Bump Sequence — To: ${op.bumpTo}`;
+    case 'createClaimableBalance':
+      return `Create Claimable Balance — Amount: ${op.amount} ${op.asset.isNative() ? 'XLM' : op.asset.code}`;
+    case 'claimClaimableBalance':
+      return `Claim Claimable Balance — ID: ${op.balanceId}`;
+    case 'invokeHostFunction':
+      return `Invoke Host Function (Soroban)`;
+    default:
+      return op.type;
+  }
+}
+
+function getOperationDetails(op) {
+  const raw = { ...op };
+  // Stringify asset objects for display
+  const stringify = (v) => {
+    if (v && typeof v === 'object' && typeof v.isNative === 'function') {
+      return v.isNative() ? 'XLM' : `${v.code}/${v.issuer}`;
+    }
+    return v;
+  };
+  return Object.fromEntries(
+    Object.entries(raw)
+      .filter(([k]) => !['type', 'source'].includes(k))
+      .map(([k, v]) => [k, stringify(v)])
+  );
+}
+
+function decodeXdr(xdr) {
+  const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE);
+  const hashBytes = tx.hash();
+  const hashHex = Array.from(new Uint8Array(hashBytes))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  const feeXlm = (parseInt(tx.fee, 10) / 1e7).toFixed(7);
+
+  return {
+    sourceAccount: tx.source,
+    sequence: tx.sequence,
+    fee: tx.fee,
+    feeXlm,
+    memo: formatMemo(tx.memo),
+    operations: tx.operations.map((op) => ({
+      type: op.type,
+      label: describeOperation(op),
+      sourceAccount: op.source || null,
+      details: getOperationDetails(op),
+    })),
+    hash: hashHex,
+  };
+}
+
+export default function XDRInspectorModal({ isOpen, onClose, xdr, txHash }) {
+  const [activeTab, setActiveTab] = useState('decoded');
   const [decoded, setDecoded] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [decodeError, setDecodeError] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const modalRef = useRef(null);
+  const closeButtonRef = useRef(null);
 
-  React.useEffect(() => {
-    if (isOpen && xdr) {
-      setLoading(true);
-      api.post('/dev/decode-xdr', { xdr })
-        .then(res => setDecoded(res.data.decoded))
-        .catch(err => toast.error(err.response?.data?.error || 'Failed to decode XDR'))
-        .finally(() => setLoading(false));
+  // Decode XDR client-side when modal opens or xdr changes
+  useEffect(() => {
+    if (!isOpen || !xdr) {
+      setDecoded(null);
+      setDecodeError(null);
+      return;
+    }
+    try {
+      setDecoded(decodeXdr(xdr));
+      setDecodeError(null);
+    } catch {
+      setDecoded(null);
+      setDecodeError('Could not decode XDR. Raw XDR is shown below.');
+      setActiveTab('raw');
     }
   }, [isOpen, xdr]);
 
+  // Focus trap and keyboard close
+  useEffect(() => {
+    if (!isOpen) return;
+    closeButtonRef.current?.focus();
+
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusable = modalRef.current?.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+        } else {
+          if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleCopy = useCallback(() => {
+    if (!xdr) return;
+    navigator.clipboard.writeText(xdr).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [xdr]);
+
   if (!isOpen) return null;
 
+  const resolvedHash = txHash || decoded?.hash;
+  const explorerUrl = resolvedHash
+    ? `https://stellar.expert/explorer/${NETWORK}/tx/${resolvedHash}`
+    : null;
+
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-900 rounded-2xl max-w-2xl w-full max-h-[80vh] overflow-hidden shadow-2xl">
-        <div className="flex items-center justify-between p-5 border-b border-gray-800">
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="xdr-modal-title"
+    >
+      <div
+        ref={modalRef}
+        className="bg-gray-900 rounded-2xl max-w-2xl w-full max-h-[85vh] overflow-hidden shadow-2xl flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-gray-800 flex-shrink-0">
           <div className="flex items-center gap-2">
             <Code size={20} className="text-primary-400" />
-            <h3 className="text-lg font-bold text-white">Transaction XDR Inspector</h3>
+            <h3 id="xdr-modal-title" className="text-lg font-bold text-white">
+              Transaction XDR Inspector
+            </h3>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            aria-label="Close modal"
+            className="text-gray-400 hover:text-white transition-colors"
+          >
             <X size={20} />
           </button>
         </div>
 
-        <div className="p-5 overflow-y-auto max-h-[calc(80vh-80px)]">
-          {loading ? (
-            <div className="flex justify-center py-8">
-              <div className="w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+        {/* Tabs */}
+        <div className="flex border-b border-gray-800 flex-shrink-0">
+          <button
+            onClick={() => setActiveTab('decoded')}
+            className={`px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'decoded'
+                ? 'text-primary-400 border-b-2 border-primary-400'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            Decoded
+          </button>
+          <button
+            onClick={() => setActiveTab('raw')}
+            className={`px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'raw'
+                ? 'text-primary-400 border-b-2 border-primary-400'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            Raw XDR
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5 overflow-y-auto flex-1">
+          {decodeError && (
+            <div className="mb-4 p-3 bg-red-900/40 border border-red-700 rounded-lg text-sm text-red-300">
+              {decodeError}
             </div>
-          ) : decoded ? (
+          )}
+
+          {activeTab === 'decoded' && decoded && (
             <div className="space-y-4">
               <div className="bg-gray-800 rounded-lg p-4">
                 <p className="text-xs text-gray-400 mb-1">Source Account</p>
@@ -46,13 +245,15 @@ export default function XDRInspectorModal({ isOpen, onClose, xdr }) {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="bg-gray-800 rounded-lg p-4">
-                  <p className="text-xs text-gray-400 mb-1">Fee (stroops)</p>
-                  <p className="text-sm text-white font-mono">{decoded.fee}</p>
+                  <p className="text-xs text-gray-400 mb-1">Fee</p>
+                  <p className="text-sm text-white font-mono">
+                    {decoded.fee} stroops
+                    <span className="text-gray-400 ml-1">({decoded.feeXlm} XLM)</span>
+                  </p>
                 </div>
-
                 <div className="bg-gray-800 rounded-lg p-4">
                   <p className="text-xs text-gray-400 mb-1">Sequence Number</p>
-                  <p className="text-sm text-white font-mono">{decoded.seqNum}</p>
+                  <p className="text-sm text-white font-mono">{decoded.sequence}</p>
                 </div>
               </div>
 
@@ -64,31 +265,79 @@ export default function XDRInspectorModal({ isOpen, onClose, xdr }) {
               )}
 
               <div className="bg-gray-800 rounded-lg p-4">
-                <p className="text-xs text-gray-400 mb-2">Operations ({decoded.operations.length})</p>
-                <div className="space-y-2">
+                <p className="text-xs text-gray-400 mb-2">
+                  Operations ({decoded.operations.length})
+                </p>
+                <div className="space-y-3">
                   {decoded.operations.map((op, idx) => (
-                    <div key={idx} className="bg-gray-900 rounded p-3">
-                      <p className="text-sm text-primary-400 font-semibold mb-1">{op.type}</p>
+                    <div key={idx} className="bg-gray-900 rounded-lg p-3">
+                      <p className="text-sm text-primary-400 font-semibold mb-1">{op.label}</p>
                       {op.sourceAccount && (
-                        <p className="text-xs text-gray-500 mb-1">Source: {op.sourceAccount}</p>
+                        <p className="text-xs text-gray-500 mb-1">
+                          Source: {op.sourceAccount}
+                        </p>
                       )}
-                      <pre className="text-xs text-gray-300 overflow-x-auto">
-                        {JSON.stringify(op.details, null, 2)}
-                      </pre>
+                      {Object.keys(op.details).length > 0 && (
+                        <pre className="text-xs text-gray-300 overflow-x-auto mt-2">
+                          {JSON.stringify(op.details, null, 2)}
+                        </pre>
+                      )}
                     </div>
                   ))}
                 </div>
               </div>
+
+              {decoded.hash && (
+                <div className="bg-gray-800 rounded-lg p-4">
+                  <p className="text-xs text-gray-400 mb-1">Transaction Hash</p>
+                  <p className="text-xs text-white font-mono break-all">{decoded.hash}</p>
+                </div>
+              )}
+
+              {explorerUrl && (
+                <a
+                  href={explorerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-sm text-primary-400 hover:text-primary-300 transition-colors"
+                >
+                  <ExternalLink size={14} />
+                  View on Stellar Expert
+                </a>
+              )}
             </div>
-          ) : (
+          )}
+
+          {activeTab === 'raw' && (
+            <div>
+              {!xdr ? (
+                <p className="text-center text-gray-500 py-8">No XDR data available</p>
+              ) : (
+                <pre className="text-xs text-gray-300 bg-gray-800 rounded-lg p-4 overflow-x-auto whitespace-pre-wrap break-all">
+                  {xdr}
+                </pre>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'decoded' && !decoded && !decodeError && (
             <p className="text-center text-gray-500 py-8">No XDR data available</p>
           )}
         </div>
 
-        <div className="p-5 border-t border-gray-800">
+        {/* Footer */}
+        <div className="p-5 border-t border-gray-800 flex gap-3 flex-shrink-0">
+          <button
+            onClick={handleCopy}
+            disabled={!xdr}
+            className="flex items-center gap-2 px-4 py-2.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl transition-colors text-sm"
+          >
+            {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+            {copied ? 'Copied!' : 'Copy XDR'}
+          </button>
           <button
             onClick={onClose}
-            className="w-full py-2.5 bg-gray-800 hover:bg-gray-700 text-white rounded-xl transition-colors"
+            className="flex-1 py-2.5 bg-gray-800 hover:bg-gray-700 text-white rounded-xl transition-colors"
           >
             Close
           </button>


### PR DESCRIPTION
…, XDR inspector (#699, #698, #697, #673)

## closes #699 — Support file attachments
- Add `support_attachments` table (migration 028) linking to `support_tickets`
- New `supportUpload` middleware: multer → UUID filenames → magic-byte validation → optional ClamAV scan; max 3 files × 5 MB each; JPEG/PNG/GIF/PDF only
- `POST /api/support/tickets` now accepts `multipart/form-data` with up to 3 `attachments` fields; stored in `uploads/support/`
- `GET /api/support/tickets/:id/attachments/:filename` serves files with correct Content-Type/Content-Disposition; ownership verified; admin bypass; path-traversal safe

## closes #698 — Immutable audit trail
- Migration 029 adds `actor_role`, `resource_type`, `resource_id`, `old_value` (JSONB), `new_value` (JSONB) columns to `audit_logs`
- RLS: `ENABLE + FORCE ROW LEVEL SECURITY`; SELECT and INSERT policies created; `REVOKE UPDATE, DELETE` from PUBLIC
- New `auditLog(ctx, action, resource)` helper in `audit.js` for structured entries; existing `log()` kept for backward compatibility
- `approveKYC`, `revokeKYC`, `bulkSuspend`, `bulkUnsuspend` in adminController updated to use `auditLog`
- `GET /api/admin/audit-logs` with cursor-based pagination and filters: `actor`, `action`, `resource_type`, `from`, `to`, `cursor`, `limit`

## closes #697 — Multi-asset balance polling
- Migration 030 adds `supported_assets` table seeded with XLM and USDC
- `getBalance` in stellar.js now returns `asset_type`, `asset_code`, `asset_issuer`, XLM reserve calculation (`minimum_balance_reserve`)
- `GET /api/wallet/balance` enriched: joins `supported_assets` for `display_name`, `icon_url`, `decimal_precision`, `is_whitelisted`; non-whitelisted assets included with `is_whitelisted: false`
- Redis cache 10-second TTL; `?refresh=true` bypasses cache for immediate update
- `POST /api/wallet/trustline` now validates asset against `supported_assets` whitelist before submitting to Stellar

## closes #673 — XDR Inspector modal
- Full rewrite of `XDRInspectorModal.jsx`: client-side XDR decoding via `@stellar/stellar-sdk`'s `TransactionBuilder.fromXDR()` (no more server round-trip)
- Two tabs: "Decoded" (source account, fee in stroops and XLM, sequence, memo, labelled operations with details) and "Raw" (raw XDR string)
- "Copy XDR" button with "Copied!" confirmation via clipboard API
- Malformed XDR: error banner shown + switches to Raw tab automatically
- Stellar Expert deep link computed from transaction hash: `https://stellar.expert/explorer/[network]/tx/[hash]`
- Accessibility: Escape closes modal; focus trap cycles through all focusable elements; `aria-modal`, `aria-labelledby`