### PR TITLE
Fix escrow race condition and IDOR gaps in escrow/dispute/ledger controllers

### DIFF
--- a/backend/src/controllers/agentEscrowController.js
+++ b/backend/src/controllers/agentEscrowController.js
@@ -221,24 +221,35 @@ async function cancel(req, res, next) {
  * records the cumulative released amount, and returns the new remaining balance.
  */
 async function partialRelease(req, res, next) {
+  const { id } = req.params;
+  const amount = parseFloat(req.body.amount);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return res.status(400).json({ error: "Amount must be greater than 0" });
+  }
+
+  const client = await db.pool.connect();
   try {
-    const { id } = req.params;
-    const amount = parseFloat(req.body.amount);
+    await client.query("BEGIN");
 
-    if (!Number.isFinite(amount) || amount <= 0) {
-      return res.status(400).json({ error: "Amount must be greater than 0" });
-    }
-
-    const escrowResult = await db.query("SELECT * FROM agent_escrows WHERE id = $1", [id]);
+    // Lock the escrow row for the duration of the transaction so concurrent
+    // partial-release requests serialize instead of racing on a stale read.
+    const escrowResult = await client.query(
+      "SELECT * FROM agent_escrows WHERE id = $1 FOR UPDATE",
+      [id]
+    );
     if (!escrowResult.rows[0]) {
+      await client.query("ROLLBACK");
       return res.status(404).json({ error: "Escrow not found" });
     }
     const escrow = escrowResult.rows[0];
 
     if (escrow.status !== "pending") {
+      await client.query("ROLLBACK");
       return res.status(400).json({ error: "Only pending escrows can be partially released" });
     }
     if (escrow.sender_wallet !== req.user.walletAddress) {
+      await client.query("ROLLBACK");
       return res.status(403).json({ error: "Only the sender can release this escrow" });
     }
 
@@ -247,6 +258,7 @@ async function partialRelease(req, res, next) {
     const remaining = total - alreadyReleased;
 
     if (amount > remaining + 1e-7) {
+      await client.query("ROLLBACK");
       return res.status(400).json({
         error: `Amount exceeds remaining escrow balance (${remaining})`,
       });
@@ -261,7 +273,7 @@ async function partialRelease(req, res, next) {
     // Fully drained escrows transition to completed.
     const fullyReleased = newRemaining <= 1e-7;
 
-    const updated = await db.query(
+    const updated = await client.query(
       `UPDATE agent_escrows
          SET released_amount = $1,
              status = CASE WHEN $2 THEN 'completed' ELSE status END
@@ -269,6 +281,8 @@ async function partialRelease(req, res, next) {
        RETURNING *`,
       [newReleased, fullyReleased, id]
     );
+
+    await client.query("COMMIT");
 
     res.json({
       message: "Partial release successful",
@@ -280,7 +294,10 @@ async function partialRelease(req, res, next) {
       status: updated.rows[0].status,
     });
   } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
     next(err);
+  } finally {
+    client.release();
   }
 }
 
@@ -296,7 +313,16 @@ async function getEscrow(req, res, next) {
     if (!result.rows[0]) {
       return res.status(404).json({ error: "Escrow not found" });
     }
-    res.json({ escrow: result.rows[0] });
+    const escrow = result.rows[0];
+
+    const isParty =
+      req.user.walletAddress === escrow.sender_wallet ||
+      req.user.walletAddress === escrow.agent_wallet;
+    if (!isParty && req.user.role !== "admin") {
+      return res.status(403).json({ error: "You are not authorized to view this escrow" });
+    }
+
+    res.json({ escrow });
   } catch (err) {
     next(err);
   }

--- a/backend/src/controllers/disputeResolutionController.js
+++ b/backend/src/controllers/disputeResolutionController.js
@@ -272,7 +272,26 @@ async function getDispute(req, res, next) {
     if (!result.rows[0]) {
       return res.status(404).json({ error: "Dispute not found" });
     }
-    res.json({ dispute: result.rows[0] });
+    const dispute = result.rows[0];
+
+    if (req.user.role !== "admin") {
+      const walletResult = await db.query(
+        "SELECT public_key FROM wallets WHERE user_id = $1",
+        [req.user.userId]
+      );
+      const public_key = walletResult.rows[0]?.public_key;
+
+      if (
+        public_key !== dispute.sender_wallet &&
+        public_key !== dispute.recipient_wallet
+      ) {
+        return res
+          .status(403)
+          .json({ error: "You are not a party to this dispute" });
+      }
+    }
+
+    res.json({ dispute });
   } catch (err) {
     next(err);
   }

--- a/backend/src/controllers/ledgerController.js
+++ b/backend/src/controllers/ledgerController.js
@@ -97,7 +97,7 @@ async function buildTransaction(req, res, next) {
  */
 async function submitSigned(req, res, next) {
   try {
-    const { xdr, recipient_address, amount, asset = 'XLM', wallet_id } = req.body;
+    const { xdr, recipient_address, amount, asset, wallet_id } = req.body;
     const userId = req.user.userId;
 
     if (!xdr) return res.status(400).json({ error: 'Signed XDR is required' });
@@ -132,15 +132,39 @@ async function submitSigned(req, res, next) {
       return res.status(400).json({ error: 'Transaction has no signatures' });
     }
 
+    // Extract the actual recipient/amount/asset from the signed transaction itself —
+    // never trust req.body for what gets persisted, since it isn't covered by the signature.
+    const paymentOp = transaction.operations.find((op) => op.type === 'payment');
+    if (!paymentOp) {
+      return res.status(400).json({ error: 'Signed transaction does not contain a payment operation' });
+    }
+
+    const actualRecipient = paymentOp.destination;
+    const actualAmount = paymentOp.amount;
+    const actualAsset = paymentOp.asset.isNative() ? 'XLM' : paymentOp.asset.getCode();
+
+    if (recipient_address && recipient_address !== actualRecipient) {
+      return res.status(400).json({ error: 'recipient_address does not match the signed transaction' });
+    }
+    if (
+      (amount !== undefined && amount !== null && amount !== '') &&
+      Math.abs(parseFloat(amount) - parseFloat(actualAmount)) > 1e-7
+    ) {
+      return res.status(400).json({ error: 'amount does not match the signed transaction' });
+    }
+    if (asset && asset !== actualAsset) {
+      return res.status(400).json({ error: 'asset does not match the signed transaction' });
+    }
+
     // Submit to Horizon
     const result = await horizonServer.submitTransaction(transaction);
 
-    // Record in DB
+    // Record in DB using the values verified from the signed XDR, not req.body
     await db.query(
       `INSERT INTO transactions (id, user_id, sender_wallet, recipient_wallet, amount, asset, status, transaction_hash, signing_method)
        VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, 'completed', $6, 'ledger')
        ON CONFLICT (transaction_hash) DO NOTHING`,
-      [userId, senderPublicKey, recipient_address || 'unknown', amount || '0', asset, result.hash]
+      [userId, senderPublicKey, actualRecipient, actualAmount, actualAsset, result.hash]
     );
 
     logger.info('Ledger-signed transaction submitted', { hash: result.hash, userId });


### PR DESCRIPTION
## Summary

Fixes four backend security/correctness issues in the escrow, dispute, and ledger controllers:

- **closes #874** — `agentEscrowController.partialRelease()` had a read-modify-write race: two concurrent partial-release calls could both read the same `released_amount`, both pass the remaining-balance check, and the second write would clobber the first, allowing over-release of escrow funds. Fixed by wrapping the read + update in a single `db.pool.connect()` transaction with `SELECT ... FOR UPDATE` on the escrow row, so concurrent requests serialize against the row lock instead of racing on a stale read. Response shape is unchanged.
- **closes #875** — `agentEscrowController.getEscrow()` (`GET /api/escrow/:id`) had no ownership check beyond authentication, letting any authenticated user fetch any other user's escrow record (IDOR). Now returns 403 unless the caller is the escrow's sender, its assigned agent, or an admin.
- **closes #876** — `disputeResolutionController.getDispute()` (`GET /api/disputes/:id`) had the same IDOR gap, inconsistent with `listEvidence()` in the same file which already checks party membership. Now returns 403 unless the caller is the dispute's sender, recipient, or an admin, mirroring the existing `listEvidence()` pattern. `listDisputes()` is untouched.
- **closes #877** — `ledgerController.submitSigned()` persisted `recipient_wallet`/`amount`/`asset` straight from `req.body` instead of the signed XDR, so a client could submit a validly-signed transaction for one recipient/amount while claiming a different one in the JSON body, corrupting the transaction history/audit trail. Now the recipient, amount, and asset are extracted from the signed transaction's payment operation itself; if the body supplies its own values they're cross-checked against the XDR and a mismatch returns 400.

## Test plan

- [x] `node -c` syntax check on all three modified files
- [x] Ran existing `tests/ledger.test.js`, `tests/escrow.test.js`, `src/__tests__/dispute-resolution.test.js` before and after the change — failure counts are identical (pre-existing environment/setup issues unrelated to this diff, e.g. a duplicate `listSessions` declaration in `routes/auth.js` breaking module load, and an unrelated auth-token mismatch in the dispute suite); no new failures introduced
- [x] `eslint` diff shows only pre-existing style violations consistent with the rest of each file (snake_case DB field destructuring), no new categories of error
- No new tests added per request scope

