### PR TITLE
feat(contracts): add insurance fund mechanism to escrow contracts

### DIFF
--- a/contracts/agent-escrow/src/lib.rs
+++ b/contracts/agent-escrow/src/lib.rs
@@ -25,6 +25,8 @@ pub enum DataKey {
     Fees,
     CancelWindow,
     Escrow(u64),
+    InsuranceFund,
+    InsuranceContributionBps,
 }
 
 // ── Domain types ──────────────────────────────────────────────────────────────
@@ -97,6 +99,21 @@ pub struct AdminOverride {
     pub amount: i128,
 }
 
+#[derive(Clone)]
+#[contracttype]
+pub struct InsuranceFundContribution {
+    pub escrow_id: u64,
+    pub amount: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct InsurancePayout {
+    pub escrow_id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -118,6 +135,8 @@ impl AgentEscrowContract {
         env.storage().persistent().set(&DataKey::UsdcAddress, &usdc_address);
         env.storage().persistent().set(&DataKey::CancelWindow, &cancel_window_seconds);
         env.storage().persistent().set(&DataKey::Counter, &0u64);
+        env.storage().persistent().set(&DataKey::InsuranceFund, &0i128);
+        env.storage().persistent().set(&DataKey::InsuranceContributionBps, &500u32); // 5% default
     }
 
     /// Lock USDC in escrow pending agent payout confirmation.
@@ -202,6 +221,7 @@ impl AgentEscrowContract {
     /// Agent confirms off-chain fiat delivery, releasing USDC from escrow.
     ///
     /// Transfers `(amount - fee)` to the agent and accumulates the fee.
+    /// A portion of the fee is contributed to the insurance fund.
     /// Only the designated agent may call this function.
     ///
     /// # Arguments
@@ -238,6 +258,26 @@ impl AgentEscrowContract {
             &agent_amount,
         );
 
+        // Calculate insurance contribution
+        let contribution_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InsuranceContributionBps)
+            .unwrap_or(500);
+        let insurance_contribution = (fee_amount * contribution_bps as i128) / 10_000;
+        let fee_to_distribute = fee_amount - insurance_contribution;
+
+        // Add to insurance fund
+        let insurance_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InsuranceFund, &(insurance_balance + insurance_contribution));
+
+        // Add remaining fee to distributable fees
         let fees: i128 = env
             .storage()
             .persistent()
@@ -245,7 +285,7 @@ impl AgentEscrowContract {
             .unwrap_or(0);
         env.storage()
             .persistent()
-            .set(&DataKey::Fees, &(fees + fee_amount));
+            .set(&DataKey::Fees, &(fees + fee_to_distribute));
 
         escrow.status = EscrowStatus::Completed;
         env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
@@ -253,6 +293,14 @@ impl AgentEscrowContract {
         env.events().publish(
             (Symbol::new(&env, "PayoutConfirmed"),),
             EvtCompleted { escrow_id, agent_amount, fee_amount },
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "InsuranceFundContribution"),),
+            InsuranceFundContribution {
+                escrow_id,
+                amount: insurance_contribution,
+            },
         );
     }
 
@@ -456,5 +504,96 @@ impl AgentEscrowContract {
                 amount: escrow.amount,
             },
         );
+    }
+
+    /// Return the current insurance fund balance.
+    pub fn get_insurance_balance(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0)
+    }
+
+    /// Admin-only function to payout from the insurance fund to a defrauded recipient.
+    ///
+    /// # Arguments
+    /// * `escrow_id` — ID of the escrow that was fraudulent.
+    /// * `recipient` — Address to receive the insurance payout.
+    pub fn insurance_payout(env: Env, escrow_id: u64, recipient: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap();
+        admin.require_auth();
+
+        let escrow: AgentEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("escrow not found");
+
+        let insurance_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InsuranceFund)
+            .unwrap_or(0);
+
+        // Pay up to the original escrow amount or available balance
+        let payout_amount = if escrow.amount <= insurance_balance {
+            escrow.amount
+        } else {
+            insurance_balance
+        };
+
+        if payout_amount == 0 {
+            panic!("insufficient insurance fund balance");
+        }
+
+        let usdc: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UsdcAddress)
+            .unwrap();
+
+        token::Client::new(&env, &usdc).transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &payout_amount,
+        );
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::InsuranceFund, &(insurance_balance - payout_amount));
+
+        env.events().publish(
+            (Symbol::new(&env, "InsurancePayout"),),
+            InsurancePayout {
+                escrow_id,
+                recipient,
+                amount: payout_amount,
+            },
+        );
+    }
+
+    /// Update the insurance contribution rate. Admin-only.
+    ///
+    /// # Arguments
+    /// * `new_bps` — New contribution rate in basis points (max 1000 = 10%).
+    pub fn update_insurance_contribution_bps(env: Env, new_bps: u32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap();
+        admin.require_auth();
+
+        if new_bps > 1000 {
+            panic!("contribution rate cannot exceed 1000 bps (10%)");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::InsuranceContributionBps, &new_bps);
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -52,6 +52,24 @@ pub struct EscrowExpired {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct EscrowBatchCreated {
+    pub batch_size: u32,
+    pub first_escrow_id: u64,
+    pub last_escrow_id: u64,
+    pub total_amount: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowParams {
+    pub recipient: Address,
+    pub agent: Address,
+    pub amount: i128,
+    pub release_fee_bps: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub struct DeliveryConfirmed {
     pub escrow_id: u64,
     pub agent: Address,
@@ -771,5 +789,129 @@ impl EscrowContract {
             .get(&DataKey::UsdcAddress)
             .expect("Contract not initialized");
         (admin, usdc_address)
+    }
+
+    /// Batch create multiple escrows in a single transaction.
+    ///
+    /// # Arguments
+    /// * `sender`  — Payer; must authorise this call.
+    /// * `escrows` — Vector of escrow parameters (max 20).
+    ///
+    /// # Returns
+    /// First escrow ID created.
+    ///
+    /// # Panics
+    /// * If batch size exceeds 20
+    /// * If any escrow has invalid parameters
+    /// * If sender doesn't have sufficient USDC for total amount
+    pub fn batch_create_escrow(
+        env: Env,
+        sender: Address,
+        escrows: soroban_sdk::Vec<EscrowParams>,
+    ) -> u64 {
+        sender.require_auth();
+
+        let batch_size = escrows.len();
+        if batch_size > 20 {
+            panic!("Batch size exceeds maximum of 20");
+        }
+        if batch_size == 0 {
+            panic!("Batch cannot be empty");
+        }
+
+        // Validate all escrows before creating any
+        let mut total_amount: i128 = 0;
+        for escrow_params in escrows.iter() {
+            if escrow_params.amount < MIN_ESCROW_AMOUNT {
+                panic!("Amount below minimum (100 stroops)");
+            }
+            if escrow_params.release_fee_bps == 10000 {
+                panic!("Fee cannot be 100%");
+            }
+            if escrow_params.release_fee_bps > MAX_FEE_BPS {
+                panic!("Fee exceeds maximum of 5000 bps (50%)");
+            }
+            if sender == escrow_params.recipient
+                || sender == escrow_params.agent
+                || escrow_params.recipient == escrow_params.agent
+            {
+                panic!("Sender, recipient, and agent must be distinct addresses");
+            }
+            total_amount += escrow_params.amount;
+        }
+
+        // Transfer total USDC once
+        let usdc_address: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UsdcAddress)
+            .expect("Contract not initialized");
+
+        token::Client::new(&env, &usdc_address).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &total_amount,
+        );
+
+        // Create all escrows
+        let mut current_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowCounter)
+            .unwrap_or(0);
+
+        let first_id = current_id + 1;
+        let now = env.ledger().timestamp();
+
+        for escrow_params in escrows.iter() {
+            let next_id = current_id.checked_add(1).expect("Escrow counter overflow");
+            current_id = next_id;
+
+            let escrow = Escrow {
+                id: next_id,
+                sender: sender.clone(),
+                recipient: escrow_params.recipient.clone(),
+                agent: escrow_params.agent.clone(),
+                amount: escrow_params.amount,
+                release_fee_bps: escrow_params.release_fee_bps,
+                status: EscrowStatus::Pending,
+                payout_confirmed: false,
+                created_at: now,
+                updated_at: now,
+                expires_at: now + DEFAULT_EXPIRY_SECS,
+            };
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(next_id), &escrow);
+
+            env.events().publish(
+                (Symbol::new(&env, "EscrowCreated"),),
+                EscrowCreated {
+                    escrow_id: next_id,
+                    sender: sender.clone(),
+                    recipient: escrow_params.recipient.clone(),
+                    agent: escrow_params.agent.clone(),
+                    amount: escrow_params.amount,
+                    release_fee_bps: escrow_params.release_fee_bps,
+                },
+            );
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowCounter, &current_id);
+
+        env.events().publish(
+            (Symbol::new(&env, "EscrowBatchCreated"),),
+            EscrowBatchCreated {
+                batch_size: batch_size as u32,
+                first_escrow_id: first_id,
+                last_escrow_id: current_id,
+                total_amount,
+            },
+        );
+
+        first_id
     }
 }

--- a/contracts/fee-distributor/src/lib.rs
+++ b/contracts/fee-distributor/src/lib.rs
@@ -21,6 +21,7 @@ pub enum DataKey {
     Admin,
     UsdcAddress,
     AccumulatedFees,
+    PlatformFeeBps,
 }
 
 // ── Event payloads ────────────────────────────────────────────────────────────
@@ -43,6 +44,14 @@ pub struct EvtFeesWithdrawn {
     pub timestamp: u64,
 }
 
+#[derive(Clone)]
+#[contracttype]
+pub struct FeeRateUpdated {
+    pub old_bps: u32,
+    pub new_bps: u32,
+    pub updated_by: Address,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -53,15 +62,20 @@ impl FeeDistributorContract {
     /// Initialise the contract. Must be called once.
     ///
     /// # Arguments
-    /// * `admin`        — Address authorised to withdraw accumulated fees.
-    /// * `usdc_address` — Stellar asset contract address for USDC.
-    pub fn initialize(env: Env, admin: Address, usdc_address: Address) {
+    /// * `admin`            — Address authorised to withdraw accumulated fees.
+    /// * `usdc_address`     — Stellar asset contract address for USDC.
+    /// * `platform_fee_bps` — Platform fee rate in basis points (max 1000 = 10%).
+    pub fn initialize(env: Env, admin: Address, usdc_address: Address, platform_fee_bps: u32) {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("already initialized");
+        }
+        if platform_fee_bps > 1000 {
+            panic!("platform fee cannot exceed 1000 bps (10%)");
         }
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::UsdcAddress, &usdc_address);
         env.storage().persistent().set(&DataKey::AccumulatedFees, &0i128);
+        env.storage().persistent().set(&DataKey::PlatformFeeBps, &platform_fee_bps);
     }
 
     /// Deposit a platform fee into the contract.
@@ -168,6 +182,50 @@ impl FeeDistributorContract {
         env.events().publish(
             (Symbol::new(&env, "FeesWithdrawn"),),
             EvtFeesWithdrawn { admin, amount, remaining, timestamp: env.ledger().timestamp() },
+        );
+    }
+
+    /// Return the current platform fee rate in basis points.
+    pub fn get_fee_rate(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PlatformFeeBps)
+            .expect("not initialized")
+    }
+
+    /// Update the platform fee rate. Admin-only.
+    ///
+    /// # Arguments
+    /// * `new_bps` — New fee rate in basis points (max 1000 = 10%).
+    pub fn update_fee_rate(env: Env, new_bps: u32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        if new_bps > 1000 {
+            panic!("fee rate cannot exceed 1000 bps (10%)");
+        }
+
+        let old_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PlatformFeeBps)
+            .unwrap_or(0);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlatformFeeBps, &new_bps);
+
+        env.events().publish(
+            (Symbol::new(&env, "FeeRateUpdated"),),
+            FeeRateUpdated {
+                old_bps,
+                new_bps,
+                updated_by: admin,
+            },
         );
     }
 }

--- a/contracts/loyalty-token/src/lib.rs
+++ b/contracts/loyalty-token/src/lib.rs
@@ -42,6 +42,7 @@ pub enum DataKey {
     TransferFeeBps,
     Balance(Address),
     Allowance(Address, Address), // (owner, spender)
+    KycContractAddress,
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -160,11 +161,16 @@ impl LoyaltyTokenContract {
     /// Transfer `amount` points from the caller to `to`.
     /// If a `transfer_fee_bps` was set at initialisation, the fee is deducted
     /// from the transferred amount and credited to the admin.
+    /// Both sender and recipient must be KYC-verified if KYC contract is set.
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         if amount <= 0 {
             panic!("amount must be positive");
         }
         from.require_auth();
+
+        // KYC check if contract address is set
+        Self::_check_kyc_for_transfer(&env, &from, &to);
+
         Self::_debit(&env, &from, amount);
 
         let fee_bps: u32 = env
@@ -188,6 +194,7 @@ impl LoyaltyTokenContract {
 
     /// Transfer `amount` points from `from` to `to` using an allowance.
     /// The fee (if any) is deducted from the transferred amount and credited to admin.
+    /// Both sender and recipient must be KYC-verified if KYC contract is set.
     pub fn transfer_from(
         env: Env,
         spender: Address,
@@ -199,6 +206,9 @@ impl LoyaltyTokenContract {
             panic!("amount must be positive");
         }
         spender.require_auth();
+
+        // KYC check if contract address is set
+        Self::_check_kyc_for_transfer(&env, &from, &to);
 
         let entry: AllowanceValue = env
             .storage()
@@ -411,5 +421,62 @@ impl LoyaltyTokenContract {
         env.storage()
             .persistent()
             .set(&DataKey::Balance(from.clone()), &(bal - amount));
+    }
+
+    fn _check_kyc_for_transfer(env: &Env, from: &Address, to: &Address) {
+        // If KYC contract is not set, skip checks
+        let kyc_contract: Option<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::KycContractAddress);
+
+        if let Some(kyc_addr) = kyc_contract {
+            // Cross-contract call to kyc-attestation contract
+            let kyc_client = env.invoke_contract::<bool>(
+                &kyc_addr,
+                &Symbol::new(env, "is_verified"),
+                soroban_sdk::vec![env, from.clone().into_val(env)].into(),
+            );
+
+            if !kyc_client {
+                panic!("Transfer requires KYC verification");
+            }
+
+            let kyc_client_to = env.invoke_contract::<bool>(
+                &kyc_addr,
+                &Symbol::new(env, "is_verified"),
+                soroban_sdk::vec![env, to.clone().into_val(env)].into(),
+            );
+
+            if !kyc_client_to {
+                panic!("Transfer requires KYC verification");
+            }
+        }
+    }
+
+    // ── Admin functions ───────────────────────────────────────────────────────
+
+    /// Set the KYC attestation contract address. Admin-only.
+    ///
+    /// # Arguments
+    /// * `kyc_contract_address` — Address of the kyc-attestation contract.
+    pub fn set_kyc_contract(env: Env, kyc_contract_address: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::KycContractAddress, &kyc_contract_address);
+    }
+
+    /// Get the current KYC contract address (if set).
+    pub fn get_kyc_contract(env: Env) -> Option<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::KycContractAddress)
     }
 }


### PR DESCRIPTION
feat: contract enhancements - batch escrow, insurance fund, fee rate storage, kyc transfers

Changes:

Escrow Contract (#752):
- Added batch_create_escrow for up to 20 escrows in single tx
- EscrowParams struct: recipient, agent, amount, release_fee_bps
- Single USDC transfer for total amount
- Atomic validation - all-or-nothing
- EscrowBatchCreated event

Agent-Escrow Contract (#753):
- Insurance fund with 5% default contribution from fees
- insurance_payout for admin compensation to fraud victims
- get_insurance_balance view function
- update_insurance_contribution_bps (max 10%)
- InsuranceFundContribution, InsurancePayout events

Fee-Distributor Contract (#754):
- PlatformFeeBps storage for on-chain fee rate
- initialize now requires platform_fee_bps param
- get_fee_rate public view
- update_fee_rate admin function (max 1000 bps)
- FeeRateUpdated event

Loyalty-Token Contract (#755):
- KYC-gated transfer and transfer_from via cross-contract call
- set_kyc_contract, get_kyc_contract functions
- mint/burn/redeem exempt from KYC
- KYC disabled if contract not set

Closes #752
Closes #753
Closes #754
Closes #755
