### PR TITLE
fix(escrow): dynamic fee BPS + Full Release confirmation

### DIFF
--- a/frontend/src/pages/Escrow.jsx
+++ b/frontend/src/pages/Escrow.jsx
@@ -25,7 +25,7 @@ export default function Escrow() {
   const [partialAmount, setPartialAmount] = useState('');
   const [partialLoading, setPartialLoading] = useState(false);
 
-  const FEE_BPS = 250; // platform fee fallback (2.5%)
+  const feeBps = partialEscrow?.fee_bps ?? 250; // platform fee from escrow, fallback 2.5%
 
   const remainingBalance = (escrow) =>
     parseFloat(escrow.amount) - parseFloat(escrow.released_amount || 0);
@@ -79,7 +79,12 @@ export default function Escrow() {
     }
   };
 
-  const handleConfirmEscrow = async (escrowId) => {
+  const handleConfirmEscrow = async (escrowId, escrow) => {
+    const remaining = remainingBalance(escrow);
+    if (!window.confirm(
+      `Are you sure you want to fully release the remaining ${remaining} ${escrow.asset}? This action cannot be undone.`
+    )) return;
+
     setLoading(true);
     try {
       await api.post(`/escrow/${escrowId}/confirm`);
@@ -146,7 +151,7 @@ export default function Escrow() {
   };
 
   const previewAmount = parseFloat(partialAmount) || 0;
-  const previewFee = (previewAmount * FEE_BPS) / 10000;
+  const previewFee = (previewAmount * feeBps) / 10000;
   const previewNet = previewAmount - previewFee;
   const partialError =
     partialEscrow && previewAmount > 0 && previewAmount > remainingBalance(partialEscrow)
@@ -310,7 +315,7 @@ export default function Escrow() {
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              handleConfirmEscrow(escrow.id);
+                              handleConfirmEscrow(escrow.id, escrow);
                             }}
                             disabled={loading}
                             className="flex-1 min-w-[120px] bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white font-medium py-2 rounded-lg transition-colors"
@@ -384,7 +389,7 @@ export default function Escrow() {
                   <span className="text-gray-900 dark:text-white">{previewAmount.toFixed(7)} {partialEscrow.asset}</span>
                 </div>
                 <div className="flex justify-between text-gray-600 dark:text-gray-400">
-                  <span>Platform fee ({(FEE_BPS / 100).toFixed(2)}%)</span>
+                  <span>Platform fee ({(feeBps / 100).toFixed(2)}%)</span>
                   <span className="text-red-500">-{previewFee.toFixed(7)} {partialEscrow.asset}</span>
                 </div>
                 <div className="flex justify-between font-medium border-t border-gray-200 dark:border-gray-700 pt-1 mt-1">


### PR DESCRIPTION
Closes #834
Closes #835


## Summary

Fixes two bugs in the Agent Escrow page:

### 1. Hardcoded fee BPS diverges from backend

**Before:** `const FEE_BPS = 250;` was a hardcoded constant that could diverge from the actual fee the backend applies when processing `/contracts/escrow/:id/partial-release`.

**After:** Uses `partialEscrow?.fee_bps ?? 250` — reads the actual `fee_bps` stored on the escrow record, which is what the backend's `partialRelease` handler uses (`escrow.fee_bps || DEFAULT_FEE_BPS`). Uses nullish coalescing (`??`) so a legitimate `fee_bps: 0` is not overridden.

### 2. Full Release has no confirmation step

**Before:** 'Full Release' called `handleConfirmEscrow` directly on click — one accidental click releases the entire escrowed balance.

**After:** Shows a `window.confirm` prompt displaying the remaining balance and asset before proceeding. Consistent with:
- Cancel (already has `window.confirm`)
- Partial Release (has a full review modal with fee/net breakdown)

## Changes

- `frontend/src/pages/Escrow.jsx` — 1 file, +10 / −5 lines
