### PR TITLE
fix: eliminate race conditions in payment channel transact() and clos…

### DIFF
--- a/backend/src/__tests__/paymentChannelConcurrency.test.js
+++ b/backend/src/__tests__/paymentChannelConcurrency.test.js
@@ -1,0 +1,471 @@
+/**
+ * Concurrency tests for payment channel service
+ *
+ * These tests verify that the SELECT ... FOR UPDATE locking in transact() and
+ * closeChannel() correctly serialises concurrent access to the same channel
+ * row.  Because there is no live database in the unit-test environment, we
+ * simulate DB-level serialisation by controlling when each mock client's
+ * SELECT … FOR UPDATE resolves: the second caller blocks until the first has
+ * committed, at which point the second caller receives the updated row.
+ *
+ * Key assertions:
+ *   transact()      – two simultaneous calls that together exceed sender_balance
+ *                     must result in exactly one success; the balance must never
+ *                     go negative.
+ *   closeChannel()  – two simultaneous close requests must result in exactly one
+ *                     on-chain settlement submission.
+ */
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before any require()
+// ---------------------------------------------------------------------------
+jest.mock('../db');
+jest.mock('../utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+// Mock the entire Stellar SDK to avoid needing real network objects
+jest.mock('@stellar/stellar-sdk', () => ({
+  Networks: { TESTNET: 'Test SDF Network ; September 2015', PUBLIC: 'Public Global Stellar Network ; September 2015' },
+  Keypair: { fromSecret: jest.fn(() => ({ publicKey: () => 'GSENDER', sign: jest.fn() })) },
+  Asset: { native: jest.fn(() => ({ code: 'XLM' })) },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn(() => ({ sign: jest.fn(), toXDR: jest.fn(() => 'mock-xdr') })),
+  })),
+  Transaction: jest.fn().mockImplementation(() => ({ sign: jest.fn() })),
+  Operation: {
+    payment: jest.fn(() => ({})),
+  },
+}));
+
+// Mock withFallback from the stellar service
+jest.mock('../services/stellar', () => ({
+  withFallback: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+const db = require('../db');
+const { withFallback } = require('../services/stellar');
+const { transact, closeChannel } = require('../services/paymentChannel');
+
+// Clear mock call history and one-time return-value queues between tests.
+// We use clearAllMocks (not resetAllMocks) so that implementations defined
+// in jest.mock() factories (e.g. TransactionBuilder, Keypair.fromSecret)
+// are preserved; only call history and mockOnce queues are wiped.
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Default stellar mock — returns a hash for submitTransaction
+// ---------------------------------------------------------------------------
+let submitCount = 0;
+function setupStellarMock() {
+  submitCount = 0;
+  withFallback.mockImplementation(async (fn) => {
+    const stellarMock = {
+      loadAccount: jest.fn(async () => ({})),
+      fetchBaseFee: jest.fn(async () => 100),
+      submitTransaction: jest.fn(async () => {
+        submitCount++;
+        return { hash: 'tx-hash-' + submitCount };
+      }),
+    };
+    return fn(stellarMock);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock pg client.  Each call to client.query() dispatches to the
+ * provided handler map keyed on the first SQL keyword of the statement.
+ */
+function makeMockClient(handlers) {
+  return {
+    query: jest.fn(async (sql, params) => {
+      const keyword = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (handlers[keyword]) {
+        return handlers[keyword](sql, params);
+      }
+      return { rows: [] };
+    }),
+    release: jest.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// transact() concurrency tests
+// ---------------------------------------------------------------------------
+describe('transact() — concurrency', () => {
+  const CHANNEL_ID = 'channel-uuid-1';
+  const USER_ID = 'user-uuid-1';
+  const SENDER_BALANCE = 10; // total available
+
+  /**
+   * Simulates two concurrent transact() calls.
+   *
+   * DB-level serialisation:
+   *   - caller-1's SELECT ... FOR UPDATE resolves immediately with current balance.
+   *   - caller-2's SELECT ... FOR UPDATE blocks until caller-1 commits, then
+   *     resolves with the post-commit balance.
+   */
+  async function runConcurrentTransact(amount1, amount2) {
+    let resolveBlocker;
+    const blockerPromise = new Promise(resolve => { resolveBlocker = resolve; });
+
+    let currentBalance = SENDER_BALANCE;
+
+    const client1 = makeMockClient({
+      SELECT: async () => ({
+        rows: [{
+          id: CHANNEL_ID, user_id: USER_ID, status: 'open',
+          sender_balance: String(currentBalance), recipient_balance: '0',
+        }],
+      }),
+      UPDATE: async (_sql, params) => {
+        currentBalance -= parseFloat(params[0]);
+        return {
+          rows: [{
+            id: CHANNEL_ID,
+            sender_balance: String(currentBalance),
+            recipient_balance: String(SENDER_BALANCE - currentBalance),
+          }],
+        };
+      },
+      COMMIT: async () => {
+        resolveBlocker();
+        return { rows: [] };
+      },
+    });
+
+    const client2 = makeMockClient({
+      SELECT: async () => {
+        await blockerPromise; // blocked until caller-1 commits
+        return {
+          rows: [{
+            id: CHANNEL_ID, user_id: USER_ID, status: 'open',
+            sender_balance: String(currentBalance),
+            recipient_balance: String(SENDER_BALANCE - currentBalance),
+          }],
+        };
+      },
+      UPDATE: async (_sql, params) => {
+        currentBalance -= parseFloat(params[0]);
+        return {
+          rows: [{
+            id: CHANNEL_ID,
+            sender_balance: String(currentBalance),
+            recipient_balance: String(SENDER_BALANCE - currentBalance),
+          }],
+        };
+      },
+    });
+
+    db.pool.connect
+      .mockResolvedValueOnce(client1)
+      .mockResolvedValueOnce(client2);
+
+    const [result1, result2] = await Promise.allSettled([
+      transact({ channelId: CHANNEL_ID, userId: USER_ID, amount: amount1 }),
+      transact({ channelId: CHANNEL_ID, userId: USER_ID, amount: amount2 }),
+    ]);
+
+    return { result1, result2, finalBalance: currentBalance };
+  }
+
+  test('both calls succeed when combined amount <= balance', async () => {
+    const { result1, result2, finalBalance } = await runConcurrentTransact(4, 4);
+    expect(result1.status).toBe('fulfilled');
+    expect(result2.status).toBe('fulfilled');
+    expect(finalBalance).toBe(2);
+    expect(finalBalance).toBeGreaterThanOrEqual(0);
+  });
+
+  test('second call fails when combined amount exceeds balance', async () => {
+    // caller-1 takes 7 → remaining 3; caller-2 requests 7 — must fail
+    const { result1, result2, finalBalance } = await runConcurrentTransact(7, 7);
+
+    expect(result1.status).toBe('fulfilled');
+    expect(result2.status).toBe('rejected');
+    expect(result2.reason.message).toMatch(/insufficient/i);
+    expect(finalBalance).toBe(3);
+    expect(finalBalance).toBeGreaterThanOrEqual(0);
+  });
+
+  test('balance never goes negative when both callers request the full balance', async () => {
+    const { finalBalance } = await runConcurrentTransact(SENDER_BALANCE, SENDER_BALANCE);
+    expect(finalBalance).toBeGreaterThanOrEqual(0);
+  });
+
+  test('second transact sees post-commit balance (serialisation confirmed)', async () => {
+    // caller-1 takes 6 (leaving 4); caller-2 requests 5 — must be rejected
+    const { result1, result2, finalBalance } = await runConcurrentTransact(6, 5);
+
+    expect(result1.status).toBe('fulfilled');
+    expect(result2.status).toBe('rejected');
+    expect(result2.reason.status).toBe(400);
+    expect(finalBalance).toBe(4);
+  });
+
+  test('transact() uses SELECT ... FOR UPDATE', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({
+        rows: [{ id: CHANNEL_ID, user_id: USER_ID, status: 'open', sender_balance: '10', recipient_balance: '0' }],
+      }),
+      UPDATE: async () => ({
+        rows: [{ id: CHANNEL_ID, sender_balance: '8', recipient_balance: '2' }],
+      }),
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    await transact({ channelId: CHANNEL_ID, userId: USER_ID, amount: 2 });
+
+    const selectCall = client.query.mock.calls.find(c =>
+      c[0].trim().toUpperCase().startsWith('SELECT')
+    );
+    expect(selectCall).toBeDefined();
+    expect(selectCall[0].toUpperCase()).toContain('FOR UPDATE');
+  });
+
+  test('transact() wraps work in BEGIN / COMMIT', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({
+        rows: [{ id: CHANNEL_ID, user_id: USER_ID, status: 'open', sender_balance: '10', recipient_balance: '0' }],
+      }),
+      UPDATE: async () => ({
+        rows: [{ id: CHANNEL_ID, sender_balance: '7', recipient_balance: '3' }],
+      }),
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    await transact({ channelId: CHANNEL_ID, userId: USER_ID, amount: 3 });
+
+    const keywords = client.query.mock.calls.map(c =>
+      c[0].trim().toUpperCase().split(/\s+/)[0]
+    );
+    expect(keywords).toContain('BEGIN');
+    expect(keywords).toContain('COMMIT');
+  });
+
+  test('transact() issues ROLLBACK and releases client on error', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({ rows: [] }), // channel not found
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    await expect(
+      transact({ channelId: CHANNEL_ID, userId: USER_ID, amount: 1 })
+    ).rejects.toThrow('Channel not found or not open');
+
+    const keywords = client.query.mock.calls.map(c =>
+      c[0].trim().toUpperCase().split(/\s+/)[0]
+    );
+    expect(keywords).toContain('BEGIN');
+    expect(keywords).toContain('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// closeChannel() concurrency tests
+// ---------------------------------------------------------------------------
+describe('closeChannel() — concurrency', () => {
+  const CHANNEL_ID = 'channel-uuid-2';
+  const USER_ID = 'user-uuid-2';
+
+  const CHANNEL_ROW = {
+    id: CHANNEL_ID,
+    user_id: USER_ID,
+    status: 'open',
+    sender_public_key: 'GSENDER',
+    recipient_public_key: 'GRECIPIENT',
+    asset: 'XLM',
+    recipient_balance: '5',
+    closing_tx_xdr: 'mock-closing-xdr',
+  };
+
+  // AES-256-CBC requires:
+  //   key  — 32 bytes  (ENCRYPTION_KEY is 32 ASCII chars)
+  //   IV   — 16 bytes  (32 hex chars)
+  //   ciphertext — must decrypt to valid UTF-8 but we mock Keypair.fromSecret
+  //                so the actual decrypted value does not matter; it just
+  //                needs to not throw during decryption.
+  //
+  // We generate a real AES-256-CBC ciphertext in beforeEach so that
+  // decryptPrivateKey() succeeds and execution reaches withFallback/stellar.
+  let ENCRYPTED_SECRET;
+
+  function buildEncryptedSecret(keyStr) {
+    const crypto = require('crypto');
+    const key = Buffer.from(keyStr, 'utf8').slice(0, 32);
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+    const plaintext = 'STEST_SECRET_KEY_PLACEHOLDER_XYZ'; // 32 chars, valid stellar secret shape
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
+  }
+
+  beforeEach(() => {
+    // 32 printable ASCII characters → valid AES-256 key
+    process.env.ENCRYPTION_KEY = 'aaaabbbbccccddddeeeeffffgggghhhh';
+    ENCRYPTED_SECRET = buildEncryptedSecret(process.env.ENCRYPTION_KEY);
+    setupStellarMock();
+  });
+
+  /**
+   * Simulates two concurrent closeChannel() calls.
+   *
+   * Caller-1 proceeds immediately and commits.  Caller-2 blocks on
+   * SELECT … FOR UPDATE until caller-1 commits, then receives an empty
+   * row set (simulating WHERE status='open' returning nothing after the
+   * channel has already been closed).
+   */
+  async function runConcurrentClose() {
+    let resolveBlocker;
+    const blockerPromise = new Promise(resolve => { resolveBlocker = resolve; });
+
+    // Reset the counter so each test starts clean
+    submitCount = 0;
+
+    // Intercept withFallback to count submitTransaction invocations
+    withFallback.mockImplementation(async (fn) => {
+      const stellarMock = {
+        loadAccount: jest.fn(async () => ({})),
+        fetchBaseFee: jest.fn(async () => 100),
+        submitTransaction: jest.fn(async () => {
+          submitCount++;
+          return { hash: 'tx-hash-' + submitCount };
+        }),
+      };
+      return fn(stellarMock);
+    });
+
+    const client1 = makeMockClient({
+      SELECT: async () => ({ rows: [CHANNEL_ROW] }),
+      UPDATE: async () => ({
+        rows: [{ ...CHANNEL_ROW, status: 'closed', settlement_tx_hash: 'tx-hash-1' }],
+      }),
+      COMMIT: async () => {
+        resolveBlocker();
+        return { rows: [] };
+      },
+    });
+
+    // Caller-2 blocks on SELECT until caller-1 commits, then sees no open channel
+    const client2 = makeMockClient({
+      SELECT: async () => {
+        await blockerPromise;
+        return { rows: [] }; // channel already closed
+      },
+    });
+
+    db.pool.connect
+      .mockResolvedValueOnce(client1)
+      .mockResolvedValueOnce(client2);
+
+    const [result1, result2] = await Promise.allSettled([
+      closeChannel({ channelId: CHANNEL_ID, userId: USER_ID, encryptedSecretKey: ENCRYPTED_SECRET }),
+      closeChannel({ channelId: CHANNEL_ID, userId: USER_ID, encryptedSecretKey: ENCRYPTED_SECRET }),
+    ]);
+
+    return { result1, result2 };
+  }
+
+  test('only one settlement transaction is submitted when two close requests race', async () => {
+    const { result1, result2 } = await runConcurrentClose();
+
+    expect(result1.status).toBe('fulfilled');
+    expect(result2.status).toBe('rejected');
+    expect(result2.reason.message).toMatch(/not found|already closed/i);
+    expect(submitCount).toBe(1);
+  });
+
+  test('first caller receives the closed channel, second receives a 404', async () => {
+    const { result1, result2 } = await runConcurrentClose();
+
+    expect(result1.status).toBe('fulfilled');
+    expect(result1.value.status).toBe('closed');
+
+    expect(result2.status).toBe('rejected');
+    expect(result2.reason.status).toBe(404);
+  });
+
+  test('closeChannel() uses SELECT ... FOR UPDATE', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({ rows: [] }), // not found — we just inspect the query
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    await expect(
+      closeChannel({ channelId: CHANNEL_ID, userId: USER_ID, encryptedSecretKey: ENCRYPTED_SECRET })
+    ).rejects.toThrow();
+
+    const selectCall = client.query.mock.calls.find(c =>
+      c[0].trim().toUpperCase().startsWith('SELECT')
+    );
+    expect(selectCall).toBeDefined();
+    expect(selectCall[0].toUpperCase()).toContain('FOR UPDATE');
+  });
+
+  test('closeChannel() wraps work in BEGIN / COMMIT', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({ rows: [CHANNEL_ROW] }),
+      UPDATE: async () => ({
+        rows: [{ ...CHANNEL_ROW, status: 'closed', settlement_tx_hash: 'tx-hash-1' }],
+      }),
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    await closeChannel({ channelId: CHANNEL_ID, userId: USER_ID, encryptedSecretKey: ENCRYPTED_SECRET });
+
+    const keywords = client.query.mock.calls.map(c =>
+      c[0].trim().toUpperCase().split(/\s+/)[0]
+    );
+    expect(keywords).toContain('BEGIN');
+    expect(keywords).toContain('COMMIT');
+  });
+
+  test('closeChannel() issues ROLLBACK and releases client on error', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({ rows: [] }), // channel not found
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    await expect(
+      closeChannel({ channelId: CHANNEL_ID, userId: USER_ID, encryptedSecretKey: ENCRYPTED_SECRET })
+    ).rejects.toThrow('Channel not found or already closed');
+
+    const keywords = client.query.mock.calls.map(c =>
+      c[0].trim().toUpperCase().split(/\s+/)[0]
+    );
+    expect(keywords).toContain('BEGIN');
+    expect(keywords).toContain('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('client is always released even when stellar submission throws', async () => {
+    const client = makeMockClient({
+      SELECT: async () => ({ rows: [CHANNEL_ROW] }),
+    });
+    db.pool.connect.mockResolvedValueOnce(client);
+
+    // Make every withFallback call throw
+    withFallback.mockRejectedValue(new Error('Horizon unavailable'));
+
+    await expect(
+      closeChannel({ channelId: CHANNEL_ID, userId: USER_ID, encryptedSecretKey: ENCRYPTED_SECRET })
+    ).rejects.toThrow('Horizon unavailable');
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/paymentChannel.js
+++ b/backend/src/services/paymentChannel.js
@@ -9,6 +9,15 @@
  *
  * Unilateral close: a time-locked "dispute" transaction lets either party
  * close after CHANNEL_TIMEOUT_SECONDS if the counterparty is unresponsive.
+ *
+ * Concurrency safety:
+ *   - transact()     acquires a row-level lock via SELECT ... FOR UPDATE inside
+ *     a serialisable transaction, so two simultaneous payments against the same
+ *     channel are serialised at the DB level.  The sender_balance >= 0 CHECK
+ *     constraint (migration 037) is an additional defence-in-depth layer.
+ *   - closeChannel() acquires the same row-level lock, so two simultaneous
+ *     close requests cannot both observe status = 'open' and proceed to
+ *     settlement; only the first one wins.
  */
 
 const StellarSdk = require('@stellar/stellar-sdk');
@@ -90,102 +99,146 @@ async function openChannel({ userId, senderPublicKey, encryptedSecretKey, recipi
 /**
  * Record an off-chain payment within the channel.
  * Updates balances in DB; no on-chain transaction.
+ *
+ * Uses SELECT ... FOR UPDATE inside a transaction to prevent concurrent
+ * requests from both reading the same stale sender_balance and independently
+ * passing the balance check — which would allow an over-spend.
  */
 async function transact({ channelId, userId, amount }) {
-  const { rows: [channel] } = await db.query(
-    `SELECT * FROM payment_channels WHERE id = $1 AND user_id = $2 AND status = 'open'`,
-    [channelId, userId]
-  );
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
 
-  if (!channel) {
-    const err = new Error('Channel not found or not open');
-    err.status = 404;
+    // Lock the row for the duration of this transaction.  Any concurrent
+    // transact() or closeChannel() call for the same channelId will block here
+    // until we COMMIT or ROLLBACK.
+    const { rows: [channel] } = await client.query(
+      `SELECT * FROM payment_channels
+       WHERE id = $1 AND user_id = $2 AND status = 'open'
+       FOR UPDATE`,
+      [channelId, userId]
+    );
+
+    if (!channel) {
+      const err = new Error('Channel not found or not open');
+      err.status = 404;
+      throw err;
+    }
+
+    const amt = parseFloat(amount);
+    if (amt <= 0 || amt > parseFloat(channel.sender_balance)) {
+      const err = new Error('Invalid amount or insufficient channel balance');
+      err.status = 400;
+      throw err;
+    }
+
+    const { rows } = await client.query(
+      `UPDATE payment_channels
+       SET sender_balance    = sender_balance - $1,
+           recipient_balance = recipient_balance + $1,
+           updated_at        = NOW()
+       WHERE id = $2
+       RETURNING *`,
+      [amt, channelId]
+    );
+
+    await client.query('COMMIT');
+    logger.info('Channel off-chain payment recorded', { channelId, amount: amt });
+    return rows[0];
+  } catch (err) {
+    await client.query('ROLLBACK');
     throw err;
+  } finally {
+    client.release();
   }
-
-  const amt = parseFloat(amount);
-  if (amt <= 0 || amt > parseFloat(channel.sender_balance)) {
-    const err = new Error('Invalid amount or insufficient channel balance');
-    err.status = 400;
-    throw err;
-  }
-
-  const { rows } = await db.query(
-    `UPDATE payment_channels
-     SET sender_balance = sender_balance - $1,
-         recipient_balance = recipient_balance + $1,
-         updated_at = NOW()
-     WHERE id = $2
-     RETURNING *`,
-    [amt, channelId]
-  );
-
-  logger.info('Channel off-chain payment recorded', { channelId, amount: amt });
-  return rows[0];
 }
 
 /**
  * Close the channel by submitting the pre-signed closing transaction on-chain.
  * If the channel has off-chain payments, builds a fresh settlement tx instead.
+ *
+ * Uses SELECT ... FOR UPDATE inside a transaction so that two simultaneous
+ * close requests cannot both read status = 'open' and both attempt to submit
+ * a settlement transaction on-chain.  Only the first caller proceeds; the
+ * second will find a row that is already being updated (blocked on the lock)
+ * and, once unblocked after COMMIT, will see status = 'closed' and return a
+ * 404 error rather than submitting a duplicate on-chain transaction.
  */
 async function closeChannel({ channelId, userId, encryptedSecretKey }) {
-  const { rows: [channel] } = await db.query(
-    `SELECT * FROM payment_channels WHERE id = $1 AND user_id = $2 AND status = 'open'`,
-    [channelId, userId]
-  );
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
 
-  if (!channel) {
-    const err = new Error('Channel not found or already closed');
-    err.status = 404;
+    // Acquire a row-level lock.  A concurrent closeChannel() for the same
+    // channelId will block here until the first caller commits or rolls back.
+    const { rows: [channel] } = await client.query(
+      `SELECT * FROM payment_channels
+       WHERE id = $1 AND user_id = $2 AND status = 'open'
+       FOR UPDATE`,
+      [channelId, userId]
+    );
+
+    if (!channel) {
+      const err = new Error('Channel not found or already closed');
+      err.status = 404;
+      throw err;
+    }
+
+    const recipientBalance = parseFloat(channel.recipient_balance);
+    let txHash;
+
+    if (recipientBalance > 0) {
+      // Settle: send recipient_balance to recipient, rest stays with sender.
+      // This on-chain call happens while we hold the row lock so that no other
+      // concurrent close request can reach this code path for the same channel.
+      const secretKey = decryptPrivateKey(encryptedSecretKey);
+      const senderKeypair = StellarSdk.Keypair.fromSecret(secretKey);
+      const senderAccount = await withFallback(s => s.loadAccount(channel.sender_public_key));
+      const baseFee = await withFallback(s => s.fetchBaseFee());
+
+      const assetObj = channel.asset === 'XLM'
+        ? StellarSdk.Asset.native()
+        : new StellarSdk.Asset(channel.asset, process.env[`${channel.asset}_ISSUER`]);
+
+      const settleTx = new StellarSdk.TransactionBuilder(senderAccount, {
+        fee: baseFee,
+        networkPassphrase,
+      })
+        .addOperation(StellarSdk.Operation.payment({
+          destination: channel.recipient_public_key,
+          asset: assetObj,
+          amount: String(recipientBalance),
+        }))
+        .setTimeout(30)
+        .build();
+
+      settleTx.sign(senderKeypair);
+      const result = await withFallback(s => s.submitTransaction(settleTx));
+      txHash = result.hash;
+    } else {
+      // No off-chain payments — submit the pre-signed unilateral closing tx.
+      const tx = new StellarSdk.Transaction(channel.closing_tx_xdr, networkPassphrase);
+      const result = await withFallback(s => s.submitTransaction(tx));
+      txHash = result.hash;
+    }
+
+    const { rows } = await client.query(
+      `UPDATE payment_channels
+       SET status = 'closed', settlement_tx_hash = $1, updated_at = NOW()
+       WHERE id = $2
+       RETURNING *`,
+      [txHash, channelId]
+    );
+
+    await client.query('COMMIT');
+    logger.info('Payment channel closed', { channelId, txHash });
+    return rows[0];
+  } catch (err) {
+    await client.query('ROLLBACK');
     throw err;
+  } finally {
+    client.release();
   }
-
-  const recipientBalance = parseFloat(channel.recipient_balance);
-  let txHash;
-
-  if (recipientBalance > 0) {
-    // Settle: send recipient_balance to recipient, rest stays with sender
-    const secretKey = decryptPrivateKey(encryptedSecretKey);
-    const senderKeypair = StellarSdk.Keypair.fromSecret(secretKey);
-    const senderAccount = await withFallback(s => s.loadAccount(channel.sender_public_key));
-    const baseFee = await withFallback(s => s.fetchBaseFee());
-
-    const assetObj = channel.asset === 'XLM'
-      ? StellarSdk.Asset.native()
-      : new StellarSdk.Asset(channel.asset, process.env[`${channel.asset}_ISSUER`]);
-
-    const settleTx = new StellarSdk.TransactionBuilder(senderAccount, {
-      fee: baseFee,
-      networkPassphrase,
-    })
-      .addOperation(StellarSdk.Operation.payment({
-        destination: channel.recipient_public_key,
-        asset: assetObj,
-        amount: String(recipientBalance),
-      }))
-      .setTimeout(30)
-      .build();
-
-    settleTx.sign(senderKeypair);
-    const result = await withFallback(s => s.submitTransaction(settleTx));
-    txHash = result.hash;
-  } else {
-    // No off-chain payments — submit the pre-signed unilateral closing tx
-    const tx = new StellarSdk.Transaction(channel.closing_tx_xdr, networkPassphrase);
-    const result = await withFallback(s => s.submitTransaction(tx));
-    txHash = result.hash;
-  }
-
-  const { rows } = await db.query(
-    `UPDATE payment_channels
-     SET status = 'closed', settlement_tx_hash = $1, updated_at = NOW()
-     WHERE id = $2
-     RETURNING *`,
-    [txHash, channelId]
-  );
-
-  logger.info('Payment channel closed', { channelId, txHash });
-  return rows[0];
 }
 
 module.exports = { openChannel, transact, closeChannel };

--- a/database/migrations/037_add_payment_channels_balance_check.js
+++ b/database/migrations/037_add_payment_channels_balance_check.js
@@ -1,0 +1,24 @@
+/**
+ * Migration: 037_add_payment_channels_balance_check
+ *
+ * Adds a CHECK constraint to the payment_channels table ensuring that
+ * sender_balance can never go below zero.  This is a defence-in-depth
+ * measure: the primary protection is the SELECT ... FOR UPDATE locking
+ * in paymentChannel.js, but this constraint guarantees that even a bug
+ * or a direct SQL UPDATE cannot create a negative balance.
+ */
+
+exports.up = (pgm) => {
+  pgm.addConstraint(
+    'payment_channels',
+    'payment_channels_sender_balance_non_negative',
+    'CHECK (sender_balance >= 0)'
+  );
+};
+
+exports.down = (pgm) => {
+  pgm.dropConstraint(
+    'payment_channels',
+    'payment_channels_sender_balance_non_negative'
+  );
+};


### PR DESCRIPTION
 fix: eliminate race conditions in payment channel transact() and closeChannel()
  
  Problem
  
  transact() and closeChannel() both had a read-check-write race condition
  (TOCTOU). Each function issued a plain SELECT to read sender_balance or check
  status = 'open', validated in application code, then issued a separate UPDATE —
  with no locking around the sequence.
  
  Two concurrent requests against the same channel could both read the same stale
  row, both pass the validation check, and both proceed:
  
  - transact(): two concurrent payments could together exceed sender_balance,
  driving it negative (over-spend / double-payment within the off-chain ledger)
  - closeChannel(): two concurrent close requests could both see status = 'open'
   and both submit competing on-chain settlement transactions before either
   marked the channel closed
  
  Changes
  
  backend/src/services/paymentChannel.js
  
  - Wrapped transact() in a PostgreSQL transaction using pool.connect() with
  SELECT ... FOR UPDATE on the payment_channels row before validating and
  updating balances. Concurrent callers block on the lock and the second sees the
  post-commit balance.
  - Wrapped closeChannel() in the same pattern. The second concurrent close
  request blocks on the lock and, once unblocked after the first caller commits,
  finds status = 'open' no longer matches and receives a 404 — preventing a
  duplicate on-chain settlement.
  - Both functions use BEGIN / COMMIT / ROLLBACK with client.release() in a
  finally block to guarantee the connection is always returned to the pool.
  
  database/migrations/037_add_payment_channels_balance_check.js
  
  - Adds CHECK (sender_balance >= 0) constraint on payment_channels as
  defence-in-depth. Even if application logic has a bug or a direct SQL update is
  issued, the database will reject any write that would make the balance
  negative.
  
  backend/src/__tests__/paymentChannelConcurrency.test.js
  
  - 13 new tests covering the fixed concurrency behaviour using mock DB clients
  that simulate serialised lock acquisition:
    - Two simultaneous transact() calls whose combined amount exceeds
  sender_balance → only one succeeds, balance never goes negative
    - Two simultaneous closeChannel() calls → only one on-chain settlement
  submitted, second receives 404
    - SELECT ... FOR UPDATE is present in both functions
    - BEGIN / COMMIT wrapping verified in both functions
    - ROLLBACK + client.release() verified on all error paths
  
  Testing
  
  PASS src/__tests__/paymentChannelConcurrency.test.js
    transact() — concurrency
      ✓ both calls succeed when combined amount <= balance
      ✓ second call fails when combined amount exceeds balance
      ✓ balance never goes negative when both callers request the full balance
      ✓ second transact sees post-commit balance (serialisation confirmed)
      ✓ transact() uses SELECT ... FOR UPDATE
      ✓ transact() wraps work in BEGIN / COMMIT
      ✓ transact() issues ROLLBACK and releases client on error
    closeChannel() — concurrency
      ✓ only one settlement transaction is submitted when two close requests race
      ✓ first caller receives the closed channel, second receives a 404
      ✓ closeChannel() uses SELECT ... FOR UPDATE
      ✓ closeChannel() wraps work in BEGIN / COMMIT
      ✓ closeChannel() issues ROLLBACK and releases client on error
      ✓ client is always released even when stellar submission throws
  
closes #897
