### PR TITLE
Fix/four UI improvements

### DIFF
--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, TrendingUp, Download, FileText, Loader2 } from 'lucide-react';
 import api from '../utils/api';
 import { useAuth } from '../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import { tokenStore } from '../context/AuthContext';
+
 
 function toDateInput(d) {
   return d.toISOString().slice(0, 10);
@@ -28,20 +28,34 @@ export default function Analytics() {
   const [loading, setLoading] = useState(true);
   const [csvLoading, setCsvLoading] = useState(false);
   const [pdfLoading, setPdfLoading] = useState(false);
+  const abortRef = useRef(null);
 
   const fetchAnalytics = useCallback(async () => {
+    // Cancel any in-flight request to prevent stale responses overwriting newer ones
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     setLoading(true);
     try {
-      const res = await api.get(`/payments/analytics?from=${range.from}&to=${range.to}`);
+      const res = await api.get(`/payments/analytics?from=${range.from}&to=${range.to}`, {
+        signal: controller.signal,
+      });
       setData(res.data);
-    } catch {
+    } catch (err) {
+      if (err?.name === 'CanceledError' || err?.code === 'ERR_CANCELED') return;
       toast.error(t('analytics.error') || 'Failed to load analytics');
     } finally {
       setLoading(false);
     }
   }, [range.from, range.to, t]);
 
-  useEffect(() => { fetchAnalytics(); }, [fetchAnalytics]);
+  useEffect(() => {
+    fetchAnalytics();
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [fetchAnalytics]);
 
   const totalSpent = data?.asset_breakdown?.reduce((sum, item) => sum + parseFloat(item.total || 0), 0) || 0;
   const totalTransactions = data?.asset_breakdown?.reduce((sum, item) => sum + item.count, 0) || 0;

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -65,14 +65,11 @@ export default function Analytics() {
     if (noData) return;
     setCsvLoading(true);
     try {
-      const token = tokenStore.get();
-      const baseURL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
-      const url = `${baseURL}/payments/export?format=csv&from=${range.from}&to=${range.to}`;
-      const resp = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
+      const res = await api.get('/payments/export', {
+        params: { format: 'csv', from: range.from, to: range.to },
+        responseType: 'blob',
       });
-      if (!resp.ok) throw new Error('Export failed');
-      const blob = await resp.blob();
+      const blob = new Blob([res.data], { type: 'text/csv' });
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);
       a.download = `transactions_${range.from}_to_${range.to}.csv`;

--- a/frontend/src/pages/BusinessSettings.jsx
+++ b/frontend/src/pages/BusinessSettings.jsx
@@ -77,10 +77,26 @@ export default function BusinessSettings() {
 
   const handleAddSigner = async (e) => {
     e.preventDefault();
+
+    // Validate Stellar public key format before submitting
+    const key = newKey.trim();
+    if (!key.startsWith('G')) {
+      toast.error('Invalid Stellar address — must start with "G"');
+      return;
+    }
+    if (key.length !== 56) {
+      toast.error(`Invalid Stellar address — must be 56 characters (got ${key.length})`);
+      return;
+    }
+    if (!/^[A-Z0-9]+$/.test(key)) {
+      toast.error('Invalid Stellar address — contains invalid characters');
+      return;
+    }
+
     setAdding(true);
     try {
-      const res = await api.post('/wallet/signers', { signer_public_key: newKey.trim(), label: newLabel.trim() || undefined });
-      setSigners(prev => [...prev, { signer_public_key: newKey.trim(), label: newLabel.trim() || null, added_at: new Date().toISOString() }]);
+      const res = await api.post('/wallet/signers', { signer_public_key: key, label: newLabel.trim() || undefined });
+      setSigners(prev => [...prev, { signer_public_key: key, label: newLabel.trim() || null, added_at: new Date().toISOString() }]);
       setNewKey('');
       setNewLabel('');
       toast.success('Signer added');

--- a/frontend/src/pages/BusinessSettings.jsx
+++ b/frontend/src/pages/BusinessSettings.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Plus, Trash2, ShieldCheck, Building2, Webhook, RefreshCw, Eye, EyeOff } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, ShieldCheck, Building2, Webhook, RefreshCw, Eye, EyeOff, Copy, CheckCheck } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import api from '../utils/api';
 import { truncateAddress } from '../utils/currency';
@@ -20,6 +20,8 @@ export default function BusinessSettings() {
   const [webhooksLoading, setWebhooksLoading] = useState(true);
   const [rotating, setRotating] = useState(null);
   const [rotateConfirm, setRotateConfirm] = useState(null);
+  const [revealedSecret, setRevealedSecret] = useState(null);
+  const [copiedSecret, setCopiedSecret] = useState(null);
 
   const isBusiness = user?.account_type === 'business';
 
@@ -42,6 +44,8 @@ export default function BusinessSettings() {
     try {
       const { data } = await api.post(`/webhooks/${webhookId}/rotate-secret`);
       setWebhooks(prev => prev.map(w => w.id === webhookId ? { ...w, secret: data.secret } : w));
+      // Auto-reveal the new secret so the user can copy it before it's masked
+      setRevealedSecret(webhookId);
       toast.success('Secret rotated successfully');
     } catch (err) {
       toast.error(err.response?.data?.error || 'Failed to rotate secret');
@@ -49,6 +53,12 @@ export default function BusinessSettings() {
       setRotating(null);
       setRotateConfirm(null);
     }
+  };
+
+  const copyWebhookSecret = (id, secret) => {
+    navigator.clipboard.writeText(secret);
+    setCopiedSecret(id);
+    setTimeout(() => setCopiedSecret(null), 2000);
   };
 
   const handleUpgrade = async () => {
@@ -242,8 +252,22 @@ export default function BusinessSettings() {
                   <div className="bg-gray-700/50 rounded-lg px-3 py-2 flex items-center gap-2">
                     <span className="text-xs text-gray-400 shrink-0">Secret:</span>
                     <span className="text-xs font-mono text-yellow-400 flex-1 truncate">
-                      ••••••••••••••••
+                      {revealedSecret === wh.id ? wh.secret : '••••••••••••••••'}
                     </span>
+                    <button
+                      onClick={() => setRevealedSecret(revealedSecret === wh.id ? null : wh.id)}
+                      className="text-gray-500 hover:text-gray-300 shrink-0"
+                      aria-label={revealedSecret === wh.id ? 'Hide secret' : 'Reveal secret'}
+                    >
+                      {revealedSecret === wh.id ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </button>
+                    <button
+                      onClick={() => copyWebhookSecret(wh.id, wh.secret)}
+                      className="text-gray-500 hover:text-gray-300 shrink-0"
+                      aria-label="Copy secret"
+                    >
+                      {copiedSecret === wh.id ? <CheckCheck size={14} className="text-green-400" /> : <Copy size={14} />}
+                    </button>
                   </div>
                 )}
 


### PR DESCRIPTION
Closes #830 
Closes #831
Closes #832
Closes #833


handleRotateSecret stores the freshly-rotated plaintext secret into webhooks[i].secret via setWebhooks (line 44), but the render for the secret field (lines 241-247) unconditionally shows masking dots whenever wh.secret is truthy — there is no reveal/eye-toggle like the one implemented on the main Webhooks.jsx page, so the new secret is masked immediately and never shown.

The 'Add Signer' form only marks the public-key input as required (line 178); unlike BatchPayment.jsx's validateStellarAddress helper, there is no check that the value starts with 'G' and is 56 base32 characters before calling POST /wallet/signers.