### PR TITLE
feat: detailed fee breakdown in payment API responses (#694)

### DIFF
--- a/backend/src/__tests__/feeBreakdown.test.js
+++ b/backend/src/__tests__/feeBreakdown.test.js
@@ -1,0 +1,256 @@
+'use strict';
+
+/**
+ * Tests for:
+ *   - buildFeeBreakdown (via estimateFees endpoint)
+ *   - GET /api/payments/estimate-fees
+ *   - GET /api/payments/:id
+ */
+
+jest.mock('../services/stellar', () => ({
+  sendPayment: jest.fn(),
+  createWallet: jest.fn(),
+  getBalance: jest.fn(),
+  getTransactions: jest.fn(),
+  decryptPrivateKey: jest.fn(),
+  fetchFee: jest.fn(),
+  fetchFeeStats: jest.fn(),
+  sendBatchPayment: jest.fn(),
+  sendPathPayment: jest.fn(),
+  findPaymentPath: jest.fn(),
+  validateBatchRecipient: jest.fn(),
+  findReceivePath: jest.fn(),
+  sendStrictReceivePathPayment: jest.fn(),
+  resolveFederationAddress: jest.fn(),
+}));
+jest.mock('../db');
+jest.mock('../utils/cache', () => ({ get: jest.fn().mockResolvedValue(null), set: jest.fn(), del: jest.fn() }));
+jest.mock('../services/webhook', () => ({ deliver: jest.fn() }));
+jest.mock('../services/fraudDetection', () => ({
+  checkVelocity: jest.fn().mockResolvedValue(false),
+  checkDailyLimit: jest.fn().mockResolvedValue(false),
+  checkFraud: jest.fn().mockResolvedValue({ blocked: false }),
+  logFraudBlock: jest.fn(),
+}));
+jest.mock('../services/loyaltyToken', () => ({ mintPoints: jest.fn() }));
+jest.mock('../services/feeDistributor', () => ({ depositFee: jest.fn() }));
+jest.mock('../services/memoRequired', () => ({ isMemoRequired: jest.fn().mockResolvedValue(false) }));
+jest.mock('../services/email', () => ({ sendTransactionEmail: jest.fn() }));
+jest.mock('../controllers/referralController', () => ({ awardReferralCredit: jest.fn() }));
+
+process.env.JWT_SECRET = 'test-secret';
+process.env.ENCRYPTION_KEY = 'test-encryption-key-32-bytes!!!';
+process.env.STELLAR_NETWORK = 'testnet';
+process.env.PLATFORM_FEE_BPS = '250';
+
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const { fetchFee } = require('../services/stellar');
+const db = require('../db');
+
+const { estimateFees, getPaymentById } = require('../controllers/paymentController');
+
+const app = express();
+app.use(express.json());
+// Inject user directly — avoids JWT secret timing issues in tests
+app.use((req, _res, next) => { req.user = { userId: 'u1' }; next(); });
+app.use('/api/payments', (() => {
+  const r = require('express').Router();
+  r.get('/estimate-fees', estimateFees);
+  r.get('/:id', getPaymentById);
+  return r;
+})());
+app.use((err, req, res, next) => res.status(err.status || 500).json({ error: err.message }));
+
+// Separate app to test actual 401
+const authMiddleware = require('../middleware/auth');
+const appWithAuth = express();
+appWithAuth.use(express.json());
+appWithAuth.use('/api/payments', authMiddleware, (() => {
+  const r = require('express').Router();
+  r.get('/estimate-fees', estimateFees);
+  return r;
+})());
+
+const token = jwt.sign({ userId: 'u1' }, process.env.JWT_SECRET);
+
+beforeEach(() => jest.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// GET /api/payments/estimate-fees
+// ---------------------------------------------------------------------------
+describe('GET /api/payments/estimate-fees', () => {
+  test('returns fee_breakdown for USDC amount', async () => {
+    fetchFee.mockResolvedValue(100);
+
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=100&asset=USDC');
+
+    expect(res.status).toBe(200);
+    const fb = res.body.fee_breakdown;
+    expect(fb.gross_amount_usdc).toBe(100);
+    expect(fb.platform_fee_bps).toBe(250);
+    expect(fb.platform_fee_usdc).toBeCloseTo(2.5, 5);
+    expect(fb.net_amount_usdc).toBeCloseTo(97.5, 5);
+    expect(fb.stellar_base_fee_xlm).toBeCloseTo(0.00001, 7);
+    expect(fb.asset).toBe('USDC');
+  });
+
+  test('stellar_base_fee_xlm is null when fetchFee fails', async () => {
+    fetchFee.mockRejectedValue(new Error('Horizon down'));
+
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=50&asset=XLM');
+
+    expect(res.status).toBe(200);
+    expect(res.body.fee_breakdown.stellar_base_fee_xlm).toBeNull();
+  });
+
+  test('defaults asset to USDC when not provided', async () => {
+    fetchFee.mockResolvedValue(100);
+
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=200');
+
+    expect(res.status).toBe(200);
+    expect(res.body.fee_breakdown.asset).toBe('USDC');
+  });
+
+  test('returns 400 when amount is missing', async () => {
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?asset=USDC');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/amount/i);
+  });
+
+  test('returns 400 when amount is zero', async () => {
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=0&asset=USDC');
+
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 for unsupported asset', async () => {
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=10&asset=FAKE');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/asset/i);
+  });
+
+  test('returns 401 without auth token', async () => {
+    const res = await request(appWithAuth).get('/api/payments/estimate-fees?amount=10');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFeeBreakdown math (platform_fee precision)
+// ---------------------------------------------------------------------------
+describe('fee_breakdown math', () => {
+  test('platform_fee_usdc rounded to 7 decimal places', async () => {
+    fetchFee.mockResolvedValue(100);
+
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=1&asset=USDC')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    // 1 * 250/10000 = 0.025 — check 7dp precision
+    const fee = res.body.fee_breakdown.platform_fee_usdc;
+    expect(fee.toString()).toMatch(/^\d+(\.\d{1,7})?$/);
+    expect(fee).toBe(0.025);
+  });
+
+  test('net_amount_usdc = gross_amount_usdc - platform_fee_usdc', async () => {
+    fetchFee.mockResolvedValue(100);
+
+    const res = await request(app)
+      .get('/api/payments/estimate-fees?amount=400&asset=USDC')
+      .set('Authorization', `Bearer ${token}`);
+
+    const fb = res.body.fee_breakdown;
+    expect(parseFloat((fb.gross_amount_usdc - fb.platform_fee_usdc).toFixed(7))).toBe(fb.net_amount_usdc);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/payments/:id
+// ---------------------------------------------------------------------------
+const TX_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const WALLET = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZC1B0K7I9BYJY8JFP2P4';
+
+const mockTx = {
+  id: TX_ID,
+  sender_wallet: WALLET,
+  recipient_wallet: 'GDZOS5NQWLRGFD7NVJYEBQNBSCQPXLBVS3Z6AZ4XKQKQFABN4FKFPV5',
+  amount: '100.0000000',
+  asset: 'USDC',
+  memo: null,
+  memo_type: null,
+  tx_hash: 'abc123',
+  status: 'completed',
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  ledger_close_time: new Date('2024-01-01T00:00:01Z'),
+  fee_breakdown: {
+    gross_amount_usdc: 100,
+    platform_fee_bps: 250,
+    platform_fee_usdc: 2.5,
+    stellar_base_fee_xlm: 0.00001,
+    net_amount_usdc: 97.5,
+    asset: 'USDC',
+  },
+};
+
+describe('GET /api/payments/:id', () => {
+  test('returns payment with fee_breakdown for sender', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: WALLET }] }) // wallets query
+      .mockResolvedValueOnce({ rows: [mockTx] });                 // transaction query
+
+    const res = await request(app).get(`/api/payments/${TX_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(TX_ID);
+    expect(res.body.direction).toBe('sent');
+    const fb = res.body.fee_breakdown;
+    expect(fb.gross_amount_usdc).toBe(100);
+    expect(fb.platform_fee_usdc).toBe(2.5);
+    expect(fb.net_amount_usdc).toBe(97.5);
+    expect(fb.stellar_base_fee_xlm).toBe(0.00001);
+    expect(fb.platform_fee_bps).toBe(250);
+  });
+
+  test('returns 404 when transaction not found', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: WALLET }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app).get(`/api/payments/${TX_ID}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  test('returns 404 when wallet not found', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app).get(`/api/payments/${TX_ID}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('direction is received for recipient', async () => {
+    const recipientWallet = 'GDZOS5NQWLRGFD7NVJYEBQNBSCQPXLBVS3Z6AZ4XKQKQFABN4FKFPV5';
+    db.query
+      .mockResolvedValueOnce({ rows: [{ public_key: recipientWallet }] })
+      .mockResolvedValueOnce({ rows: [mockTx] });
+
+    const res = await request(app).get(`/api/payments/${TX_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.direction).toBe('received');
+  });
+});

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -37,6 +37,31 @@ function calculateFee(amount) {
   return parseFloat((parseFloat(amount) * FEE_BPS / 10000).toFixed(7));
 }
 
+/**
+ * Build the structured fee breakdown for a payment.
+ * @param {string|number} grossAmount  - Amount the sender sent
+ * @param {string}        asset        - e.g. "USDC" or "XLM"
+ * @param {string|null}   feeCharged   - Stellar fee_charged in stroops (from Horizon result)
+ */
+function buildFeeBreakdown(grossAmount, asset, feeCharged) {
+  const gross = parseFloat(grossAmount);
+  const PLATFORM_FEE_BPS = parseInt(process.env.PLATFORM_FEE_BPS || "250", 10);
+  const platformFee = parseFloat((gross * PLATFORM_FEE_BPS / 10000).toFixed(7));
+  const stellarBaseFeeXlm = feeCharged != null
+    ? parseFloat((parseInt(feeCharged, 10) / 1e7).toFixed(7))
+    : null;
+  const netAmount = parseFloat((gross - platformFee).toFixed(7));
+
+  return {
+    gross_amount_usdc: parseFloat(gross.toFixed(7)),
+    platform_fee_bps: PLATFORM_FEE_BPS,
+    platform_fee_usdc: platformFee,
+    stellar_base_fee_xlm: stellarBaseFeeXlm,
+    net_amount_usdc: parseFloat(netAmount.toFixed(7)),
+    asset,
+  };
+}
+
 // Approximate XLM/USD rate  in production replace with a live price feed
 const XLM_USD_RATE = parseFloat(process.env.XLM_USD_RATE || "0.11");
 
@@ -162,6 +187,29 @@ async function estimateFee(req, res, next) {
   try {
     const fee = await fetchFee();
     res.json({ fee_stroops: fee, fee_xlm: (fee / 1e7).toFixed(7) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/payments/estimate-fees?amount=100&asset=USDC
+ * Returns a pre-submission fee breakdown without processing a payment.
+ */
+async function estimateFees(req, res, next) {
+  try {
+    const { amount, asset = "USDC" } = req.query;
+    if (!amount || isNaN(parseFloat(amount)) || parseFloat(amount) <= 0) {
+      return res.status(400).json({ error: "amount must be a positive number" });
+    }
+    const VALID = ["XLM", "USDC", "NGN", "GHS", "KES"];
+    if (!VALID.includes(asset)) {
+      return res.status(400).json({ error: `asset must be one of: ${VALID.join(", ")}` });
+    }
+    let stellarFeeStroops = null;
+    try { stellarFeeStroops = await fetchFee(); } catch (_) { /* non-fatal */ }
+    const breakdown = buildFeeBreakdown(amount, asset, stellarFeeStroops);
+    res.json({ fee_breakdown: breakdown });
   } catch (err) {
     next(err);
   }
@@ -314,7 +362,7 @@ async function send(req, res, next) {
     await checkSufficientBalance(public_key, amount, asset);
 
     // Broadcast to Stellar
-    const { transactionHash, ledger, type, claimableBalanceId } = await sendPayment({
+    const { transactionHash, ledger, type, claimableBalanceId, feeCharged } = await sendPayment({
       senderPublicKey: public_key,
       encryptedSecretKey: encrypted_secret_key,
       recipientPublicKey: recipient_address,
@@ -327,12 +375,15 @@ async function send(req, res, next) {
 
     const ledger_close_time = await fetchLedgerCloseTime(ledger);
 
+    // Build fee breakdown
+    const fee_breakdown = buildFeeBreakdown(amount, asset, feeCharged ?? null);
+
     // Save to DB
     const txStatus = type === "claimable_balance" ? "pending_claim" : "confirming";
     await db.query(
-      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, claimable_balance_id, request_id, is_encrypted, encrypted_memo, ledger_close_time)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-      [txId, public_key, recipient_address, amount, asset, memo || null, memo_type, transactionHash, txStatus, claimableBalanceId || null, req.requestId, is_encrypted, encrypted_memo, ledger_close_time],
+      `INSERT INTO transactions (id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, claimable_balance_id, request_id, is_encrypted, encrypted_memo, ledger_close_time, fee_breakdown)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+      [txId, public_key, recipient_address, amount, asset, memo || null, memo_type, transactionHash, txStatus, claimableBalanceId || null, req.requestId, is_encrypted, encrypted_memo, ledger_close_time, JSON.stringify(fee_breakdown)],
     );
 
     if (type !== "claimable_balance") {
@@ -391,6 +442,7 @@ async function send(req, res, next) {
         recipient: recipient_address,
         type,
         claimableBalanceId,
+        fee_breakdown,
       },
     });
   } catch (err) {
@@ -626,7 +678,7 @@ async function history(req, res, next) {
     }
     const whereClause = conditions.join(" AND ");
 
-    const listSql = `SELECT id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, created_at, ledger_close_time
+    const listSql = `SELECT id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type, tx_hash, status, created_at, ledger_close_time, fee_breakdown
          FROM transactions
          WHERE ${whereClause}
          ORDER BY id DESC LIMIT $${baseParams.length + 1}`;
@@ -986,4 +1038,36 @@ async function exportCSV(req, res, next) {
   }
 }
 
-module.exports = { send, sendBatch, history, findPath, sendPath, exportCSV, estimateFee, getFeeStats, getFeeRate, findReceivePathHandler, sendStrictReceivePath };
+/**
+ * GET /api/payments/:id
+ * Returns a single payment record for the authenticated user, including fee_breakdown.
+ */
+async function getPaymentById(req, res, next) {
+  try {
+    const walletResult = await db.query(
+      "SELECT public_key FROM wallets WHERE user_id = $1",
+      [req.user.userId],
+    );
+    const publicKeys = walletResult.rows.map((r) => r.public_key);
+    if (publicKeys.length === 0) return res.status(404).json({ error: "Wallet not found" });
+
+    const result = await db.query(
+      `SELECT id, sender_wallet, recipient_wallet, amount, asset, memo, memo_type,
+              tx_hash, status, created_at, ledger_close_time, fee_breakdown
+       FROM transactions
+       WHERE id = $1 AND (sender_wallet = ANY($2) OR recipient_wallet = ANY($2))`,
+      [req.params.id, publicKeys],
+    );
+    if (!result.rows[0]) return res.status(404).json({ error: "Payment not found" });
+
+    const tx = result.rows[0];
+    res.json({
+      ...tx,
+      direction: publicKeys.includes(tx.sender_wallet) ? "sent" : "received",
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { send, sendBatch, history, findPath, sendPath, exportCSV, estimateFee, estimateFees, getFeeStats, getFeeRate, findReceivePathHandler, sendStrictReceivePath, getPaymentById };

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 ﻿const router = require("express").Router();
 const { body, query, validationResult } = require("express-validator");
+const rateLimit = require("express-rate-limit");
 const StellarSdk = require("@stellar/stellar-sdk");
 const authMiddleware = require("../middleware/auth");
 const idempotency = require("../middleware/idempotency");
@@ -13,12 +14,14 @@ const {
   history,
   exportCSV,
   estimateFee,
+  estimateFees,
   getFeeStats,
   getFeeRate,
   findPath,
   sendPath,
   findReceivePathHandler,
   sendStrictReceivePath,
+  getPaymentById,
 } = require("../controllers/paymentController");
 const { buildTransaction, submitSigned } = require("../controllers/ledgerController");
 const { resolveFederationAddress } = require("../services/stellar");
@@ -51,7 +54,17 @@ const validate = (req, res, next) => {
 
 router.use(authMiddleware);
 
+const estimateFeesLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  keyGenerator: (req) => req.user?.userId || req.ip,
+  message: { error: "Too many fee estimation requests. Limit: 60 per minute." },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.get("/estimate-fee", estimateFee);
+router.get("/estimate-fees", estimateFeesLimiter, estimateFees);
 router.get("/fee-stats", getFeeStats);
 router.get("/fee-rate", getFeeRate);
 
@@ -304,5 +317,15 @@ router.post(
 // User-specific analytics (accessible to all authenticated users)
 const { summary: userAnalyticsSummary } = require("../controllers/analyticsController");
 router.get("/analytics", userAnalyticsSummary);
+
+/**
+ * GET /api/payments/:id
+ * Returns a single payment with fee_breakdown.
+ * Must be after all named GET routes.
+ */
+router.get("/:id", [
+  require("express-validator").param("id").isUUID().withMessage("id must be a valid UUID"),
+  validate,
+], getPaymentById);
 
 module.exports = router;

--- a/database/migrations/029_add_fee_breakdown_to_transactions.js
+++ b/database/migrations/029_add_fee_breakdown_to_transactions.js
@@ -1,0 +1,17 @@
+/**
+ * Migration: 029_add_fee_breakdown_to_transactions
+ *
+ * Adds a fee_breakdown JSONB column to transactions for storing structured
+ * fee components: platform_fee_usdc, platform_fee_bps, stellar_base_fee_xlm,
+ * net_amount_usdc, gross_amount_usdc.
+ */
+
+exports.up = (pgm) => {
+  pgm.addColumns('transactions', {
+    fee_breakdown: { type: 'jsonb' },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('transactions', ['fee_breakdown']);
+};


### PR DESCRIPTION
Closes #694

Closes #694.

Adds a structured `fee_breakdown` object to payment API responses so the frontend can render fee previews and compliance reports have auditable fee records.

## Changes

**`paymentController.js`**
- `buildFeeBreakdown(grossAmount, asset, feeCharged)` — computes and returns `{ gross_amount_usdc, platform_fee_usdc, platform_fee_bps, stellar_base_fee_xlm, net_amount_usdc, asset }`. Platform fee is rounded to 7 decimal places (Stellar stroop precision). `stellar_base_fee_xlm` is the actual fee charged on-chain from the Horizon result, or `null` if unavailable.
- `send()` — stores `fee_breakdown` in the `transactions` row and includes it in the response.
- `estimateFees()` — `GET /api/payments/estimate-fees?amount=&asset=` returns a fee breakdown without processing a payment.
- `getPaymentById()` — `GET /api/payments/:id` returns a single transaction scoped to the authenticated user's wallets, including `fee_breakdown`.

**`routes/payments.js`**
- Registers `GET /api/payments/estimate-fees` with a 60 req/min per-user rate limiter.
- Registers `GET /api/payments/:id` (after all named routes to avoid conflicts) with UUID param validation.

**`database/migrations/029_add_fee_breakdown_to_transactions.js`**
- Adds nullable `fee_breakdown JSONB` column to `transactions`. Reversible via `down`.

**`src/__tests__/feeBreakdown.test.js`**
- 13 tests covering: estimate-fees happy path, Horizon failure fallback, input validation (missing/zero amount, unsupported asset), auth guard, fee math precision (`net = gross - platform_fee`), and the `GET /:id` endpoint (sender, recipient, 404 cases).

## Acceptance Criteria

- [x] `POST /api/payments/send` response includes `fee_breakdown` with all required fields
- [x] `GET /api/payments/:id` returns the same `fee_breakdown` structure
- [x] `platform_fee_usdc` computed as `gross * fee_bps / 10000`, rounded to 7dp
- [x] `stellar_base_fee_xlm` is the actual on-chain fee from the transaction result
- [x] `GET /api/payments/estimate-fees` added for pre-submission estimation
- [x] `fee_breakdown` stored in `transactions` via migration 029 (JSONB column)
- [x] Estimate endpoint rate-limited to 60 req/min per user

## Testing

```
npx jest --runInBand --testPathPatterns=feeBreakdown
# 13 tests, all passing
```