### PR TITLE
feat: DEX order book depth API with estimated price and Redis cache (#695)

### DIFF
--- a/backend/src/__tests__/dex.test.js
+++ b/backend/src/__tests__/dex.test.js
@@ -7,9 +7,11 @@ jest.mock('../middleware/auth', () => (req, res, next) => {
   next();
 });
 jest.mock('../services/dex');
+jest.mock('../utils/cache', () => ({ get: jest.fn(), set: jest.fn() }));
 
 const db = require('../db');
 const dex = require('../services/dex');
+const cache = require('../utils/cache');
 const dexRouter = require('../routes/dex');
 
 const app = express();
@@ -18,21 +20,96 @@ app.use('/dex', dexRouter);
 app.use((err, req, res, next) => res.status(err.status || 500).json({ error: err.message }));
 
 const WALLET = 'GCSEQ5XE5YYKPITLT63FZ7LCW2JZNYVP3L2XKMGELRKGPNZXNNBVPOU3';
+const ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  // parseAssetParam is called inside the route before getOrderbook; provide a pass-through mock
+  dex.parseAssetParam.mockImplementation((p) => p);
+  cache.get.mockResolvedValue(null);
+  cache.set.mockResolvedValue(undefined);
+});
 
 // ---------------------------------------------------------------------------
 // GET /dex/orderbook
 // ---------------------------------------------------------------------------
 describe('GET /dex/orderbook', () => {
+  const BOOK = { bids: [], asks: [], midPrice: 1.5 };
+
   test('returns orderbook data for valid asset pair', async () => {
-    dex.getOrderbook.mockResolvedValue({ bids: [], asks: [], midPrice: 1.5 });
+    dex.getOrderbook.mockResolvedValue(BOOK);
 
     const res = await request(app).get('/dex/orderbook?selling=XLM&buying=USDC');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ bids: [], asks: [], midPrice: 1.5 });
-    expect(dex.getOrderbook).toHaveBeenCalledWith('XLM', 'USDC');
+    expect(res.body).toEqual(BOOK);
+    expect(dex.getOrderbook).toHaveBeenCalledWith('XLM', 'USDC', 10, null);
+  });
+
+  test('passes limit and amount to getOrderbook', async () => {
+    dex.getOrderbook.mockResolvedValue({ ...BOOK, estimated_price: 0.1 });
+
+    const res = await request(app).get('/dex/orderbook?selling=XLM&buying=USDC&limit=5&amount=100');
+
+    expect(res.status).toBe(200);
+    expect(dex.getOrderbook).toHaveBeenCalledWith('XLM', 'USDC', 5, 100);
+  });
+
+  test('accepts CODE:ISSUER format for issued assets', async () => {
+    dex.getOrderbook.mockResolvedValue(BOOK);
+
+    const res = await request(app).get(`/dex/orderbook?selling=USDC:${ISSUER}&buying=XLM`);
+
+    expect(res.status).toBe(200);
+    expect(dex.getOrderbook).toHaveBeenCalledWith(`USDC:${ISSUER}`, 'XLM', 10, null);
+  });
+
+  test('returns cached response without calling getOrderbook', async () => {
+    cache.get.mockResolvedValue(BOOK);
+
+    const res = await request(app).get('/dex/orderbook?selling=XLM&buying=USDC');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(BOOK);
+    expect(dex.getOrderbook).not.toHaveBeenCalled();
+  });
+
+  test('caches response with 5s TTL', async () => {
+    dex.getOrderbook.mockResolvedValue(BOOK);
+
+    await request(app).get('/dex/orderbook?selling=XLM&buying=USDC');
+
+    expect(cache.set).toHaveBeenCalledWith(
+      expect.stringContaining('orderbook:'),
+      BOOK,
+      5,
+    );
+  });
+
+  test('returns insufficient_liquidity flag when present in service response', async () => {
+    const insufficientBook = {
+      ...BOOK,
+      insufficient_liquidity: true,
+      max_fillable_amount: 50,
+      estimated_price: null,
+    };
+    dex.getOrderbook.mockResolvedValue(insufficientBook);
+
+    const res = await request(app).get('/dex/orderbook?selling=XLM&buying=USDC&amount=1000');
+
+    expect(res.status).toBe(200);
+    expect(res.body.insufficient_liquidity).toBe(true);
+    expect(res.body.max_fillable_amount).toBe(50);
+  });
+
+  test('returns 400 when parseAssetParam throws for malformed asset', async () => {
+    dex.parseAssetParam.mockImplementation(() => {
+      throw Object.assign(new Error('Invalid issuer address'), { status: 400 });
+    });
+
+    const res = await request(app).get('/dex/orderbook?selling=USDC:BADINVALID&buying=XLM');
+
+    expect(res.status).toBe(400);
   });
 
   test('returns 400 when selling param is missing', async () => {
@@ -47,6 +124,16 @@ describe('GET /dex/orderbook', () => {
 
   test('returns 400 for invalid asset code with special characters', async () => {
     const res = await request(app).get('/dex/orderbook?selling=XL%24&buying=USDC');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 for invalid amount (negative)', async () => {
+    const res = await request(app).get('/dex/orderbook?selling=XLM&buying=USDC&amount=-5');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 for invalid limit (> 200)', async () => {
+    const res = await request(app).get('/dex/orderbook?selling=XLM&buying=USDC&limit=201');
     expect(res.status).toBe(400);
   });
 });

--- a/backend/src/__tests__/dexHelpers.test.js
+++ b/backend/src/__tests__/dexHelpers.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+/**
+ * Unit tests for dex service helpers: parseAssetParam and simulateFill.
+ * No mocking of Horizon — these are pure computation tests.
+ */
+
+// Provide env issuer for plain CODE tests
+process.env.USDC_ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+// Mock stellar service so resolveAsset doesn't need Horizon
+jest.mock('../services/stellar', () => ({
+  resolveAsset: jest.fn((code) => {
+    const StellarSdk = require('@stellar/stellar-sdk');
+    if (code === 'XLM') return StellarSdk.Asset.native();
+    const issuer = process.env[`${code}_ISSUER`];
+    if (!issuer) throw Object.assign(new Error(`${code}_ISSUER not configured`), { status: 500 });
+    return new StellarSdk.Asset(code, issuer);
+  }),
+  decryptPrivateKey: jest.fn(),
+  sendPathPayment: jest.fn(),
+  findPaymentPath: jest.fn(),
+}));
+
+const StellarSdk = require('@stellar/stellar-sdk');
+const { parseAssetParam, simulateFill } = require('../services/dex');
+
+const ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+// ---------------------------------------------------------------------------
+// parseAssetParam
+// ---------------------------------------------------------------------------
+describe('parseAssetParam', () => {
+  test('returns native asset for XLM', () => {
+    const asset = parseAssetParam('XLM');
+    expect(asset.isNative()).toBe(true);
+  });
+
+  test('returns issued asset for CODE:ISSUER format', () => {
+    const asset = parseAssetParam(`USDC:${ISSUER}`);
+    expect(asset.getCode()).toBe('USDC');
+    expect(asset.getIssuer()).toBe(ISSUER);
+  });
+
+  test('is case-insensitive (lowercase input)', () => {
+    const asset = parseAssetParam(`usdc:${ISSUER.toLowerCase()}`);
+    expect(asset.getCode()).toBe('USDC');
+  });
+
+  test('resolves plain CODE via env issuer', () => {
+    const asset = parseAssetParam('USDC');
+    expect(asset.getCode()).toBe('USDC');
+    expect(asset.getIssuer()).toBe(ISSUER);
+  });
+
+  test('throws 400 for null input', () => {
+    expect(() => parseAssetParam(null)).toThrow(expect.objectContaining({ status: 400 }));
+  });
+
+  test('throws 400 for invalid code in CODE:ISSUER format', () => {
+    expect(() => parseAssetParam(`BAD!CODE:${ISSUER}`)).toThrow(expect.objectContaining({ status: 400 }));
+  });
+
+  test('throws 400 for malformed issuer in CODE:ISSUER format', () => {
+    expect(() => parseAssetParam('USDC:NOTANISSUER')).toThrow(expect.objectContaining({ status: 400 }));
+  });
+
+  test('throws 400 for empty string', () => {
+    expect(() => parseAssetParam('')).toThrow(expect.objectContaining({ status: 400 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// simulateFill
+// ---------------------------------------------------------------------------
+describe('simulateFill', () => {
+  const asks = [
+    { price: '0.1', amount: '100' },
+    { price: '0.11', amount: '200' },
+    { price: '0.12', amount: '300' },
+  ];
+
+  test('fills exactly from first level', () => {
+    const result = simulateFill(asks, 50);
+    expect(result.filledAmount).toBe(50);
+    expect(result.estimatedPrice).toBeCloseTo(0.1, 6);
+    expect(result.insufficientLiquidity).toBe(false);
+  });
+
+  test('fills across multiple levels', () => {
+    const result = simulateFill(asks, 150);
+    expect(result.filledAmount).toBe(150);
+    // 100 * 0.1 + 50 * 0.11 = 10 + 5.5 = 15.5 / 150 = 0.10333...
+    expect(result.estimatedPrice).toBeCloseTo(15.5 / 150, 5);
+    expect(result.insufficientLiquidity).toBe(false);
+  });
+
+  test('fills completely available liquidity and flags insufficient', () => {
+    const result = simulateFill(asks, 1000); // more than 600 total
+    expect(result.insufficientLiquidity).toBe(true);
+    expect(result.filledAmount).toBe(600);
+    expect(result.maxFillableAmount).toBe(600);
+  });
+
+  test('returns insufficientLiquidity false when exactly fills', () => {
+    const result = simulateFill(asks, 600);
+    expect(result.insufficientLiquidity).toBe(false);
+    expect(result.filledAmount).toBe(600);
+  });
+
+  test('returns null estimatedPrice and zero filled for empty asks', () => {
+    const result = simulateFill([], 100);
+    expect(result.estimatedPrice).toBeNull();
+    expect(result.filledAmount).toBe(0);
+    expect(result.insufficientLiquidity).toBe(true);
+    expect(result.maxFillableAmount).toBe(0);
+  });
+});

--- a/backend/src/routes/dex.js
+++ b/backend/src/routes/dex.js
@@ -2,9 +2,13 @@ const router = require('express').Router();
 const { query, body, validationResult } = require('express-validator');
 const authMiddleware = require('../middleware/auth');
 const db = require('../db');
-const { getOrderbook, executeSwap, getTradeHistory } = require('../services/dex');
+const cache = require('../utils/cache');
+const { parseAssetParam, getOrderbook, executeSwap, getTradeHistory } = require('../services/dex');
 
-const VALID_ASSETS = /^[A-Z0-9]{1,12}$/;
+const ORDERBOOK_TTL = 5; // seconds — one Stellar ledger close
+
+// Accepts "XLM" or "CODE" or "CODE:GISSUER..."
+const ASSET_PARAM_RE = /^[A-Z0-9]{1,12}(:[A-Z2-7]{56})?$/i;
 
 const validate = (req, res, next) => {
   const errors = validationResult(req);
@@ -18,15 +22,44 @@ const validate = (req, res, next) => {
  */
 router.get('/orderbook',
   [
-    query('selling').matches(VALID_ASSETS).withMessage('Invalid selling asset'),
-    query('buying').matches(VALID_ASSETS).withMessage('Invalid buying asset'),
+    query('selling')
+      .matches(ASSET_PARAM_RE)
+      .withMessage('selling must be XLM, a CODE, or CODE:GISSUER'),
+    query('buying')
+      .matches(ASSET_PARAM_RE)
+      .withMessage('buying must be XLM, a CODE, or CODE:GISSUER'),
+    query('limit')
+      .optional()
+      .isInt({ min: 1, max: 200 })
+      .withMessage('limit must be 1–200'),
+    query('amount')
+      .optional()
+      .isFloat({ gt: 0 })
+      .withMessage('amount must be a positive number'),
   ],
   validate,
   async (req, res, next) => {
     try {
-      const data = await getOrderbook(req.query.selling, req.query.buying);
+      // Validate asset params early to return a clean 400 before hitting Horizon
+      try {
+        parseAssetParam(req.query.selling);
+        parseAssetParam(req.query.buying);
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+
+      const limit  = req.query.limit  ? parseInt(req.query.limit, 10) : 10;
+      const amount = req.query.amount ? parseFloat(req.query.amount)  : null;
+      const cacheKey = `orderbook:${req.query.selling}:${req.query.buying}:${limit}:${amount ?? ''}`;
+
+      const cached = await cache.get(cacheKey);
+      if (cached) return res.json(cached);
+
+      const data = await getOrderbook(req.query.selling, req.query.buying, limit, amount);
+      await cache.set(cacheKey, data, ORDERBOOK_TTL);
       res.json(data);
     } catch (err) {
+      if (err.status === 400) return res.status(400).json({ error: err.message });
       next(err);
     }
   }
@@ -39,9 +72,9 @@ router.get('/orderbook',
 router.post('/swap',
   authMiddleware,
   [
-    body('sell_asset').matches(VALID_ASSETS).withMessage('Invalid sell_asset'),
+    body('sell_asset').matches(ASSET_PARAM_RE).withMessage('Invalid sell_asset'),
     body('sell_amount').isFloat({ gt: 0 }).withMessage('sell_amount must be > 0'),
-    body('buy_asset').matches(VALID_ASSETS).withMessage('Invalid buy_asset'),
+    body('buy_asset').matches(ASSET_PARAM_RE).withMessage('Invalid buy_asset'),
     body('slippage_pct').optional().isFloat({ min: 0, max: 50 }).withMessage('slippage_pct must be 0–50'),
   ],
   validate,

--- a/backend/src/services/__mocks__/dex.js
+++ b/backend/src/services/__mocks__/dex.js
@@ -1,4 +1,6 @@
 module.exports = {
+  parseAssetParam: jest.fn(),
+  simulateFill: jest.fn(),
   getOrderbook: jest.fn(),
   executeSwap: jest.fn(),
   getTradeHistory: jest.fn(),

--- a/backend/src/services/dex.js
+++ b/backend/src/services/dex.js
@@ -8,23 +8,123 @@ const server = new StellarSdk.Horizon.Server(
 );
 
 /**
- * Fetch the current DEX orderbook for a selling/buying pair.
- * Returns bids, asks, and a derived mid-price.
+ * Parse an asset parameter that is either:
+ *   "XLM"                  — native
+ *   "CODE"                 — uses env CODE_ISSUER
+ *   "CODE:GISSUER..."      — fully qualified issued asset
+ *
+ * Throws a 400-status error for malformed input.
  */
-async function getOrderbook(sellingAsset, buyingAsset) {
-  const selling = resolveAsset(sellingAsset);
-  const buying = resolveAsset(buyingAsset);
+function parseAssetParam(param) {
+  if (!param || typeof param !== 'string') {
+    throw Object.assign(new Error('Asset parameter is required'), { status: 400 });
+  }
+  const upper = param.trim().toUpperCase();
+  if (upper === 'XLM') return StellarSdk.Asset.native();
+
+  if (upper.includes(':')) {
+    const [code, issuer] = upper.split(':');
+    if (!code || !/^[A-Z0-9]{1,12}$/.test(code)) {
+      throw Object.assign(new Error(`Invalid asset code: ${code}`), { status: 400 });
+    }
+    if (!issuer || !/^G[A-Z2-7]{55}$/.test(issuer)) {
+      throw Object.assign(new Error(`Invalid issuer address: ${issuer}`), { status: 400 });
+    }
+    return new StellarSdk.Asset(code, issuer);
+  }
+
+  // Plain code — fall back to env issuer
+  return resolveAsset(upper);
+}
+
+/**
+ * Simulate filling `amount` of the selling asset against the asks,
+ * returning { estimatedPrice, filledAmount, insufficientLiquidity, maxFillableAmount }.
+ */
+function simulateFill(asks, amount) {
+  let remaining = parseFloat(amount);
+  let totalCost = 0;
+  let maxFillable = 0;
+
+  for (const level of asks) {
+    const levelAmount = parseFloat(level.amount);
+    const levelPrice  = parseFloat(level.price);
+    maxFillable += levelAmount;
+    if (remaining <= 0) break;
+    const filled = Math.min(remaining, levelAmount);
+    totalCost += filled * levelPrice;
+    remaining -= filled;
+  }
+
+  const insufficientLiquidity = remaining > 0;
+  const filledAmount = parseFloat(amount) - remaining;
+  const estimatedPrice = filledAmount > 0 ? totalCost / filledAmount : null;
+
+  return {
+    estimatedPrice: estimatedPrice !== null ? parseFloat(estimatedPrice.toFixed(7)) : null,
+    filledAmount: parseFloat(filledAmount.toFixed(7)),
+    insufficientLiquidity,
+    maxFillableAmount: parseFloat(maxFillable.toFixed(7)),
+  };
+}
+
+/**
+ * Add cumulative totals to a side of the order book.
+ */
+function addCumulative(levels) {
+  let cumAmount = 0;
+  let cumTotal = 0;
+  return levels.map((lvl) => {
+    const amount = parseFloat(lvl.amount);
+    const price  = parseFloat(lvl.price);
+    cumAmount += amount;
+    cumTotal  += amount * price;
+    return {
+      price: lvl.price,
+      amount: lvl.amount,
+      cumulative_amount: parseFloat(cumAmount.toFixed(7)),
+      cumulative_total: parseFloat(cumTotal.toFixed(7)),
+    };
+  });
+}
+
+/**
+ * Fetch the current DEX orderbook for a selling/buying pair.
+ * Returns bids and asks with cumulative depth, mid-price, and optional
+ * estimated execution price for a given input amount.
+ *
+ * @param {string} sellingAsset  e.g. "XLM" | "USDC:GA5Z..."
+ * @param {string} buyingAsset
+ * @param {number} limit         number of levels (default 10)
+ * @param {number|null} amount   input amount for estimated_price simulation
+ */
+async function getOrderbook(sellingAsset, buyingAsset, limit = 10, amount = null) {
+  const selling = parseAssetParam(sellingAsset);
+  const buying  = parseAssetParam(buyingAsset);
 
   const book = await withRetry(
-    () => server.orderbook(selling, buying).limit(10).call(),
+    () => server.orderbook(selling, buying).limit(limit).call(),
     { label: 'orderbook' }
   );
 
+  const bids = addCumulative(book.bids);
+  const asks = addCumulative(book.asks);
+
   const bestAsk = book.asks[0] ? parseFloat(book.asks[0].price) : null;
   const bestBid = book.bids[0] ? parseFloat(book.bids[0].price) : null;
-  const midPrice = bestAsk && bestBid ? (bestAsk + bestBid) / 2 : bestAsk ?? bestBid;
+  const midPrice = bestAsk && bestBid ? parseFloat(((bestAsk + bestBid) / 2).toFixed(7)) : bestAsk ?? bestBid;
 
-  return { bids: book.bids, asks: book.asks, midPrice };
+  const response = { bids, asks, midPrice };
+
+  if (amount !== null && parseFloat(amount) > 0) {
+    const sim = simulateFill(book.asks, amount);
+    response.estimated_price      = sim.estimatedPrice;
+    response.filled_amount        = sim.filledAmount;
+    response.insufficient_liquidity = sim.insufficientLiquidity;
+    response.max_fillable_amount  = sim.maxFillableAmount;
+  }
+
+  return response;
 }
 
 /**
@@ -79,4 +179,4 @@ async function getTradeHistory(publicKey, cursor = null, limit = 50) {
   return result.records || [];
 }
 
-module.exports = { getOrderbook, executeSwap, getTradeHistory };
+module.exports = { parseAssetParam, simulateFill, getOrderbook, executeSwap, getTradeHistory };


### PR DESCRIPTION
Closes #695

Implements `GET /api/dex/orderbook` with cumulative depth, estimated execution price simulation, 5s Redis cache, XLM + issued asset support, and insufficient liquidity detection.

## Changes

**`backend/src/services/dex.js`**
- `parseAssetParam(param)` — parses `XLM`, plain `CODE` (env issuer), or `CODE:GISSUER` format; throws 400 for malformed input
- `simulateFill(asks, amount)` — sweeps order levels to compute weighted average execution price; returns `insufficientLiquidity` and `maxFillableAmount` when depth is insufficient
- `addCumulative(levels)` — annotates each price level with `cumulative_amount` and `cumulative_total`
- `getOrderbook(selling, buying, limit, amount)` — calls Horizon, applies cumulative enrichment, and appends simulation fields when `amount` is provided

**`backend/src/routes/dex.js`**
- Replaced `VALID_ASSETS` regex with `ASSET_PARAM_RE` (`CODE` or `CODE:GISSUER`) across orderbook and swap routes
- Added `limit` (1–200) and `amount` (> 0) query params with express-validator
- Calls `parseAssetParam` early for a clean 400 before any Horizon call
- Redis cache with 5s TTL keyed on `orderbook:selling:buying:limit:amount`

**`backend/src/services/__mocks__/dex.js`** — Added `parseAssetParam` and `simulateFill` jest fns to the manual mock.

## Tests

- **`dexHelpers.test.js`** (13 tests) — pure unit tests for `parseAssetParam` and `simulateFill`: XLM, CODE:ISSUER, plain CODE, null/empty/malformed inputs, fill across levels, exact fill, insufficient liquidity, empty book
- **`dex.test.js`** (27 route tests) — updated orderbook tests now verify limit/amount forwarding, CODE:ISSUER acceptance, cache hit (getOrderbook not called), 5s TTL on cache.set, insufficient_liquidity pass-through, and new 400 validation cases

All 40 tests pass:
```
PASS src/__tests__/dex.test.js
PASS src/__tests__/dexHelpers.test.js
Tests: 40 passed, 40 total
```

Closes #695