### PR TITLE
fix(idempotency): reject replayed Idempotency-Key with different request body (#901)

### DIFF
--- a/backend/src/__tests__/idempotency.test.js
+++ b/backend/src/__tests__/idempotency.test.js
@@ -1,26 +1,47 @@
+const crypto = require('crypto');
 const idempotency = require('../middleware/idempotency');
 const db = require('../db');
+const cache = require('../utils/cache');
 
 jest.mock('../db');
+jest.mock('../utils/cache');
 
-function makeReq({ key, body = { amount: 10, recipient_address: 'GABC' }, userId = 'user-1' } = {}) {
+// Valid UUID v4 for use in tests
+const VALID_KEY = '123e4567-e89b-4d3c-a456-426614174000';
+
+function makeReq({ key = VALID_KEY, body = { amount: 10, recipient_address: 'GABC' }, userId = 'user-1' } = {}) {
   return {
     headers: { 'idempotency-key': key },
     body,
-    user: { userId }
+    user: { userId },
+    path: '/api/payments/send',
+    method: 'POST',
   };
 }
 
 function makeRes() {
+  const jsonSpy = jest.fn();
   const res = {
     statusCode: 200,
+    _jsonSpy: jsonSpy,
     status(code) { this.statusCode = code; return this; },
-    json: jest.fn()
+    // The middleware replaces res.json, so we expose the original spy separately
+    json: jsonSpy,
+    set: jest.fn(),
+    on: jest.fn(),
   };
   return res;
 }
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: no in-flight marker, no Redis cache hit
+  cache.get.mockResolvedValue(null);
+  cache.set.mockResolvedValue(undefined);
+  cache.del.mockResolvedValue(undefined);
+  // Default: no DB hit
+  db.query.mockResolvedValue({ rows: [] });
+});
 
 describe('idempotency middleware', () => {
   test('passes through when no Idempotency-Key header is present', async () => {
@@ -28,77 +49,143 @@ describe('idempotency middleware', () => {
     const res = makeRes();
     const next = jest.fn();
 
-    db.query.mockResolvedValue({ rows: [] });
     await idempotency(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(res.json).not.toHaveBeenCalled();
+    // No response sent directly
+    expect(res._jsonSpy).not.toHaveBeenCalled();
   });
 
-  test('returns 400 when key exceeds 255 characters', async () => {
-    const req = makeReq({ key: 'a'.repeat(256) });
+  test('returns 400 for an invalid (non-UUID v4) Idempotency-Key', async () => {
+    const req = makeReq({ key: 'not-a-uuid' });
     const res = makeRes();
     const next = jest.fn();
 
     await idempotency(req, res, next);
 
-    expect(res.status).toBeDefined();
     expect(next).not.toHaveBeenCalled();
+    expect(res._jsonSpy).toHaveBeenCalledWith({ error: 'Invalid Idempotency-Key format' });
   });
 
-  test('replays cached response for duplicate key with same body', async () => {
-    const crypto = require('crypto');
+  test('returns 409 when a request with the same key is already in-flight', async () => {
+    cache.get.mockImplementation((k) => {
+      if (k.startsWith('idem:inflight:')) return Promise.resolve('1');
+      return Promise.resolve(null);
+    });
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await idempotency(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._jsonSpy).toHaveBeenCalledWith({ error: 'Request in progress' });
+  });
+
+  // --- Redis cache-hit path ---
+
+  test('replays cached Redis response when same key is reused with the same body', async () => {
     const body = { amount: 10, recipient_address: 'GABC' };
     const requestHash = crypto.createHash('sha256').update(JSON.stringify(body)).digest('hex');
 
-    const cached = { request_hash: requestHash, status_code: 200, response: { message: 'Payment sent successfully' } };
+    cache.get.mockImplementation((k) => {
+      if (k === `idem:payment:${VALID_KEY}`) {
+        return Promise.resolve({ statusCode: 200, body: { txHash: 'abc123' }, request_hash: requestHash });
+      }
+      return Promise.resolve(null);
+    });
 
-    // First call: purge query, then lookup returns cached row
-    db.query
-      .mockResolvedValueOnce({ rows: [] })   // purge
-      .mockResolvedValueOnce({ rows: [cached] }); // lookup
-
-    const req = makeReq({ key: 'key-123', body });
+    const req = makeReq({ body });
     const res = makeRes();
     const next = jest.fn();
 
     await idempotency(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith(cached.response);
+    expect(res.set).toHaveBeenCalledWith('X-Idempotency-Replayed', 'true');
+    expect(res._jsonSpy).toHaveBeenCalledWith({ txHash: 'abc123' });
   });
 
-  test('returns 400 when same key is reused with different body', async () => {
-    const crypto = require('crypto');
+  test('returns 422 when same key is reused with a different body (Redis cache hit)', async () => {
     const originalBody = { amount: 10, recipient_address: 'GABC' };
-    const differentBody = { amount: 99, recipient_address: 'GXYZ' };
     const originalHash = crypto.createHash('sha256').update(JSON.stringify(originalBody)).digest('hex');
 
-    const cached = { request_hash: originalHash, status_code: 200, response: {} };
+    cache.get.mockImplementation((k) => {
+      if (k === `idem:payment:${VALID_KEY}`) {
+        return Promise.resolve({ statusCode: 200, body: { txHash: 'abc123' }, request_hash: originalHash });
+      }
+      return Promise.resolve(null);
+    });
 
-    db.query
-      .mockResolvedValueOnce({ rows: [] })        // purge
-      .mockResolvedValueOnce({ rows: [cached] }); // lookup
-
-    const req = makeReq({ key: 'key-123', body: differentBody });
+    const differentBody = { amount: 99, recipient_address: 'GXYZ' };
+    const req = makeReq({ body: differentBody });
     const res = makeRes();
     const next = jest.fn();
 
     await idempotency(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ error: expect.stringContaining('different request parameters') })
-    );
+    expect(res.statusCode).toBe(422);
+    expect(res._jsonSpy).toHaveBeenCalledWith({
+      error: 'Idempotency-Key reused with a different request body',
+    });
   });
 
-  test('calls next and caches response for a new key', async () => {
-    db.query
-      .mockResolvedValueOnce({ rows: [] })  // purge
-      .mockResolvedValueOnce({ rows: [] })  // lookup — no existing record
-      .mockResolvedValueOnce({ rows: [] }); // INSERT
+  // --- DB fallback cache-hit path ---
 
-    const req = makeReq({ key: 'new-key', body: { amount: 5, recipient_address: 'GDEF' } });
+  test('replays DB-cached response when same key is reused with the same body (DB fallback)', async () => {
+    const body = { amount: 10, recipient_address: 'GABC' };
+    const requestHash = crypto.createHash('sha256').update(JSON.stringify(body)).digest('hex');
+
+    // Redis miss, DB hit
+    cache.get.mockResolvedValue(null);
+    db.query.mockResolvedValue({
+      rows: [{ request_hash: requestHash, status_code: 200, response: { txHash: 'def456' } }],
+    });
+
+    const req = makeReq({ body });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await idempotency(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.set).toHaveBeenCalledWith('X-Idempotency-Replayed', 'true');
+    expect(res._jsonSpy).toHaveBeenCalledWith({ txHash: 'def456' });
+  });
+
+  test('returns 422 when same key is reused with a different body (DB fallback)', async () => {
+    const originalBody = { amount: 10, recipient_address: 'GABC' };
+    const originalHash = crypto.createHash('sha256').update(JSON.stringify(originalBody)).digest('hex');
+
+    // Redis miss, DB hit with a different hash stored
+    cache.get.mockResolvedValue(null);
+    db.query.mockResolvedValue({
+      rows: [{ request_hash: originalHash, status_code: 200, response: {} }],
+    });
+
+    const differentBody = { amount: 99, recipient_address: 'GXYZ' };
+    const req = makeReq({ body: differentBody });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await idempotency(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(422);
+    expect(res._jsonSpy).toHaveBeenCalledWith({
+      error: 'Idempotency-Key reused with a different request body',
+    });
+  });
+
+  // --- New key (first request) ---
+
+  test('calls next and caches response for a new key', async () => {
+    cache.get.mockResolvedValue(null);
+    db.query.mockResolvedValue({ rows: [] });
+
+    const req = makeReq({ body: { amount: 5, recipient_address: 'GDEF' } });
     const res = makeRes();
     const next = jest.fn();
 
@@ -106,12 +193,17 @@ describe('idempotency middleware', () => {
 
     expect(next).toHaveBeenCalled();
 
-    // Simulate the controller calling res.json
+    // Simulate the controller calling res.json (the middleware has replaced it)
     await res.json({ message: 'Payment sent successfully' });
 
+    expect(cache.set).toHaveBeenCalledWith(
+      expect.stringContaining('idem:payment:'),
+      expect.objectContaining({ statusCode: 200, request_hash: expect.any(String) }),
+      expect.any(Number)
+    );
     expect(db.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO idempotency_keys'),
-      expect.arrayContaining(['new-key', 'user-1'])
+      expect.arrayContaining([VALID_KEY, 'user-1'])
     );
   });
 });

--- a/backend/src/__tests__/send-path-idempotency.test.js
+++ b/backend/src/__tests__/send-path-idempotency.test.js
@@ -6,27 +6,45 @@
 const crypto = require('crypto');
 const idempotency = require('../middleware/idempotency');
 const db = require('../db');
+const cache = require('../utils/cache');
 
 jest.mock('../db');
+jest.mock('../utils/cache');
+
+// Valid UUID v4 keys
+const KEY_EXISTING = '123e4567-e89b-4d3c-a456-426614174001';
+const KEY_NEW = '123e4567-e89b-4d3c-a456-426614174002';
 
 function makeReq({ key, body = {} } = {}) {
   return {
     headers: { 'idempotency-key': key },
     body,
     user: { userId: 'user-1' },
+    path: '/api/payments/send-path',
+    method: 'POST',
   };
 }
 
 function makeRes(statusCode = 200) {
+  const jsonSpy = jest.fn();
   const res = {
     statusCode,
+    _jsonSpy: jsonSpy,
     status(code) { this.statusCode = code; return this; },
-    json: jest.fn(),
+    json: jsonSpy,
+    set: jest.fn(),
+    on: jest.fn(),
   };
   return res;
 }
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  cache.get.mockResolvedValue(null);
+  cache.set.mockResolvedValue(undefined);
+  cache.del.mockResolvedValue(undefined);
+  db.query.mockResolvedValue({ rows: [] });
+});
 
 describe('send-path idempotency', () => {
   const sendPathBody = {
@@ -48,13 +66,14 @@ describe('send-path idempotency', () => {
       transaction: { tx_hash: 'abc123', amount: '10', asset: 'XLM' },
     };
 
-    db.query
-      .mockResolvedValueOnce({ rows: [] })  // purge expired keys
-      .mockResolvedValueOnce({              // lookup — cached entry found
-        rows: [{ request_hash: requestHash, status_code: 200, response: cachedResponse }],
-      });
+    cache.get.mockImplementation((k) => {
+      if (k === `idem:payment:${KEY_EXISTING}`) {
+        return Promise.resolve({ statusCode: 200, body: cachedResponse, request_hash: requestHash });
+      }
+      return Promise.resolve(null);
+    });
 
-    const req = makeReq({ key: 'idem-key-send-path-1', body: sendPathBody });
+    const req = makeReq({ key: KEY_EXISTING, body: sendPathBody });
     const res = makeRes();
     const next = jest.fn();
 
@@ -62,16 +81,14 @@ describe('send-path idempotency', () => {
 
     // Should replay cached response, not call next (i.e. not hit Stellar again)
     expect(next).not.toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith(cachedResponse);
+    expect(res._jsonSpy).toHaveBeenCalledWith(cachedResponse);
   });
 
   test('proceeds to handler and caches response for a new Idempotency-Key', async () => {
-    db.query
-      .mockResolvedValueOnce({ rows: [] })  // purge
-      .mockResolvedValueOnce({ rows: [] })  // lookup — no existing record
-      .mockResolvedValueOnce({ rows: [] }); // INSERT
+    cache.get.mockResolvedValue(null);
+    db.query.mockResolvedValue({ rows: [] });
 
-    const req = makeReq({ key: 'idem-key-send-path-new', body: sendPathBody });
+    const req = makeReq({ key: KEY_NEW, body: sendPathBody });
     const res = makeRes();
     const next = jest.fn();
 
@@ -84,7 +101,7 @@ describe('send-path idempotency', () => {
 
     expect(db.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO idempotency_keys'),
-      expect.arrayContaining(['idem-key-send-path-new', 'user-1'])
+      expect.arrayContaining([KEY_NEW, 'user-1'])
     );
   });
 });

--- a/backend/src/middleware/idempotency.js
+++ b/backend/src/middleware/idempotency.js
@@ -31,6 +31,9 @@ module.exports = async function idempotency(req, res, next) {
   const redisKey = `idem:payment:${key}`;
   const inFlightKey = `idem:inflight:${key}`;
 
+  // Compute hash up-front so it can be validated against any cached entry
+  const requestHash = hashBody(req.body);
+
   // Check in-flight marker before doing anything else
   const inFlight = await cache.get(inFlightKey);
   if (inFlight) {
@@ -40,6 +43,9 @@ module.exports = async function idempotency(req, res, next) {
   // Check Redis for a cached completed response
   const cached = await cache.get(redisKey);
   if (cached) {
+    if (cached.request_hash !== requestHash) {
+      return res.status(422).json({ error: 'Idempotency-Key reused with a different request body' });
+    }
     res.set('X-Idempotency-Replayed', 'true');
     return res.status(cached.statusCode).json(cached.body);
   }
@@ -52,6 +58,9 @@ module.exports = async function idempotency(req, res, next) {
 
   if (existing?.rows[0]) {
     const row = existing.rows[0];
+    if (row.request_hash !== requestHash) {
+      return res.status(422).json({ error: 'Idempotency-Key reused with a different request body' });
+    }
     res.set('X-Idempotency-Replayed', 'true');
     return res.status(row.status_code).json(row.response);
   }
@@ -59,13 +68,11 @@ module.exports = async function idempotency(req, res, next) {
   // Mark request as in-flight so concurrent duplicates get 409
   await cache.set(inFlightKey, '1', IN_FLIGHT_TTL);
 
-  const requestHash = hashBody(req.body);
-
   const originalJson = res.json.bind(res);
   res.json = async (body) => {
     await cache.del(inFlightKey);
     if (res.statusCode < 500) {
-      await cache.set(redisKey, { statusCode: res.statusCode, body }, TTL_SECONDS);
+      await cache.set(redisKey, { statusCode: res.statusCode, body, request_hash: requestHash }, TTL_SECONDS);
       await db.query(
         `INSERT INTO idempotency_keys (key, user_id, request_hash, status_code, response)
          VALUES ($1, $2, $3, $4, $5)


### PR DESCRIPTION
## Summary

Fixes #901.

`hashBody(req.body)` was computed and stored alongside each idempotent response, but neither the Redis cache-hit path nor the DB fallback cache-hit path ever compared the incoming request's hash against the stored `request_hash` before replaying the cached response. A client reusing the same key with a different body silently received the first request's response.

## Changes

### `backend/src/middleware/idempotency.js`
- Move `requestHash = hashBody(req.body)` to before the cache lookups so it is available for validation in both paths.
- **Redis path**: compare `cached.request_hash` against `requestHash`; return **HTTP 422** with `{ error: 'Idempotency-Key reused with a different request body' }` on mismatch.
- **DB fallback path**: compare `row.request_hash` against `requestHash`; same 422 response on mismatch.
- Include `request_hash` in the Redis cache entry object (previously only `statusCode` and `body` were stored), so future replays can validate against it.

### `backend/src/__tests__/idempotency.test.js`
- Add `jest.mock('../utils/cache')` with default no-hit behaviour so the middleware runs correctly under test.
- Use valid UUID v4 keys throughout (previous tests used arbitrary strings that failed the UUID validation gate).
- Add four targeted tests:
  - Same key + same body via Redis → replays cached response with `X-Idempotency-Replayed: true`
  - Same key + different body via Redis → HTTP 422 conflict
  - Same key + same body via DB fallback → replays cached response
  - Same key + different body via DB fallback → HTTP 422 conflict

### `backend/src/__tests__/send-path-idempotency.test.js`
- Add `jest.mock('../utils/cache')` and switch to valid UUID v4 keys (pre-existing issue causing those tests to fail).

## Testing

```
PASS src/__tests__/idempotency.test.js
PASS src/__tests__/send-path-idempotency.test.js

Tests: 10 passed, 10 total
```