### PR TITLE
fix: add Stellar address validation to escrow creation and populate AuthContext on TOTP login

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -65,7 +65,7 @@ export function AuthProvider({ children }) {
     Sentry.setUser(null);
   };
 
-  const updateUser = (fields) => setUser((prev) => (prev ? { ...prev, ...fields } : prev));
+  const updateUser = (fields) => setUser((prev) => (prev ? { ...prev, ...fields } : fields));
 
   return (
     <AuthContext.Provider value={{ user, loading, login, register, logout, updateUser }}>

--- a/frontend/src/pages/Escrow.jsx
+++ b/frontend/src/pages/Escrow.jsx
@@ -65,6 +65,27 @@ export default function Escrow() {
       return;
     }
 
+    // Validate Stellar address format (56 chars, starts with 'G')
+    const validateWallet = (addr, label) => {
+      const trimmed = addr.trim();
+      if (!trimmed.startsWith('G')) {
+        toast.error(`${label} must be a valid Stellar address (starts with G)`);
+        return false;
+      }
+      if (trimmed.length !== 56) {
+        toast.error(`${label} must be 56 characters (got ${trimmed.length})`);
+        return false;
+      }
+      if (!/^[A-Z0-9]+$/.test(trimmed)) {
+        toast.error(`${label} contains invalid characters`);
+        return false;
+      }
+      return true;
+    };
+
+    if (!validateWallet(createForm.agent_wallet, 'Agent wallet')) return;
+    if (!validateWallet(createForm.recipient_wallet, 'Recipient wallet')) return;
+
     setLoading(true);
     try {
       const { data } = await api.post('/escrow/create', createForm);

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import api from '../utils/api';
 
 export default function Login() {
-  const { login } = useAuth();
+  const { login, updateUser } = useAuth();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
@@ -115,7 +115,16 @@ export default function Login() {
         // Manually set token + user via the same path login() uses
         const { tokenStore } = await import('../context/AuthContext');
         tokenStore.set(res.data.token);
-        // Reload user via /auth/me so AuthContext is populated
+        // Populate AuthContext user from the login response (same as login() does)
+        updateUser(res.data.user);
+        // Set Sentry user context for error tracking
+        const { default: Sentry } = await import('@sentry/react');
+        Sentry.setUser({
+          id: res.data.user.id,
+          wallet: res.data.user.wallet_address
+            ? `${res.data.user.wallet_address.slice(0, 4)}...${res.data.user.wallet_address.slice(-4)}`
+            : undefined,
+        });
         navigate('/dashboard');
       } catch (err) {
         toast.error(err.response?.data?.error || t('login.totp_error', 'Invalid code. Try again.'));


### PR DESCRIPTION
Closes #836
Closes #837

## Summary

Fixes two bugs:

### Bug 1: Escrow creation missing Stellar address validation
**File:** `frontend/src/pages/Escrow.jsx`

`handleCreateEscrow` previously only checked that `agent_wallet`/`recipient_wallet`/`amount` were non-empty before posting to `/escrow/create`. Added inline validation that checks:
- Address starts with `G`
- Address is exactly 56 characters
- Address contains only uppercase letters and digits

This matches the existing `validateStellarAddress` function in `BatchPayment.jsx`.

### Bug 2: TOTP login not populating AuthContext user
**Files:** `frontend/src/context/AuthContext.jsx`, `frontend/src/pages/Login.jsx`

`handleTotpChange` previously set the token via `tokenStore.set(res.data.token)` and navigated straight to `/dashboard` without populating the AuthContext user object, unlike the normal `login()` path.

- **AuthContext.jsx**: Fixed `updateUser` to initialize user when `prev` is null (was returning null before, making it impossible to set an initial user).
- **Login.jsx**: `handleTotpChange` now calls `updateUser(res.data.user)` and `Sentry.setUser(...)` after TOTP login, matching the normal `login()` flow.

## Files Changed
- `frontend/src/context/AuthContext.jsx` — 1 line
- `frontend/src/pages/Escrow.jsx` — +20 lines
- `frontend/src/pages/Login.jsx` — +13 lines
