### PR TITLE
fix: implement real AML provider integrations and fail-closed compliance gate (#898)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -74,6 +74,21 @@ DAILY_SEND_LIMIT=50000
 PHONE_VERIFICATION_THRESHOLD_USD=100
 XLM_USD_RATE=0.11
 
+# AML / sanctions screening
+# Provider: 'complyadvantage' or 'elliptic'. Leave unset to disable real screening.
+# When unset, a startup warning is logged in production and high-value payments
+# (>= $1000 USD equivalent) are BLOCKED fail-closed; KYC wallets are flagged not_screened.
+AML_PROVIDER=
+AML_API_KEY=
+# Required for elliptic: API secret (base64) used to HMAC-sign requests
+AML_API_SECRET=
+# Optional base URL override for the provider API (proxies, sandboxes, tests)
+# AML_API_URL=
+# Elliptic risk score >= this value is treated as flagged (default: 70)
+# AML_HIGH_RISK_SCORE=70
+# Provider request timeout in milliseconds (default: 5000)
+# AML_API_TIMEOUT_MS=5000
+
 # Exchange rate API key (optional)
 # Used by priceOracle to fetch live USD→NGN/GHS/KES rates.
 # Without a key the free open.er-api.com endpoint is used (1500 req/month).

--- a/backend/src/__tests__/amlScreening.test.js
+++ b/backend/src/__tests__/amlScreening.test.js
@@ -1,0 +1,381 @@
+'use strict';
+
+/**
+ * Tests for AML/sanctions screening (backend/src/services/amlScreening.js) and
+ * the fail-closed compliance gate (amlRescreenForPayment in kycController).
+ *
+ * Provider tests cover flagged, clear, and provider-error responses for the
+ * ComplyAdvantage and Elliptic integrations.
+ */
+
+jest.mock('../utils/logger', () => ({ warn: jest.fn(), error: jest.fn(), info: jest.fn() }));
+jest.mock('../utils/metrics', () => ({
+  amlScreeningsTotal: { inc: jest.fn() },
+  amlScreeningCoverageGauge: { set: jest.fn() },
+}));
+jest.mock('../db', () => ({ query: jest.fn() }));
+
+const logger = require('../utils/logger');
+const metrics = require('../utils/metrics');
+
+const WALLET = 'GCSEQ5XE5YYKPITLT63FZ7LCW2JZNYVP3L2XKMGELRKGPNZXNNBVPOU3';
+
+function mockFetchOk(body) {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(body) });
+}
+
+function mockFetchError(status, text) {
+  global.fetch = jest.fn().mockResolvedValue({ ok: false, status, text: async () => text });
+}
+
+function mockFetchNetworkError() {
+  global.fetch = jest.fn().mockRejectedValue(new Error('network down'));
+}
+
+function clearAmlEnv() {
+  delete process.env.AML_PROVIDER;
+  delete process.env.AML_API_KEY;
+  delete process.env.AML_API_SECRET;
+  delete process.env.AML_API_URL;
+  delete process.env.AML_HIGH_RISK_SCORE;
+  delete process.env.AML_API_TIMEOUT_MS;
+}
+
+describe('AML screening service', () => {
+  let amlScreen;
+  let isAmlConfigured;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAmlEnv();
+    global.fetch = jest.fn();
+    amlScreen = require('../services/amlScreening').amlScreen;
+    isAmlConfigured = require('../services/amlScreening').isAmlConfigured;
+    require('../services/amlScreening').resetAmlMetricCounters();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unconfigured passthrough
+  // -------------------------------------------------------------------------
+
+  test('returns not_screened passthrough when no provider is configured', async () => {
+    const result = await amlScreen(WALLET, { userId: 'user-1' });
+
+    expect(result).toMatchObject({
+      screened: false,
+      status: 'not_screened',
+      risk_level: null,
+      provider: null,
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(metrics.amlScreeningsTotal.inc).toHaveBeenCalledWith({ status: 'not_screened' });
+    expect(metrics.amlScreeningCoverageGauge.set).toHaveBeenCalledWith(0);
+  });
+
+  test('isAmlConfigured is false without provider or key', () => {
+    expect(isAmlConfigured()).toBe(false);
+  });
+
+  test('returns not_screened for an unknown provider even with a key set', async () => {
+    process.env.AML_PROVIDER = 'unknown';
+    process.env.AML_API_KEY = 'some-key';
+    const result = await amlScreen(WALLET, { userId: 'user-1' });
+    expect(result.status).toBe('not_screened');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('returns error when a configured provider screens a missing wallet address', async () => {
+    process.env.AML_PROVIDER = 'complyadvantage';
+    process.env.AML_API_KEY = 'test-key';
+    const result = await amlScreen('', { userId: 'user-1' });
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('missing_wallet_address');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // ComplyAdvantage
+  // -------------------------------------------------------------------------
+
+  describe('ComplyAdvantage integration', () => {
+    beforeEach(() => {
+      process.env.AML_PROVIDER = 'complyadvantage';
+      process.env.AML_API_KEY = 'test-ca-key';
+    });
+
+    test('isAmlConfigured is true when provider and key are set', () => {
+      expect(isAmlConfigured()).toBe(true);
+    });
+
+    test('flags a wallet with a true_positive sanctions hit', async () => {
+      mockFetchOk({
+        status: 'success',
+        content: {
+          data: {
+            id: 12345,
+            ref: 'CA12345',
+            search_term: WALLET,
+            match_status: 'true_positive',
+            risk_level: 'high',
+            total_hits: 2,
+          },
+        },
+      });
+
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+
+      expect(result).toMatchObject({
+        screened: true,
+        status: 'flagged',
+        risk_level: 'high',
+        provider: 'complyadvantage',
+        reference_id: '12345',
+      });
+      expect(metrics.amlScreeningsTotal.inc).toHaveBeenCalledWith({ status: 'flagged' });
+    });
+
+    test('flags a wallet with total_hits > 0 even when match_status is absent', async () => {
+      mockFetchOk({ status: 'success', content: { data: { id: 1, total_hits: 1 } } });
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+      expect(result.status).toBe('flagged');
+    });
+
+    test('returns clear when there are no hits', async () => {
+      mockFetchOk({
+        status: 'success',
+        content: {
+          data: { id: 54321, match_status: 'no_match', risk_level: 'low', total_hits: 0, hits: [] },
+        },
+      });
+
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+
+      expect(result).toMatchObject({
+        screened: true,
+        status: 'clear',
+        risk_level: 'low',
+        provider: 'complyadvantage',
+        reference_id: '54321',
+      });
+      expect(metrics.amlScreeningsTotal.inc).toHaveBeenCalledWith({ status: 'clear' });
+      expect(metrics.amlScreeningCoverageGauge.set).toHaveBeenCalledWith(1);
+    });
+
+    test('sends the wallet address and auth header to the provider', async () => {
+      mockFetchOk({ status: 'success', content: { data: { id: 1, total_hits: 0 } } });
+
+      await amlScreen(WALLET, { userId: 'user-1' });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = global.fetch.mock.calls[0];
+      expect(url).toContain('/searches');
+      expect(init.headers.Authorization).toBe('Token test-ca-key');
+      const body = JSON.parse(init.body);
+      expect(body.search_term).toBe(WALLET);
+      expect(body.client_ref).toBe('afripay-user-1');
+    });
+
+    test('uses full_name as the search term when provided', async () => {
+      mockFetchOk({ status: 'success', content: { data: { id: 1, total_hits: 0 } } });
+      await amlScreen(WALLET, { userId: 'user-1', full_name: 'Jane Doe' });
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.search_term).toBe('Jane Doe');
+    });
+
+    test('returns error on HTTP 500 from the provider', async () => {
+      mockFetchError(500, 'Internal Server Error');
+
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+
+      expect(result).toMatchObject({
+        screened: false,
+        status: 'error',
+        provider: 'complyadvantage',
+      });
+      expect(result.error).toContain('HTTP 500');
+      expect(logger.error).toHaveBeenCalled();
+      expect(metrics.amlScreeningsTotal.inc).toHaveBeenCalledWith({ status: 'error' });
+    });
+
+    test('returns error on network failure', async () => {
+      mockFetchNetworkError();
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+      expect(result).toMatchObject({
+        screened: false,
+        status: 'error',
+        provider: 'complyadvantage',
+      });
+    });
+
+    test('returns error on unparseable provider response', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: async () => 'not-json' });
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+      expect(result.status).toBe('error');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Elliptic
+  // -------------------------------------------------------------------------
+
+  describe('Elliptic integration', () => {
+    beforeEach(() => {
+      process.env.AML_PROVIDER = 'elliptic';
+      process.env.AML_API_KEY = 'test-elliptic-key';
+      process.env.AML_API_SECRET = Buffer.from('this-is-a-test-secret-for-elliptic!').toString(
+        'base64'
+      );
+    });
+
+    test('isAmlConfigured is true when key and secret are set', () => {
+      expect(isAmlConfigured()).toBe(true);
+    });
+
+    test('isAmlConfigured is false when the secret is missing', () => {
+      delete process.env.AML_API_SECRET;
+      expect(isAmlConfigured()).toBe(false);
+    });
+
+    test('flags a wallet with a high risk score', async () => {
+      mockFetchOk({ id: 'ELL-1', risk_score: 95, risk_rules: [] });
+
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+
+      expect(result).toMatchObject({
+        screened: true,
+        status: 'flagged',
+        risk_level: 'high',
+        provider: 'elliptic',
+        reference_id: 'ELL-1',
+      });
+    });
+
+    test('flags a wallet with a high-severity risk rule even at a low score', async () => {
+      mockFetchOk({
+        id: 'ELL-2',
+        risk_score: 20,
+        risk_rules: [{ id: 'r1', name: 'sanctions', severity: 'critical' }],
+      });
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+      expect(result.status).toBe('flagged');
+    });
+
+    test('returns clear for a low risk score with no severe rules', async () => {
+      mockFetchOk({
+        id: 'ELL-3',
+        risk_score: 12,
+        risk_rules: [{ id: 'r2', name: 'exchange', severity: 'low' }],
+      });
+
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+
+      expect(result).toMatchObject({
+        screened: true,
+        status: 'clear',
+        risk_level: 'low',
+        provider: 'elliptic',
+      });
+    });
+
+    test('signs the request with the configured secret', async () => {
+      mockFetchOk({ id: 'ELL-4', risk_score: 0, risk_rules: [] });
+
+      await amlScreen(WALLET, { userId: 'user-1' });
+
+      const [url, init] = global.fetch.mock.calls[0];
+      expect(url).toContain('/v2/wallet/synchronous');
+      expect(init.headers['x-access-key']).toBe('test-elliptic-key');
+      expect(init.headers['x-access-timestamp']).toMatch(/^\d+$/);
+      expect(init.headers['x-access-sign']).toBeTruthy();
+    });
+
+    test('returns error on HTTP 500 from the provider', async () => {
+      mockFetchError(500, 'boom');
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+      expect(result).toMatchObject({ screened: false, status: 'error', provider: 'elliptic' });
+    });
+
+    test('returns error on network failure', async () => {
+      mockFetchNetworkError();
+      const result = await amlScreen(WALLET, { userId: 'user-1' });
+      expect(result.status).toBe('error');
+    });
+  });
+});
+
+// -------------------------------------------------------------------------
+// Fail-closed compliance gate (kycController.amlRescreenForPayment)
+// -------------------------------------------------------------------------
+
+describe('amlRescreenForPayment fail-closed gate', () => {
+  let amlRescreenForPayment;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAmlEnv();
+    global.fetch = jest.fn();
+    amlRescreenForPayment = require('../controllers/kycController').amlRescreenForPayment;
+    require('../services/amlScreening').resetAmlMetricCounters();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  test('returns null below the rescreen threshold even when screening is unconfigured', async () => {
+    const result = await amlRescreenForPayment('user-1', WALLET, 999);
+    expect(result).toBeNull();
+  });
+
+  test('blocks a high-value payment with 403 when screening is not configured', async () => {
+    await expect(amlRescreenForPayment('user-1', WALLET, 1500)).rejects.toMatchObject({
+      status: 403,
+      payload: { code: 'AML_SCREENING_UNAVAILABLE' },
+    });
+  });
+
+  test('blocks a high-value payment with 403 when the provider flags the wallet', async () => {
+    process.env.AML_PROVIDER = 'complyadvantage';
+    process.env.AML_API_KEY = 'test-ca-key';
+    mockFetchOk({
+      status: 'success',
+      content: { data: { match_status: 'true_positive', total_hits: 1, risk_level: 'high' } },
+    });
+
+    await expect(amlRescreenForPayment('user-1', WALLET, 1500)).rejects.toMatchObject({
+      status: 403,
+      message: expect.stringContaining('flagged'),
+    });
+  });
+
+  test('blocks a high-value payment with 503 when the provider errors', async () => {
+    process.env.AML_PROVIDER = 'complyadvantage';
+    process.env.AML_API_KEY = 'test-ca-key';
+    mockFetchNetworkError();
+
+    await expect(amlRescreenForPayment('user-1', WALLET, 1500)).rejects.toMatchObject({
+      status: 503,
+      payload: { code: 'AML_SCREENING_ERROR' },
+    });
+  });
+
+  test('passes through a high-value payment when the provider returns clear', async () => {
+    process.env.AML_PROVIDER = 'complyadvantage';
+    process.env.AML_API_KEY = 'test-ca-key';
+    mockFetchOk({
+      status: 'success',
+      content: { data: { match_status: 'no_match', total_hits: 0 } },
+    });
+
+    const result = await amlRescreenForPayment('user-1', WALLET, 1500);
+    expect(result).toMatchObject({ screened: true, status: 'clear' });
+  });
+});

--- a/backend/src/controllers/kycController.js
+++ b/backend/src/controllers/kycController.js
@@ -71,6 +71,16 @@ async function submitKYC(req, res, next) {
         await audit.log(req.user.userId, 'aml_flagged', req.ip, req.headers['user-agent'], { walletAddress, amlResult });
         return res.status(403).json({ error: 'Payment blocked: wallet flagged by AML screening.' });
       }
+      // Explicit compliance decision for a non-cleared screening:
+      // KYC document submission is allowed through with a flag so compliance can
+      // review it, but the outcome is recorded in the audit trail.
+      if (amlResult.status === 'not_screened') {
+        logger.warn('AML screening unavailable — KYC submission allowed with flag', { userId: req.user.userId, walletAddress });
+        await audit.log(req.user.userId, 'aml_not_screened', req.ip, req.headers['user-agent'], { walletAddress, amlResult });
+      } else if (amlResult.status === 'error') {
+        logger.warn('AML screening provider error — KYC submission allowed with flag', { userId: req.user.userId, walletAddress, amlResult });
+        await audit.log(req.user.userId, 'aml_screening_error', req.ip, req.headers['user-agent'], { walletAddress, amlResult });
+      }
     }
 
     res.status(200).json({
@@ -85,6 +95,9 @@ async function submitKYC(req, res, next) {
 /**
  * Re-screen a sender wallet for payments over AML_RESCREEN_THRESHOLD_USD.
  * Call this from the payment flow before submitting high-value transactions.
+ *
+ * Fail-closed compliance gate: a high-value payment is blocked unless the
+ * wallet was actually screened and returned a clear result.
  */
 async function amlRescreenForPayment(userId, walletAddress, amountUsd) {
   if (amountUsd < AML_RESCREEN_THRESHOLD_USD) return null;
@@ -94,6 +107,22 @@ async function amlRescreenForPayment(userId, walletAddress, amountUsd) {
     await audit.log(userId, 'aml_payment_flagged', null, null, { walletAddress, amountUsd, amlResult });
     const err = new Error('Payment blocked: wallet flagged by AML screening.');
     err.status = 403;
+    throw err;
+  }
+  if (amlResult.status === 'not_screened') {
+    logger.warn('AML screening unavailable — blocking high-value payment', { userId, walletAddress, amountUsd });
+    await audit.log(userId, 'aml_payment_not_screened', null, null, { walletAddress, amountUsd, amlResult });
+    const err = new Error('Payment blocked: AML screening is not configured for high-value transactions.');
+    err.status = 403;
+    err.payload = { code: 'AML_SCREENING_UNAVAILABLE' };
+    throw err;
+  }
+  if (amlResult.status === 'error') {
+    logger.error('AML screening provider error — blocking high-value payment', { userId, walletAddress, amountUsd, amlResult });
+    await audit.log(userId, 'aml_payment_screening_error', null, null, { walletAddress, amountUsd, amlResult });
+    const err = new Error('Payment blocked: AML screening provider error. Please try again later.');
+    err.status = 503;
+    err.payload = { code: 'AML_SCREENING_ERROR' };
     throw err;
   }
   return amlResult;

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -30,6 +30,7 @@ const { getActiveConfig } = require("../services/feeConfigService");
 const logger = require("../utils/logger");
 const { cancelEscrow } = require("../services/agentEscrow");
 const audit = require("../services/audit");
+const { amlRescreenForPayment } = require("./kycController");
 
 const KYC_THRESHOLD_USD = parseFloat(process.env.KYC_THRESHOLD_USD || "100");
 
@@ -390,6 +391,9 @@ async function send(req, res, next) {
       return res.status(400).json({ error: "Cannot send payment to your own wallet" });
     }
 
+    // AML re-screen for high-value payments — fail closed when screening is unavailable
+    await amlRescreenForPayment(req.user.userId, public_key, estimatedUSD);
+
     // Use a per-wallet distributed lock to prevent concurrent sends from
     // racing past the daily-limit check (issue #888).
     const lockKey = `daily_limit:${public_key}`;
@@ -595,6 +599,9 @@ async function sendBatch(req, res, next) {
 
     ({ public_key } = wallet);
     const { encrypted_secret_key } = wallet;
+
+    // AML re-screen for high-value batches — fail closed when screening is unavailable
+    await amlRescreenForPayment(req.user.userId, public_key, estimateUSDValue(totalAmount, asset));
 
     const overLimit = await dailyLimitExceeded(public_key, totalAmount);
     if (overLimit) {
@@ -862,6 +869,9 @@ async function sendPath(req, res, next) {
 
     if (recipient_address === public_key) return res.status(400).json({ error: "Cannot send payment to your own wallet" });
 
+    // AML re-screen for high-value payments — fail closed when screening is unavailable
+    await amlRescreenForPayment(req.user.userId, public_key, estimatedUSD);
+
     const fraudCheck = await checkFraud(public_key, source_amount, source_asset);
     if (fraudCheck.blocked) {
       await logFraudBlock(public_key, fraudCheck.reason, source_amount, source_asset);
@@ -969,6 +979,9 @@ async function sendStrictReceivePath(req, res, next) {
     const { encrypted_secret_key } = walletResult.rows[0];
 
     if (recipient_address === public_key) return res.status(400).json({ error: "Cannot send payment to your own wallet" });
+
+    // AML re-screen for high-value payments — fail closed when screening is unavailable
+    await amlRescreenForPayment(req.user.userId, public_key, estimatedUSD);
 
     const fraudCheck = await checkFraud(public_key, source_max_amount, source_asset);
     if (fraudCheck.blocked) {

--- a/backend/src/services/amlScreening.js
+++ b/backend/src/services/amlScreening.js
@@ -1,53 +1,271 @@
-const logger = require('../utils/logger');
+'use strict';
 
-const AML_PROVIDER = process.env.AML_PROVIDER;
-const AML_API_KEY = process.env.AML_API_KEY;
+const crypto = require('crypto');
+const logger = require('../utils/logger');
+const { amlScreeningsTotal, amlScreeningCoverageGauge } = require('../utils/metrics');
+
+const PROVIDER_BASE_URLS = {
+  complyadvantage: 'https://api.complyadvantage.com',
+  elliptic: 'https://aml-api.elliptic.co',
+};
+
+const FLAGGED_MATCH_STATUSES = ['true_positive', 'potential_match'];
+const HIGH_SEVERITIES = ['high', 'critical', 'severe'];
+
+// In-memory tallies backing the coverage gauge (resets on process restart, as with all gauges).
+let amlAttempts = 0;
+let amlScreened = 0;
 
 /**
- * Screen a wallet address against AML/sanctions lists.
- * Returns a structured result; placeholder logs a warning and returns not_screened.
- * Wire to a real provider (Elliptic, Chainalysis, ComplyAdvantage) by setting
- * AML_PROVIDER and AML_API_KEY environment variables.
+ * Read AML configuration from the environment at call time so tests and
+ * container restarts can change it without a module re-load.
  *
- * @param {string} walletAddress - Stellar public key to screen
- * @param {object} userDetails - { userId, email, ... }
- * @returns {{ screened: boolean, status: string, risk_level: string|null, provider: string|null, screened_at: string }}
+ * Env contract:
+ *  - AML_PROVIDER        'complyadvantage' | 'elliptic'
+ *  - AML_API_KEY         API key/token
+ *  - AML_API_SECRET      Elliptic secret (base64) used to HMAC-sign requests
+ *  - AML_API_URL         Optional base URL override (proxy / tests)
+ *  - AML_HIGH_RISK_SCORE Elliptic score >= this is treated as flagged (default 70)
+ *  - AML_API_TIMEOUT_MS  Provider request timeout in ms (default 5000)
  */
-async function amlScreen(walletAddress, userDetails) {
-  if (!AML_PROVIDER || !AML_API_KEY) {
-    logger.warn('WARN: AML screening not configured — using passthrough', { walletAddress });
-    return {
-      screened: false,
-      status: 'not_screened',
-      risk_level: null,
-      provider: null,
-      screened_at: new Date().toISOString(),
-    };
-  }
+function getConfig() {
+  const provider = (process.env.AML_PROVIDER || '').trim().toLowerCase();
+  return {
+    provider,
+    apiKey: process.env.AML_API_KEY || '',
+    apiSecret: process.env.AML_API_SECRET || '',
+    apiUrl: (process.env.AML_API_URL || '').trim(),
+    highRiskScore: parseInt(process.env.AML_HIGH_RISK_SCORE || '70', 10),
+    timeoutMs: parseInt(process.env.AML_API_TIMEOUT_MS || '5000', 10),
+  };
+}
 
-  // Production integration point — replace with real provider SDK/HTTP call
+/**
+ * @returns {boolean} true when a real provider is fully configured.
+ */
+function isAmlConfigured() {
+  const { provider, apiKey, apiSecret } = getConfig();
+  if (!apiKey) return false;
+  if (provider === 'complyadvantage') return true;
+  if (provider === 'elliptic') return !!apiSecret;
+  return false;
+}
+
+function notScreenedResult(provider = null) {
+  return {
+    screened: false,
+    status: 'not_screened',
+    risk_level: null,
+    provider,
+    reference_id: null,
+    screened_at: new Date().toISOString(),
+  };
+}
+
+function recordAmlMetric(result) {
+  amlAttempts += 1;
+  amlScreeningsTotal.inc({ status: result.status });
+  if (result.screened) amlScreened += 1;
+  amlScreeningCoverageGauge.set(amlAttempts > 0 ? amlScreened / amlAttempts : 0);
+}
+
+/**
+ * Internal — resets the in-memory coverage tallies. Used by tests so each case
+ * starts from a clean coverage ratio.
+ */
+function resetAmlMetricCounters() {
+  amlAttempts = 0;
+  amlScreened = 0;
+}
+
+/**
+ * POST a JSON body with a timeout. Throws on non-2xx or network/timeout errors.
+ */
+async function postJson(url, headers, body, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    // Example interface (adapt per provider):
-    // const result = await providerClient.screen({ address: walletAddress, ...userDetails });
-    // return { screened: true, status: result.status, risk_level: result.risk_level, provider: AML_PROVIDER, screened_at: new Date().toISOString() };
-    logger.warn('AML provider configured but integration not implemented — using passthrough', { provider: AML_PROVIDER });
-    return {
-      screened: false,
-      status: 'not_screened',
-      risk_level: null,
-      provider: AML_PROVIDER,
-      screened_at: new Date().toISOString(),
-    };
-  } catch (err) {
-    logger.error('AML screening error', { walletAddress, provider: AML_PROVIDER, error: err.message });
-    return {
-      screened: false,
-      status: 'not_screened',
-      risk_level: null,
-      provider: AML_PROVIDER,
-      screened_at: new Date().toISOString(),
-    };
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(
+        `AML provider returned HTTP ${res.status}${text ? `: ${text.slice(0, 300)}` : ''}`
+      );
+    }
+    return text ? JSON.parse(text) : {};
+  } finally {
+    clearTimeout(timer);
   }
 }
 
-module.exports = { amlScreen };
+function ellipticSignature(apiSecret, timestamp, httpPath, body) {
+  const key = Buffer.from(apiSecret, 'base64');
+  const requestText = `${timestamp}POST${httpPath.toLowerCase()}${body}`;
+  return crypto.createHmac('sha256', key).update(requestText).digest('base64');
+}
+
+/**
+ * ComplyAdvantage — Case Management Searches API.
+ * POST https://api.complyadvantage.com/searches with `Authorization: Token <key>`.
+ * Flagged when sanctions hits exist (match_status true_positive/potential_match or total_hits > 0).
+ */
+function parseComplyAdvantageResponse(payload) {
+  const data = (payload && payload.content && payload.content.data) || payload || {};
+  const totalHits = Number(data.total_hits || 0);
+  const flagged = totalHits > 0 || FLAGGED_MATCH_STATUSES.includes(data.match_status);
+  return {
+    status: flagged ? 'flagged' : 'clear',
+    risk_level: flagged ? data.risk_level || 'high' : data.risk_level || 'low',
+    reference_id: data.id != null ? String(data.id) : data.ref || null,
+  };
+}
+
+async function screenComplyAdvantage(walletAddress, userDetails, config) {
+  const baseUrl = config.apiUrl || PROVIDER_BASE_URLS.complyadvantage;
+  const searchTerm =
+    userDetails && userDetails.full_name && userDetails.full_name.trim()
+      ? userDetails.full_name.trim()
+      : walletAddress;
+  const payload = await postJson(
+    `${baseUrl}/searches`,
+    { Authorization: `Token ${config.apiKey}`, 'Content-Type': 'application/json' },
+    {
+      search_term: searchTerm,
+      client_ref:
+        userDetails && userDetails.userId ? `afripay-${userDetails.userId}` : walletAddress,
+      exact_match: true,
+      fuzziness: 0.0,
+      filters: { types: ['sanction'] },
+    },
+    config.timeoutMs
+  );
+  return parseComplyAdvantageResponse(payload);
+}
+
+/**
+ * Elliptic — Wallet Analyses API (synchronous endpoint).
+ * POST https://aml-api.elliptic.co/v2/wallet/synchronous with HMAC-signed headers.
+ * Flagged when risk_score >= AML_HIGH_RISK_SCORE or a high/critical/severe risk rule fires.
+ */
+function parseEllipticResponse(payload, config) {
+  const riskScore = Number(payload && payload.risk_score);
+  const riskRules = Array.isArray(payload && payload.risk_rules) ? payload.risk_rules : [];
+  const highSeverity = riskRules.some((rule) =>
+    HIGH_SEVERITIES.includes(String(rule && rule.severity).toLowerCase())
+  );
+  const flagged = (Number.isFinite(riskScore) && riskScore >= config.highRiskScore) || highSeverity;
+  return {
+    status: flagged ? 'flagged' : 'clear',
+    risk_level: flagged ? 'high' : 'low',
+    reference_id: payload && payload.id ? String(payload.id) : null,
+  };
+}
+
+async function screenElliptic(walletAddress, userDetails, config) {
+  const baseUrl = config.apiUrl || PROVIDER_BASE_URLS.elliptic;
+  const httpPath = '/v2/wallet/synchronous';
+  const timestamp = String(Date.now());
+  const body = {
+    subject: { asset: 'holistic', blockchain: 'holistic', type: 'address', hash: walletAddress },
+    type: 'wallet_exposure',
+    customer_reference:
+      userDetails && userDetails.userId ? `afripay-${userDetails.userId}` : walletAddress,
+  };
+  const payload = await postJson(
+    `${baseUrl}${httpPath}`,
+    {
+      'Content-Type': 'application/json',
+      'x-access-key': config.apiKey,
+      'x-access-timestamp': timestamp,
+      'x-access-sign': ellipticSignature(
+        config.apiSecret,
+        timestamp,
+        httpPath,
+        JSON.stringify(body)
+      ),
+    },
+    body,
+    config.timeoutMs
+  );
+  return parseEllipticResponse(payload, config);
+}
+
+/**
+ * Screen a wallet address against AML/sanctions lists.
+ *
+ * Result statuses:
+ *  - 'clear'        screened by a provider, no match
+ *  - 'flagged'      screened by a provider, sanctions/high-risk match — callers MUST block
+ *  - 'error'        provider configured but the call failed — callers must make a compliance decision
+ *  - 'not_screened' no provider configured — passthrough, callers must make a compliance decision
+ *
+ * @param {string} walletAddress - Stellar public key to screen
+ * @param {object} [userDetails] - { userId, full_name, ... } used for provider references
+ * @returns {Promise<{screened: boolean, status: string, risk_level: string|null, provider: string|null, reference_id: string|null, screened_at: string}>}
+ */
+async function amlScreen(walletAddress, userDetails = {}) {
+  if (!isAmlConfigured()) {
+    if (process.env.NODE_ENV !== 'production') {
+      logger.warn('AML screening not configured — returning not_screened passthrough', {
+        walletAddress,
+      });
+    }
+    const result = notScreenedResult();
+    recordAmlMetric(result);
+    return result;
+  }
+
+  if (typeof walletAddress !== 'string' || !walletAddress.trim()) {
+    logger.warn('AML screening skipped — missing wallet address');
+    const result = {
+      ...notScreenedResult(getConfig().provider),
+      status: 'error',
+      error: 'missing_wallet_address',
+    };
+    recordAmlMetric(result);
+    return result;
+  }
+
+  const config = getConfig();
+  try {
+    const outcome =
+      config.provider === 'elliptic'
+        ? await screenElliptic(walletAddress.trim(), userDetails, config)
+        : await screenComplyAdvantage(walletAddress.trim(), userDetails, config);
+
+    const result = {
+      screened: true,
+      status: outcome.status,
+      risk_level: outcome.risk_level,
+      provider: config.provider,
+      reference_id: outcome.reference_id || null,
+      screened_at: new Date().toISOString(),
+    };
+    recordAmlMetric(result);
+    return result;
+  } catch (err) {
+    logger.error('AML screening error', {
+      walletAddress,
+      provider: config.provider,
+      error: err.message,
+    });
+    const result = {
+      screened: false,
+      status: 'error',
+      risk_level: null,
+      provider: config.provider,
+      reference_id: null,
+      screened_at: new Date().toISOString(),
+      error: err.message,
+    };
+    recordAmlMetric(result);
+    return result;
+  }
+}
+
+module.exports = { amlScreen, isAmlConfigured, recordAmlMetric, resetAmlMetricCounters };

--- a/backend/src/utils/metrics.js
+++ b/backend/src/utils/metrics.js
@@ -69,6 +69,19 @@ const emailQueueDepth = new client.Gauge({
   registers: [registry],
 });
 
+const amlScreeningsTotal = new client.Counter({
+  name: 'afripay_aml_screenings_total',
+  help: 'Total AML screening decisions, labelled by outcome (clear, flagged, error, not_screened)',
+  labelNames: ['status'],
+  registers: [registry],
+});
+
+const amlScreeningCoverageGauge = new client.Gauge({
+  name: 'afripay_aml_screening_coverage_ratio',
+  help: 'Ratio of AML screening attempts performed by a real provider vs total attempts (provider screens + passthrough)',
+  registers: [registry],
+});
+
 module.exports = {
   registry,
   httpRequestDuration,
@@ -80,4 +93,6 @@ module.exports = {
   afripayHorizonDuration,
   activeUsers,
   emailQueueDepth,
+  amlScreeningsTotal,
+  amlScreeningCoverageGauge,
 };

--- a/backend/src/utils/validateEnv.js
+++ b/backend/src/utils/validateEnv.js
@@ -15,6 +15,10 @@ function isSet(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function isAmlConfigured() {
+  return isSet(process.env.AML_PROVIDER) && isSet(process.env.AML_API_KEY);
+}
+
 /**
  * Validates required configuration before the server listens.
  * Never logs secret values — only variable names.
@@ -52,6 +56,13 @@ function validateEnv() {
   if (!isSet(process.env.FRONTEND_URL)) {
     console.warn(
       '\x1b[33m[CONFIG WARNING] FRONTEND_URL is not set. CORS and email links may not work as expected.\x1b[0m'
+    );
+  }
+
+  if (process.env.NODE_ENV === 'production' && !isAmlConfigured()) {
+    console.warn(
+      '\x1b[33m[CONFIG WARNING] AML/sanctions screening is NOT configured (set AML_PROVIDER and AML_API_KEY). ' +
+      'KYC wallets will be flagged as not_screened and high-value payments (>= $1000 USD) will be BLOCKED.\x1b[0m'
     );
   }
 

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -168,6 +168,30 @@
           "legendFormat": "Email Queue Depth"
         }
       ]
+    },
+    {
+      "title": "AML Screening Coverage (%)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 40, "w": 12, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "afripay_aml_screening_coverage_ratio * 100",
+          "legendFormat": "screened %"
+        }
+      ]
+    },
+    {
+      "title": "AML Screening Decisions (by status)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 40, "w": 12, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(afripay_aml_screenings_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION


Closes #898

## What changed

### Real AML provider integrations (`backend/src/services/amlScreening.js`)
The service is no longer a passthrough. It now performs real sanctions/high-risk screening via one of two configurable providers (using Node's built-in `fetch`, no new dependencies):

- **ComplyAdvantage** — `POST /searches` with `Authorization: Token <key>`. Flagged when `total_hits > 0` or `match_status` is `true_positive`/`potential_match`.
- **Elliptic** — `POST /v2/wallet/synchronous` with HMAC-SHA256 request signing (`x-access-sign`) using the base64 `AML_API_SECRET`. Flagged when `risk_score >= AML_HIGH_RISK_SCORE` (default 70) or a high/critical/severe risk rule fires.

Result statuses are now explicit and actionable:
- `clear` — screened by a provider, no match
- `flagged` — screened, sanctions/high-risk match; callers **must block**
- `error` — provider configured but the call failed; callers must make a compliance decision
- `not_screened` — no provider configured; callers must make a compliance decision

Each call records a `reference_id`, `screened_at`, and per-call metrics. Timeouts use `AbortController` (`AML_API_TIMEOUT_MS`, default 5000).

### Fail-closed gate for high-value payments (`backend/src/controllers/kycController.js`)
`amlRescreenForPayment` now enforces a fail-closed compliance gate for payments at or above `AML_RESCREEN_THRESHOLD_USD` (1000):

- `clear` → payment proceeds
- `flagged` → **403** blocked
- `not_screened` → **403** `AML_SCREENING_UNAVAILABLE` (previously a silent passthrough — this was the core compliance gap)
- `error` → **503** `AML_SCREENING_ERROR`

Every blocked/flagged decision is written to the audit trail (`aml_payment_not_screened`, `aml_payment_screening_error`). `submitKYC` now makes explicit compliance decisions for non-cleared screenings (`aml_not_screened`, `aml_screening_error` audit events) instead of silently allowing them.

### AML gate wired into all payment entry points (`backend/src/controllers/paymentController.js`)
- `send`
- `sendBatch`
- `sendPath`
- `sendStrictReceivePath`

### Operational visibility
- `backend/src/utils/validateEnv.js` — `isAmlConfigured()` helper and a production startup warning when AML screening is not configured, making the fail-closed behavior discoverable.
- `backend/src/utils/metrics.js` — new `afripay_aml_screenings_total` counter (label: status) and `afripay_aml_screening_coverage_ratio` gauge.
- `monitoring/grafana-dashboard.json` — new **AML Screening Coverage (%)** and **AML Screening Decisions (by status)** panels.

### Configuration (`backend/.env.example`)
```
AML_PROVIDER=complyadvantage|elliptic
AML_API_KEY=...
AML_API_SECRET=...   # Elliptic only (base64)
AML_API_URL=...      # optional base URL override
AML_HIGH_RISK_SCORE=70
AML_API_TIMEOUT_MS=5000
```

## Testing
- **New:** `backend/src/__tests__/amlScreening.test.js` — 26 tests, all passing: provider detection, ComplyAdvantage flagged/clear/hit-count, Elliptic high-score/severe-rule/clear, HMAC signing, HTTP/network/parse error handling, metric recording, and the fail-closed gate (below-threshold `null`, 403 unavailable, 403 flagged, 503 error, clear pass).
- Verified no regressions: baseline pre-existing failures (`transaction-limits`, `kyc`, `payment.integration` and related suites) are byte-for-byte identical with and without this change.

## Note
- Local ESLint cannot run against this repo (installed ESLint v9 expects flat config; the repo uses `.eslintrc.js`). Files were syntax-checked with `node --check` and Prettier-checked; controller edits preserve the existing file style.
