### PR TITLE
Fix scheduled payments validation, row-count checks, and bulk KYC on-…

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -912,15 +912,62 @@ async function bulkKycUpdate(req, res, next) {
   const kycStatus = status === 'approved' ? 'verified' : 'rejected';
   const client = await db.pool.connect();
   try {
+    // Fetch users with wallets and current kyc_status before updating
+    const { rows: users } = await client.query(
+      `SELECT u.id, u.kyc_status, u.kyc_data, w.public_key
+       FROM users u LEFT JOIN wallets w ON w.user_id = u.id
+       WHERE u.id = ANY($1::uuid[])`,
+      [userIds]
+    );
+
     await client.query('BEGIN');
     await client.query(
       `UPDATE users SET kyc_status = $1, updated_at = NOW() WHERE id = ANY($2::uuid[])`,
       [kycStatus, userIds]
     );
     await client.query('COMMIT');
+
+    // Get admin wallet for on-chain operations
+    const adminWallet = await db.query(
+      "SELECT public_key FROM wallets WHERE user_id = $1",
+      [req.user.userId]
+    );
+    const adminPublicKey = adminWallet.rows[0]?.public_key;
+
+    const attestationResults = [];
+
+    for (const user of users) {
+      let txHash = null;
+      let attestationError = null;
+
+      if (status === 'approved') {
+        const idType = user.kyc_data?.id_type || 'unknown';
+        try {
+          txHash = await attestKyc(adminPublicKey, user.public_key, user.id, idType);
+        } catch (err) {
+          attestationError = err.message;
+          console.error(`On-chain attestation failed for user ${user.id}:`, err.message);
+        }
+      } else if (status === 'rejected' && user.kyc_status === 'verified') {
+        try {
+          txHash = await revokeKyc(adminPublicKey, user.public_key);
+        } catch (err) {
+          attestationError = err.message;
+          console.error(`On-chain revocation failed for user ${user.id}:`, err.message);
+        }
+      }
+
+      attestationResults.push({
+        user_id: user.id,
+        onchain_tx_hash: txHash,
+        onchain_success: !attestationError,
+        onchain_error: attestationError,
+      });
+    }
+
     await audit.log(req.user.userId, 'bulk_kyc_update', req.ip, req.headers['user-agent'],
-      { user_count: userIds.length, status: kycStatus, reason: reason || null });
-    res.json({ message: 'KYC status updated', count: userIds.length, status: kycStatus });
+      { user_count: userIds.length, status: kycStatus, reason: reason || null, attestation_results: attestationResults });
+    res.json({ message: 'KYC status updated', count: userIds.length, status: kycStatus, attestation_results: attestationResults });
   } catch (err) {
     await client.query('ROLLBACK');
     next(err);

--- a/backend/src/controllers/scheduledPaymentController.js
+++ b/backend/src/controllers/scheduledPaymentController.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
 const db = require('../db');
+const StellarSdk = require('@stellar/stellar-sdk');
 
 async function create(req, res, next) {
   try {
@@ -11,6 +12,9 @@ async function create(req, res, next) {
     }
     if (!['daily', 'weekly', 'monthly'].includes(frequency)) {
       return res.status(400).json({ error: 'Invalid frequency' });
+    }
+    if (!recipient_wallet || !StellarSdk.StrKey.isValidEd25519PublicKey(recipient_wallet)) {
+      return res.status(400).json({ error: 'Invalid recipient wallet address' });
     }
 
     const id = uuidv4();
@@ -52,7 +56,14 @@ async function update(req, res, next) {
     const { amount, frequency, active, recipient_wallet } = req.body;
     const userId = req.user.userId;
 
-    await db.query(
+    if (frequency !== undefined && frequency !== null && !['daily', 'weekly', 'monthly'].includes(frequency)) {
+      return res.status(400).json({ error: 'Invalid frequency' });
+    }
+    if (recipient_wallet !== undefined && recipient_wallet !== null && !StellarSdk.StrKey.isValidEd25519PublicKey(recipient_wallet)) {
+      return res.status(400).json({ error: 'Invalid recipient wallet address' });
+    }
+
+    const result = await db.query(
       `UPDATE scheduled_payments
        SET amount = COALESCE($1, amount),
            frequency = COALESCE($2, frequency),
@@ -61,6 +72,10 @@ async function update(req, res, next) {
        WHERE id = $5 AND user_id = $6`,
       [amount, frequency, active, recipient_wallet, id, userId]
     );
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Scheduled payment not found' });
+    }
 
     res.json({ message: 'Scheduled payment updated' });
   } catch (err) {
@@ -73,10 +88,14 @@ async function delete_(req, res, next) {
     const { id } = req.params;
     const userId = req.user.userId;
 
-    await db.query(
+    const result = await db.query(
       `DELETE FROM scheduled_payments WHERE id = $1 AND user_id = $2`,
       [id, userId]
     );
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Scheduled payment not found' });
+    }
 
     res.json({ message: 'Scheduled payment deleted' });
   } catch (err) {

--- a/backend/src/routes/scheduledPayments.js
+++ b/backend/src/routes/scheduledPayments.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { body, validationResult } = require('express-validator');
 const auth = require('../middleware/auth');
+const StellarSdk = require('@stellar/stellar-sdk');
 const { create, list, update, delete: delete_ } = require('../controllers/scheduledPaymentController');
 
 const router = express.Router();
@@ -56,6 +57,20 @@ router.post(
   '/',
   auth,
   [
+    body('recipient_wallet')
+      .notEmpty().withMessage('recipient_wallet is required')
+      .custom((value) => {
+        if (!StellarSdk.StrKey.isValidEd25519PublicKey(value)) {
+          throw new Error('Invalid Stellar wallet address');
+        }
+        return true;
+      }),
+    body('amount')
+      .notEmpty().withMessage('amount is required')
+      .isFloat({ gt: 0 }).withMessage('Amount must be greater than 0'),
+    body('frequency')
+      .notEmpty().withMessage('frequency is required')
+      .isIn(['daily', 'weekly', 'monthly']).withMessage('Frequency must be daily, weekly, or monthly'),
     body('execute_at')
       .notEmpty().withMessage('execute_at is required')
       .isISO8601().withMessage('execute_at must be a valid ISO 8601 timestamp')
@@ -76,7 +91,28 @@ router.post(
 );
 
 router.get('/', auth, list);
-router.put('/:id', auth, update);
+router.put(
+  '/:id',
+  auth,
+  [
+    body('amount')
+      .optional()
+      .isFloat({ gt: 0 }).withMessage('Amount must be greater than 0'),
+    body('frequency')
+      .optional()
+      .isIn(['daily', 'weekly', 'monthly']).withMessage('Frequency must be daily, weekly, or monthly'),
+    body('recipient_wallet')
+      .optional()
+      .custom((value) => {
+        if (!StellarSdk.StrKey.isValidEd25519PublicKey(value)) {
+          throw new Error('Invalid Stellar wallet address');
+        }
+        return true;
+      }),
+  ],
+  validate,
+  update,
+);
 router.delete('/:id', auth, delete_);
 
 module.exports = router;


### PR DESCRIPTION
…chain attestation

- #885: scheduledPaymentController update() and delete() now check result.rowCount and return 404 when no row matches (wrong id or not owned by caller), preventing misleading 200 responses
- #884: update() validates frequency against ['daily','weekly','monthly'] enum when provided; PUT /:id route gains express-validator body() rules for amount (>0), frequency (enum), and recipient_wallet (Stellar addr)
- #883: create() and PUT /:id validate recipient_wallet via StellarSdk.StrKey.isValidEd25519PublicKey with 400 on invalid input; POST route also gets recipient_wallet/amount/frequency validation
- #882: bulkKycUpdate() now fetches users with wallets before the DB update, calls attestKyc() for each approved user (best-effort try/catch), calls revokeKyc() for rejected users whose prior status was verified, and records per-user attestation results in both the audit log and the API response

Closes #885 
Closes #884 
Closes #883 
Closes #882 