### PR TITLE
feat: enhance Soroban contracts — transfer fee, attestation expiry, bulk revocation, two-step arbitrator handoff

### DIFF
--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -32,6 +32,7 @@ const RESOLUTION_DEADLINE_SECS: u64 = 7 * 24 * 60 * 60;
 pub enum DataKey {
     Admin,
     Arbitrator,
+    PendingArbitrator,
     UsdcAddress,
     MaxEvidenceBytes,
     Counter,
@@ -399,13 +400,31 @@ impl DisputeResolutionContract {
             .expect("dispute not found")
     }
 
-    /// Update the arbitrator address. Only admin may call this.
-    pub fn set_arbitrator(env: Env, admin: Address, new_arbitrator: Address) {
+    /// Step 1 of two-step arbitrator handoff. Admin proposes a new arbitrator.
+    /// The proposal is stored but the active arbitrator is unchanged until the
+    /// nominee accepts.
+    pub fn propose_new_arbitrator(env: Env, admin: Address, new_arbitrator: Address) {
         admin.require_auth();
         let stored_admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
             panic!("unauthorized: caller is not admin");
         }
+        env.storage().persistent().set(&DataKey::PendingArbitrator, &new_arbitrator);
+    }
+
+    /// Step 2 of two-step arbitrator handoff. The proposed address accepts and
+    /// becomes the active arbitrator, clearing the pending slot.
+    pub fn accept_arbitrator(env: Env, new_arbitrator: Address) {
+        new_arbitrator.require_auth();
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingArbitrator)
+            .expect("no pending arbitrator");
+        if new_arbitrator != pending {
+            panic!("caller is not the pending arbitrator");
+        }
         env.storage().persistent().set(&DataKey::Arbitrator, &new_arbitrator);
+        env.storage().persistent().remove(&DataKey::PendingArbitrator);
     }
 }

--- a/contracts/kyc-attestation/src/lib.rs
+++ b/contracts/kyc-attestation/src/lib.rs
@@ -36,6 +36,9 @@ pub struct Attestation {
     pub attested_at: u64,
     /// Unix timestamp when the attestation was revoked, or 0 if still active.
     pub revoked_at: u64,
+    /// Unix ledger timestamp after which the attestation is considered expired.
+    /// 0 means the attestation never expires.
+    pub expires_at: u64,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -62,10 +65,12 @@ impl KycAttestationContract {
     /// (non-revoked) attestation.
     ///
     /// # Arguments
-    /// * `admin`    — Must match the admin set during `initialize`.
-    /// * `user`     — Stellar address of the verified user.
-    /// * `kyc_hash` — SHA-256 hash of the KYC document bundle. Never raw PII.
-    pub fn attest(env: Env, admin: Address, user: Address, kyc_hash: Bytes) {
+    /// * `admin`      — Must match the admin set during `initialize`.
+    /// * `user`       — Stellar address of the verified user.
+    /// * `kyc_hash`   — SHA-256 hash of the KYC document bundle. Never raw PII.
+    /// * `expires_at` — Ledger timestamp after which the attestation expires.
+    ///                  Pass 0 for no expiry.
+    pub fn attest(env: Env, admin: Address, user: Address, kyc_hash: Bytes, expires_at: u64) {
         admin.require_auth();
         Self::assert_admin(&env, &admin);
 
@@ -88,6 +93,7 @@ impl KycAttestationContract {
             kyc_hash,
             attested_at: env.ledger().timestamp(),
             revoked_at: 0,
+            expires_at,
         };
         env.storage()
             .persistent()
@@ -131,7 +137,7 @@ impl KycAttestationContract {
         );
     }
 
-    /// Returns `true` if `user` has a current, non-revoked KYC attestation.
+    /// Returns `true` if `user` has a current, non-revoked, non-expired KYC attestation.
     ///
     /// Public — any caller may invoke this.
     ///
@@ -143,8 +149,48 @@ impl KycAttestationContract {
             .persistent()
             .get::<_, Attestation>(&DataKey::Attestation(user))
         {
-            Some(record) => record.revoked_at == 0,
+            Some(record) => {
+                if record.revoked_at != 0 {
+                    return false;
+                }
+                if record.expires_at != 0 && env.ledger().timestamp() > record.expires_at {
+                    return false;
+                }
+                true
+            }
             None => false,
+        }
+    }
+
+    /// Revoke attestations for multiple users atomically.
+    ///
+    /// Only the admin may call this. Skips users with no active attestation
+    /// rather than panicking, to allow partial-valid batches.
+    ///
+    /// # Arguments
+    /// * `admin` — Must match the admin set during `initialize`.
+    /// * `users` — List of Stellar addresses to revoke.
+    pub fn revoke_batch(env: Env, admin: Address, users: soroban_sdk::Vec<Address>) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let now = env.ledger().timestamp();
+        for user in users.iter() {
+            let key = DataKey::Attestation(user.clone());
+            if let Some(mut record) = env
+                .storage()
+                .persistent()
+                .get::<_, Attestation>(&key)
+            {
+                if record.revoked_at == 0 {
+                    record.revoked_at = now;
+                    env.storage().persistent().set(&key, &record);
+                    env.events().publish(
+                        (Symbol::new(&env, "KycRevoked"),),
+                        user,
+                    );
+                }
+            }
         }
     }
 

--- a/contracts/loyalty-token/src/lib.rs
+++ b/contracts/loyalty-token/src/lib.rs
@@ -39,6 +39,7 @@ pub enum DataKey {
     Admin,
     TotalSupply,
     MaxSupply,
+    TransferFeeBps,
     Balance(Address),
     Allowance(Address, Address), // (owner, spender)
 }
@@ -60,18 +61,24 @@ impl LoyaltyTokenContract {
     /// Initialise the contract. Must be called once before any other function.
     ///
     /// # Arguments
-    /// * `admin`      — Address authorised to mint tokens (the AfriPay backend).
-    /// * `max_supply` — Hard ceiling on total points that can ever be minted (must be > 0).
-    pub fn initialize(env: Env, admin: Address, max_supply: i128) {
+    /// * `admin`            — Address authorised to mint tokens (the AfriPay backend).
+    /// * `max_supply`       — Hard ceiling on total points that can ever be minted (must be > 0).
+    /// * `transfer_fee_bps` — Fee taken on peer transfers in basis points (0–10000). Fee is
+    ///                        credited to the admin. Pass 0 to disable fees.
+    pub fn initialize(env: Env, admin: Address, max_supply: i128, transfer_fee_bps: u32) {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("already initialized");
         }
         if max_supply <= 0 {
             panic!("max_supply must be positive");
         }
+        if transfer_fee_bps > 10000 {
+            panic!("transfer_fee_bps must be <= 10000");
+        }
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::TotalSupply, &0i128);
         env.storage().persistent().set(&DataKey::MaxSupply, &max_supply);
+        env.storage().persistent().set(&DataKey::TransferFeeBps, &transfer_fee_bps);
     }
 
     // ── SEP-41: token metadata ────────────────────────────────────────────────
@@ -151,16 +158,36 @@ impl LoyaltyTokenContract {
     // ── SEP-41: transfers ─────────────────────────────────────────────────────
 
     /// Transfer `amount` points from the caller to `to`.
+    /// If a `transfer_fee_bps` was set at initialisation, the fee is deducted
+    /// from the transferred amount and credited to the admin.
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         if amount <= 0 {
             panic!("amount must be positive");
         }
         from.require_auth();
         Self::_debit(&env, &from, amount);
-        Self::_credit(&env, &to, amount);
+
+        let fee_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TransferFeeBps)
+            .unwrap_or(0);
+        let fee = if fee_bps > 0 { amount * fee_bps as i128 / 10000 } else { 0 };
+        let net = amount - fee;
+
+        Self::_credit(&env, &to, net);
+        if fee > 0 {
+            let admin: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Admin)
+                .expect("not initialized");
+            Self::_credit(&env, &admin, fee);
+        }
     }
 
     /// Transfer `amount` points from `from` to `to` using an allowance.
+    /// The fee (if any) is deducted from the transferred amount and credited to admin.
     pub fn transfer_from(
         env: Env,
         spender: Address,
@@ -194,7 +221,24 @@ impl LoyaltyTokenContract {
             });
 
         Self::_debit(&env, &from, amount);
-        Self::_credit(&env, &to, amount);
+
+        let fee_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TransferFeeBps)
+            .unwrap_or(0);
+        let fee = if fee_bps > 0 { amount * fee_bps as i128 / 10000 } else { 0 };
+        let net = amount - fee;
+
+        Self::_credit(&env, &to, net);
+        if fee > 0 {
+            let admin: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Admin)
+                .expect("not initialized");
+            Self::_credit(&env, &admin, fee);
+        }
     }
 
     // ── SEP-41: burn ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary


This PR delivers four improvements across three Soroban smart contracts.

---

### closes #544 — Transfer fee in `loyalty-token`

**File:** `contracts/loyalty-token/src/lib.rs`

- `initialize` now accepts a `transfer_fee_bps: u32` parameter (0–10 000).
- `transfer` and `transfer_from` deduct the fee from the transferred amount and credit it directly to the admin address.
- Passing `0` disables the fee entirely (backward-compatible default behaviour).

---

### closes #542 — Attestation expiry in `kyc-attestation`

**File:** `contracts/kyc-attestation/src/lib.rs`

- Added `expires_at: u64` field to the `Attestation` struct (ledger Unix timestamp; `0` = no expiry).
- `attest` now takes an `expires_at` argument and stores it.
- `is_verified` returns `false` when `expires_at != 0` and `ledger.timestamp() > expires_at`, in addition to the existing revocation check.

---

### closes  #543 — Bulk revocation in `kyc-attestation`

**File:** `contracts/kyc-attestation/src/lib.rs`

- Added `revoke_batch(admin, users: Vec<Address>)` that revokes all supplied attestations in a single transaction.
- Skips users with no active attestation (tolerant of partial-valid lists) rather than panicking.
- Emits a `KycRevoked` event per revoked address, identical to the single-revoke path.

---

### closes #541 — Two-step arbitrator handoff in `dispute-resolution`

**File:** `contracts/dispute-resolution/src/lib.rs`

- Added `PendingArbitrator` storage key.
- Replaced `set_arbitrator` with a two-step flow:
  1. **`propose_new_arbitrator(admin, new_arbitrator)`** — admin records the nominee without activating them.
  2. **`accept_arbitrator(new_arbitrator)`** — nominee signs and is set as the live arbitrator; the pending slot is cleared.
- Prevents accidental lockout: wrong nominee simply cannot call `accept_arbitrator`, so the active arbitrator remains unchanged.

---

## Testing

Existing test suites were not modified. Changes are isolated to contract logic and are verifiable via unit tests targeting the new function signatures.