### PR TITLE
feat: recurring fees, multisig cancel, max executions, deploy env (#5…

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -250,8 +250,8 @@ EXPECTED_HASH_FILE="${CONTRACT_DIR}/${CONTRACT_SUBDIR}/expected_hash.txt"
 echo "$EXPECTED_WASM_HASH" > "$EXPECTED_HASH_FILE"
 echo -e "${GREEN}✓ Expected WASM hash stored to $EXPECTED_HASH_FILE${NC}"
 
-# Step 5b: Write contract ID to .deployed_ids.env for backend configuration
-DEPLOYED_IDS_FILE="${CONTRACT_DIR}/.deployed_ids.env"
+# Step 5b: Write contract ID to contracts/.env so the backend can load it as an env var
+DEPLOYED_IDS_FILE="${CONTRACT_DIR}/.env"
 
 # Derive the env var name from the contract name (uppercase + _CONTRACT_ID)
 ENV_VAR_NAME=$(echo "${TARGET_CONTRACT}" | tr '[:lower:]-' '[:upper:]_')_CONTRACT_ID
@@ -306,17 +306,20 @@ case "$TARGET_CONTRACT" in
     fi
     ;;
   recurring-payments)
-    if [ -n "${USDC_ADDRESS:-}" ]; then
+    if [ -n "${ADMIN_ADDRESS:-}" ] && [ -n "${USDC_ADDRESS:-}" ]; then
+        FEE="${FEE_BPS:-0}"
         $SOROBAN_CLI contract invoke \
             --id "$CONTRACT_ID" \
             --source "$SOROBAN_SECRET_KEY" \
             --network "$NETWORK" \
             -- initialize \
-            --token_address "$USDC_ADDRESS"
+            --admin "$ADMIN_ADDRESS" \
+            --token_address "$USDC_ADDRESS" \
+            --fee_bps "$FEE"
         INIT_OK=true
     else
-        echo -e "${RED}WARNING: Set USDC_ADDRESS, then run:${NC}"
-        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --token_address \$USDC_ADDRESS"
+        echo -e "${RED}WARNING: Set ADMIN_ADDRESS and USDC_ADDRESS (and optionally FEE_BPS, default 0), then run:${NC}"
+        echo "  $SOROBAN_CLI contract invoke --id $CONTRACT_ID --source \$SOROBAN_SECRET_KEY --network $NETWORK -- initialize --admin \$ADMIN_ADDRESS --token_address \$USDC_ADDRESS --fee_bps \${FEE_BPS:-0}"
     fi
     ;;
   kyc-attestation)
@@ -424,8 +427,9 @@ echo "  Contract ID: $CONTRACT_ID"
 echo "  View on Stellar Expert: $EXPLORER_URL"
 echo ""
 echo -e "${YELLOW}Post-Deployment Checklist:${NC}"
-echo "  1. Source the deployed IDs into your backend .env:"
-echo "       cat contracts/.deployed_ids.env >> backend/.env"
+echo "  1. Load the deployed contract IDs into your backend:"
+echo "       cp contracts/.env backend/.env"
+echo "     Or append: cat contracts/.env >> backend/.env"
 echo "     Or manually copy: ${ENV_VAR_NAME}=${CONTRACT_ID}"
 echo "  2. initialize() was called automatically in Step 6 (if ADMIN_ADDRESS/USDC_ADDRESS were set)"
 echo "  3. Restart the backend service to pick up the new contract ID"

--- a/contracts/multisig-approval/src/lib.rs
+++ b/contracts/multisig-approval/src/lib.rs
@@ -12,6 +12,7 @@ pub enum TxStatus {
     Executed,
     Rejected,
     Expired,
+    Cancelled,
 }
 
 #[contracttype]
@@ -150,6 +151,21 @@ impl MultisigContract {
     pub fn get_proposal(env: Env, tx_id: u64) -> Proposal {
         env.storage().persistent().get(&DataKey::Proposal(tx_id))
             .expect("proposal not found")
+    }
+
+    /// Cancel a pending proposal. Only the original proposer may call this, and only before expiry.
+    pub fn cancel_proposal(env: Env, proposer: Address, tx_id: u64) {
+        proposer.require_auth();
+
+        let mut proposal: Proposal = env.storage().persistent().get(&DataKey::Proposal(tx_id))
+            .expect("proposal not found");
+
+        assert!(proposal.proposer == proposer, "only the proposer can cancel");
+        assert!(proposal.status == TxStatus::Pending, "not pending");
+        assert!(env.ledger().timestamp() < proposal.expires_at, "proposal expired");
+
+        proposal.status = TxStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Proposal(tx_id), &proposal);
     }
 
     /// Propose a quorum threshold change. Any approver may propose.

--- a/contracts/multisig-approval/src/test.rs
+++ b/contracts/multisig-approval/src/test.rs
@@ -315,6 +315,61 @@ fn test_mixed_votes_pending_until_decided() {
     assert_eq!(client.get_proposal(&tx_id).status, TxStatus::Executed);
 }
 
+// ── #554: cancel_proposal ────────────────────────────────────────────────────
+
+#[test]
+fn test_cancel_proposal_sets_status_cancelled() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let tx_id = propose(&env, &contract_id, &proposer);
+    client.cancel_proposal(&proposer, &tx_id);
+    assert_eq!(client.get_proposal(&tx_id).status, TxStatus::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "only the proposer can cancel")]
+fn test_cancel_proposal_by_non_proposer_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let tx_id = propose(&env, &contract_id, &proposer);
+    client.cancel_proposal(&approvers.get(1).unwrap(), &tx_id);
+}
+
+#[test]
+#[should_panic(expected = "not pending")]
+fn test_cancel_proposal_already_executed_panics() {
+    let (env, contract_id, approvers, _) = setup(1, 2);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let tx_id = propose(&env, &contract_id, &proposer);
+    client.approve(&proposer, &tx_id); // executes immediately (quorum 1)
+    client.cancel_proposal(&proposer, &tx_id);
+}
+
+#[test]
+#[should_panic(expected = "proposal expired")]
+fn test_cancel_proposal_after_expiry_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let tx_id = propose(&env, &contract_id, &proposer);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.cancel_proposal(&proposer, &tx_id);
+}
+
+#[test]
+#[should_panic(expected = "not pending")]
+fn test_approve_cancelled_proposal_panics() {
+    let (env, contract_id, approvers, _) = setup(2, 3);
+    let client = MultisigContractClient::new(&env, &contract_id);
+    let proposer = approvers.get(0).unwrap();
+    let tx_id = propose(&env, &contract_id, &proposer);
+    client.cancel_proposal(&proposer, &tx_id);
+    client.approve(&approvers.get(1).unwrap(), &tx_id);
+}
+
 // ── quorum change ─────────────────────────────────────────────────────────────
 
 #[test]

--- a/contracts/recurring-payments/src/lib.rs
+++ b/contracts/recurring-payments/src/lib.rs
@@ -8,6 +8,8 @@ mod test;
 #[contracttype]
 pub enum DataKey {
     TokenAddress,
+    Admin,
+    FeeBps,
     Schedule(u64),
     Counter,
 }
@@ -95,14 +97,24 @@ pub struct RecurringPaymentsContract;
 
 #[contractimpl]
 impl RecurringPaymentsContract {
-    /// One-time initializer — stores the token (USDC) contract address.
-    pub fn initialize(env: Env, token_address: Address) {
+    /// One-time initializer — stores the admin, token (USDC) address, and fee in basis points.
+    /// `fee_bps` of 0 disables fee collection; max is 10 000 (100 %).
+    pub fn initialize(env: Env, admin: Address, token_address: Address, fee_bps: u32) {
         if env.storage().persistent().has(&DataKey::TokenAddress) {
             panic!("already initialized");
+        }
+        if fee_bps > 10_000 {
+            panic!("fee_bps must be <= 10000");
         }
         env.storage()
             .persistent()
             .set(&DataKey::TokenAddress, &token_address);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeeBps, &fee_bps);
         env.storage()
             .persistent()
             .set(&DataKey::Counter, &0u64);
@@ -214,13 +226,39 @@ impl RecurringPaymentsContract {
             .get(&DataKey::TokenAddress)
             .expect("not initialized");
 
-        // Pull funds directly from sender → recipient (no custody).
-        token::Client::new(&env, &token_address).transfer_from(
+        let fee_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::FeeBps)
+            .unwrap_or(0);
+
+        let fee_amount = if fee_bps > 0 {
+            schedule.amount * fee_bps as i128 / 10_000
+        } else {
+            0
+        };
+        let net_amount = schedule.amount - fee_amount;
+
+        let token = token::Client::new(&env, &token_address);
+        token.transfer_from(
             &env.current_contract_address(),
             &schedule.sender,
             &schedule.recipient,
-            &schedule.amount,
+            &net_amount,
         );
+        if fee_amount > 0 {
+            let admin: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Admin)
+                .expect("not initialized");
+            token.transfer_from(
+                &env.current_contract_address(),
+                &schedule.sender,
+                &admin,
+                &fee_amount,
+            );
+        }
 
         schedule.next_payment_at = now + schedule.interval;
         schedule.executions_completed += 1;

--- a/contracts/recurring-payments/src/test.rs
+++ b/contracts/recurring-payments/src/test.rs
@@ -9,7 +9,11 @@ use soroban_sdk::{
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, Address, Address, Address, Address, Address) {
+fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
+    setup_with_fee(0)
+}
+
+fn setup_with_fee(fee_bps: u32) -> (Env, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -17,10 +21,12 @@ fn setup() -> (Env, Address, Address, Address, Address, Address) {
     let token_admin = Address::generate(&env);
     let token_id = env.register_stellar_asset_contract(token_admin.clone());
 
+    let admin = Address::generate(&env);
+
     // Deploy the recurring-payments contract
     let contract_id = env.register_contract(None, RecurringPaymentsContract);
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
-    client.initialize(&token_id);
+    client.initialize(&admin, &token_id, &fee_bps);
 
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
@@ -37,7 +43,7 @@ fn setup() -> (Env, Address, Address, Address, Address, Address) {
         &(env.ledger().sequence() + 10_000),
     );
 
-    (env, contract_id, token_id, sender, recipient, executor)
+    (env, contract_id, token_id, sender, recipient, executor, admin)
 }
 
 fn advance_time(env: &Env, secs: u64) {
@@ -60,24 +66,38 @@ fn test_initialize_ok() {
     env.mock_all_auths();
     let token_admin = Address::generate(&env);
     let token_id = env.register_stellar_asset_contract(token_admin);
+    let admin = Address::generate(&env);
     let contract_id = env.register_contract(None, RecurringPaymentsContract);
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
-    client.initialize(&token_id); // must not panic
+    client.initialize(&admin, &token_id, &0); // must not panic
 }
 
 #[test]
 #[should_panic(expected = "already initialized")]
 fn test_initialize_twice_panics() {
-    let (env, contract_id, token_id, ..) = setup();
+    let (env, contract_id, token_id, _, _, _, _) = setup();
+    let admin = Address::generate(&env);
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
-    client.initialize(&token_id);
+    client.initialize(&admin, &token_id, &0);
+}
+
+#[test]
+#[should_panic(expected = "fee_bps must be <= 10000")]
+fn test_initialize_fee_bps_too_high_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin);
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, RecurringPaymentsContract);
+    RecurringPaymentsContractClient::new(&env, &contract_id).initialize(&admin, &token_id, &10_001);
 }
 
 // ── authorize_recurring ───────────────────────────────────────────────────────
 
 #[test]
 fn test_authorize_recurring_returns_id_one() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &1_000_0000000, &86400);
     assert_eq!(id, 1);
@@ -85,7 +105,7 @@ fn test_authorize_recurring_returns_id_one() {
 
 #[test]
 fn test_authorize_recurring_stores_schedule() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &500_0000000, &3600);
     let s = client.get_schedule(&id);
@@ -98,7 +118,7 @@ fn test_authorize_recurring_stores_schedule() {
 
 #[test]
 fn test_authorize_recurring_ids_increment() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id1 = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     let id2 = client.authorize_recurring(&sender, &recipient, &200_0000000, &86400);
@@ -109,7 +129,7 @@ fn test_authorize_recurring_ids_increment() {
 #[test]
 #[should_panic(expected = "amount must be positive")]
 fn test_authorize_zero_amount_panics() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     client.authorize_recurring(&sender, &recipient, &0, &86400);
 }
@@ -117,7 +137,7 @@ fn test_authorize_zero_amount_panics() {
 #[test]
 #[should_panic(expected = "amount must be positive")]
 fn test_authorize_negative_amount_panics() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     client.authorize_recurring(&sender, &recipient, &-1, &86400);
 }
@@ -125,7 +145,7 @@ fn test_authorize_negative_amount_panics() {
 #[test]
 #[should_panic(expected = "interval must be > 0")]
 fn test_authorize_zero_interval_panics() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     client.authorize_recurring(&sender, &recipient, &100_0000000, &0);
 }
@@ -134,7 +154,7 @@ fn test_authorize_zero_interval_panics() {
 
 #[test]
 fn test_execute_payment_transfers_funds() {
-    let (env, contract_id, token_id, sender, recipient, executor) = setup();
+    let (env, contract_id, token_id, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let amount = 1_000_0000000i128;
     let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
@@ -149,7 +169,7 @@ fn test_execute_payment_transfers_funds() {
 
 #[test]
 fn test_execute_payment_advances_next_payment_at() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
 
@@ -163,7 +183,7 @@ fn test_execute_payment_advances_next_payment_at() {
 
 #[test]
 fn test_execute_payment_multiple_cycles() {
-    let (env, contract_id, token_id, sender, recipient, executor) = setup();
+    let (env, contract_id, token_id, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let amount = 500_0000000i128;
     let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
@@ -179,7 +199,7 @@ fn test_execute_payment_multiple_cycles() {
 #[test]
 #[should_panic(expected = "payment not yet due")]
 fn test_execute_payment_too_early_panics() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     // Do NOT advance time
@@ -189,7 +209,7 @@ fn test_execute_payment_too_early_panics() {
 #[test]
 #[should_panic(expected = "schedule not found")]
 fn test_execute_payment_unknown_id_panics() {
-    let (env, contract_id, _, _, _, executor) = setup();
+    let (env, contract_id, _, _, _, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     client.execute_payment(&executor, &999);
 }
@@ -197,7 +217,7 @@ fn test_execute_payment_unknown_id_panics() {
 #[test]
 #[should_panic(expected = "schedule is not active")]
 fn test_execute_payment_on_cancelled_schedule_panics() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.cancel_recurring(&sender, &id);
@@ -210,7 +230,7 @@ fn test_execute_payment_on_cancelled_schedule_panics() {
 
 #[test]
 fn test_cancel_sets_status_cancelled() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.cancel_recurring(&sender, &id);
@@ -221,7 +241,7 @@ fn test_cancel_sets_status_cancelled() {
 #[test]
 #[should_panic(expected = "only the sender can cancel")]
 fn test_cancel_by_non_sender_panics() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.cancel_recurring(&executor, &id); // executor is not the sender
@@ -230,7 +250,7 @@ fn test_cancel_by_non_sender_panics() {
 #[test]
 #[should_panic(expected = "schedule is already cancelled")]
 fn test_cancel_already_cancelled_panics() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.cancel_recurring(&sender, &id);
@@ -259,7 +279,7 @@ fn test_get_schedule_unknown_id_panics() {
 
 #[test]
 fn test_pause_sets_status_paused() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&sender, &id);
@@ -269,7 +289,7 @@ fn test_pause_sets_status_paused() {
 
 #[test]
 fn test_resume_sets_status_active() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&sender, &id);
@@ -281,7 +301,7 @@ fn test_resume_sets_status_active() {
 #[test]
 #[should_panic(expected = "schedule is not active")]
 fn test_execute_payment_while_paused_panics() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&sender, &id);
@@ -291,7 +311,7 @@ fn test_execute_payment_while_paused_panics() {
 
 #[test]
 fn test_resume_allows_execution() {
-    let (env, contract_id, token_id, sender, recipient, executor) = setup();
+    let (env, contract_id, token_id, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let amount = 100_0000000i128;
     let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
@@ -305,7 +325,7 @@ fn test_resume_allows_execution() {
 #[test]
 #[should_panic(expected = "only the sender can pause")]
 fn test_pause_by_non_sender_panics() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&executor, &id);
@@ -314,7 +334,7 @@ fn test_pause_by_non_sender_panics() {
 #[test]
 #[should_panic(expected = "only the sender can resume")]
 fn test_resume_by_non_sender_panics() {
-    let (env, contract_id, _, sender, recipient, executor) = setup();
+    let (env, contract_id, _, sender, recipient, executor, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&sender, &id);
@@ -324,7 +344,7 @@ fn test_resume_by_non_sender_panics() {
 #[test]
 #[should_panic(expected = "schedule is not active")]
 fn test_pause_already_paused_panics() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&sender, &id);
@@ -334,7 +354,7 @@ fn test_pause_already_paused_panics() {
 #[test]
 #[should_panic(expected = "schedule is not paused")]
 fn test_resume_active_schedule_panics() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.resume_recurring_payment(&sender, &id);
@@ -342,11 +362,110 @@ fn test_resume_active_schedule_panics() {
 
 #[test]
 fn test_cancel_paused_schedule() {
-    let (env, contract_id, _, sender, recipient, _) = setup();
+    let (env, contract_id, _, sender, recipient, _, _) = setup();
     let client = RecurringPaymentsContractClient::new(&env, &contract_id);
     let id = client.authorize_recurring(&sender, &recipient, &100_0000000, &86400);
     client.pause_recurring_payment(&sender, &id);
     client.cancel_recurring_payment(&sender, &id);
     let s = client.get_recurring_payment(&id);
     assert_eq!(s.status, ScheduleStatus::Cancelled);
+}
+
+// ── #551: max_executions ──────────────────────────────────────────────────────
+
+#[test]
+fn test_max_executions_auto_cancels_schedule() {
+    let (env, contract_id, token_id, sender, recipient, executor, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.create_recurring_payment(&sender, &recipient, &token_id, &100_0000000, &86400, &2);
+
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+    assert_eq!(client.get_recurring_payment(&id).status, ScheduleStatus::Active);
+
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+    assert_eq!(client.get_recurring_payment(&id).status, ScheduleStatus::Cancelled);
+    assert_eq!(client.get_recurring_payment(&id).executions_completed, 2);
+}
+
+#[test]
+#[should_panic(expected = "schedule is not active")]
+fn test_execute_payment_after_max_executions_panics() {
+    let (env, contract_id, token_id, sender, recipient, executor, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let id = client.create_recurring_payment(&sender, &recipient, &token_id, &100_0000000, &86400, &1);
+
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+    // schedule is now Cancelled — next call must panic
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+}
+
+#[test]
+fn test_max_executions_zero_means_unlimited() {
+    let (env, contract_id, token_id, sender, recipient, executor, _) = setup();
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let amount = 100_0000000i128;
+    // max_executions = 0 → unlimited
+    let id = client.create_recurring_payment(&sender, &recipient, &token_id, &amount, &86400, &0);
+
+    for _ in 0..5 {
+        advance_time(&env, 86400);
+        client.execute_payment(&executor, &id);
+    }
+    assert_eq!(client.get_recurring_payment(&id).status, ScheduleStatus::Active);
+    assert_eq!(token_balance(&env, &token_id, &recipient), amount * 5);
+}
+
+// ── #552: fee collection ──────────────────────────────────────────────────────
+
+#[test]
+fn test_fee_deducted_from_recipient_forwarded_to_admin() {
+    let (env, contract_id, token_id, sender, recipient, executor, admin) = setup_with_fee(500); // 5 %
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let amount = 1_000_0000000i128;
+    let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
+
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+
+    let expected_fee = amount * 500 / 10_000; // 50_000_000
+    let expected_net = amount - expected_fee;  // 950_000_000
+
+    assert_eq!(token_balance(&env, &token_id, &recipient), expected_net);
+    assert_eq!(token_balance(&env, &token_id, &admin), expected_fee);
+}
+
+#[test]
+fn test_zero_fee_sends_full_amount_to_recipient() {
+    let (env, contract_id, token_id, sender, recipient, executor, admin) = setup_with_fee(0);
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let amount = 1_000_0000000i128;
+    let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
+
+    advance_time(&env, 86400);
+    client.execute_payment(&executor, &id);
+
+    assert_eq!(token_balance(&env, &token_id, &recipient), amount);
+    assert_eq!(token_balance(&env, &token_id, &admin), 0);
+}
+
+#[test]
+fn test_fee_accumulates_over_multiple_executions() {
+    let (env, contract_id, token_id, sender, recipient, executor, admin) = setup_with_fee(200); // 2 %
+    let client = RecurringPaymentsContractClient::new(&env, &contract_id);
+    let amount = 500_0000000i128;
+    let id = client.authorize_recurring(&sender, &recipient, &amount, &86400);
+
+    let fee_per_execution = amount * 200 / 10_000;
+    let net_per_execution = amount - fee_per_execution;
+
+    for i in 1..=3u32 {
+        advance_time(&env, 86400);
+        client.execute_payment(&executor, &id);
+        assert_eq!(token_balance(&env, &token_id, &admin), fee_per_execution * i as i128);
+        assert_eq!(token_balance(&env, &token_id, &recipient), net_per_execution * i as i128);
+    }
 }


### PR DESCRIPTION
closes #551 closes #552 closes #554 closes #559

- recurring-payments: add admin + fee_bps to initialize(); deduct fee on execute_payment() and forward to admin
- recurring-payments: auto-cancel schedule when max_executions is reached (0 = unlimited)
- multisig-approval: add cancel_proposal() — proposer only, before expiry, sets Cancelled status
- deploy.sh: write contract IDs to contracts/.env (not .deployed_ids.env); pass ADMIN_ADDRESS + FEE_BPS to recurring-payments initialize