### PR TITLE
fix(security): prevent X-Forwarded-For spoofing bypass in geoRestriction middleware #900

### DIFF
--- a/backend/src/__tests__/geoRestriction.test.js
+++ b/backend/src/__tests__/geoRestriction.test.js
@@ -5,8 +5,10 @@
  * real MaxMind data.  We verify:
  *   - Allowed countries pass through to next().
  *   - Blocked countries receive HTTP 451 with the correct error body.
- *   - Unknown / unresolvable IPs pass through (fail-open).
- *   - Blocked attempts are logged via Winston.
+ *   - Unknown / unresolvable IPs fail closed (451) when no trusted proxy.
+ *   - Spoofed X-Forwarded-For headers are never trusted without `trust proxy`.
+ *   - X-Forwarded-For is honored only when Express `trust proxy` is enabled.
+ *   - Proxy misconfiguration / fail-closed paths are logged via Winston.
  */
 
 // Set env BEFORE any module loads so the middleware caches the correct list.
@@ -149,7 +151,7 @@ describe('geoRestriction middleware', () => {
     expect(res.statusCode).toBe(200);
   });
 
-  test('allows request when IP cannot be determined', () => {
+  test('fails closed when IP cannot be determined and no trusted proxy is configured', () => {
     geoip.lookup.mockReturnValue(null);
 
     const req = makeReq({ ip: undefined, headers: {} });
@@ -158,14 +160,42 @@ describe('geoRestriction middleware', () => {
 
     geoRestriction(req, res, next);
 
-    expect(next).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+    expect(res.body).toEqual({
+      error: 'Service unavailable in your jurisdiction',
+    });
   });
 
-  test('reads IP from x-forwarded-for when req.ip is missing', () => {
+  test('does NOT trust a spoofed x-forwarded-for header when trust proxy is unset', () => {
+    geoip.lookup.mockReturnValue(null);
+
+    const req = makeReq({
+      ip: undefined,
+      headers: { 'x-forwarded-for': '8.8.8.8, 10.0.0.1' },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    // X-Forwarded-For is attacker-controlled with no trusted proxy, so the
+    // spoofed IP must never be geolocated.
+    expect(geoip.lookup).not.toHaveBeenCalledWith('8.8.8.8');
+    expect(geoip.lookup).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+    expect(res.body).toEqual({
+      error: 'Service unavailable in your jurisdiction',
+    });
+  });
+
+  test('honors legitimate x-forwarded-for when trust proxy is configured', () => {
     geoip.lookup.mockReturnValue({ country: 'CU' });
 
     const req = makeReq({
       ip: undefined,
+      app: { get: (key) => (key === 'trust proxy' ? true : undefined) },
       headers: { 'x-forwarded-for': '9.8.7.6, 10.0.0.1' },
     });
     const res = makeRes();
@@ -173,10 +203,60 @@ describe('geoRestriction middleware', () => {
 
     geoRestriction(req, res, next);
 
-    // The middleware should use the first IP in x-forwarded-for
     expect(geoip.lookup).toHaveBeenCalledWith('9.8.7.6');
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(451);
+  });
+
+  test('honors req.ips chain when trust proxy is configured', () => {
+    geoip.lookup.mockReturnValue({ country: 'IR' });
+
+    const req = makeReq({
+      ip: undefined,
+      app: { get: (key) => (key === 'trust proxy' ? true : undefined) },
+      ips: ['5.6.7.8', '10.0.0.1'],
+      headers: {},
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(geoip.lookup).toHaveBeenCalledWith('5.6.7.8');
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(451);
+  });
+
+  test('logs a distinct warning when falling back to header-based IP resolution', () => {
+    geoip.lookup.mockReturnValue(null);
+
+    const req = makeReq({
+      ip: undefined,
+      app: { get: (key) => (key === 'trust proxy' ? true : undefined) },
+      headers: { 'x-forwarded-for': '9.8.7.6, 10.0.0.1' },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Geo-restriction: resolved client IP from X-Forwarded-For header - verify proxy configuration',
+      expect.objectContaining({ ip: '9.8.7.6' })
+    );
+  });
+
+  test('logs a warning when failing closed on an unresolvable IP', () => {
+    const req = makeReq({ ip: undefined, headers: {} });
+    const res = makeRes();
+    const next = jest.fn();
+
+    geoRestriction(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Geo-restriction: unable to determine client IP - request blocked (fail closed)',
+      expect.objectContaining({})
+    );
   });
 
   test('country code comparison is case-insensitive', () => {

--- a/backend/src/middleware/geoRestriction.js
+++ b/backend/src/middleware/geoRestriction.js
@@ -19,18 +19,62 @@ const blockedCountries = new Set(
     .filter(Boolean)
 );
 
+// Whether the X-Forwarded-For header may be trusted.
+// Express only honors X-Forwarded-For when `trust proxy` is explicitly
+// configured. Without it, the header is attacker-controlled and must never
+// be used for geo-location decisions.
+function isTrustProxyConfigured(req) {
+  return Boolean(req.app && req.app.get('trust proxy'));
+}
+
 module.exports = function geoRestriction(req, res, next) {
-  // Determine the client IP.
-  // When behind a reverse proxy with trust-proxy enabled, req.ip already
-  // contains the real client address. Fall back to x-forwarded-for header.
-  const forwarded = req.headers['x-forwarded-for'];
-  const ip =
-    req.ip ||
-    (typeof forwarded === 'string' ? forwarded.split(',')[0].trim() : undefined);
+  const blocked = () =>
+    res.status(451).json({ error: 'Service unavailable in your jurisdiction' });
+
+  // Determine the client IP. When `trust proxy` is configured Express has
+  // already resolved req.ip from X-Forwarded-For using the configured hop
+  // count, so req.ip is authoritative and no direct header access is needed.
+  let ip = req.ip;
+  let ipFromHeader = false;
+
+  if (!ip && isTrustProxyConfigured(req)) {
+    // Express could not resolve the address but the header is safe to parse
+    // because trust proxy is explicitly enabled. Prefer req.ips (the chain
+    // Express resolved) so the hop count is honored.
+    ip =
+      (Array.isArray(req.ips) && req.ips.length > 0 && req.ips[0]) ||
+      (typeof req.headers['x-forwarded-for'] === 'string'
+        ? req.headers['x-forwarded-for'].split(',')[0].trim()
+        : undefined);
+
+    if (ip) {
+      ipFromHeader = true;
+      logger.warn(
+        'Geo-restriction: resolved client IP from X-Forwarded-For header - verify proxy configuration',
+        {
+          requestId: req.requestId,
+          ip,
+          trustProxy: String(req.app.get('trust proxy')),
+          method: req.method,
+          path: req.originalUrl,
+        }
+      );
+    }
+  }
 
   if (!ip) {
-    // Cannot determine IP – let the request through (fail-open).
-    return next();
+    // Cannot reliably determine the client jurisdiction. Fail closed rather
+    // than trusting a client-supplied header.
+    logger.warn('Geo-restriction: unable to determine client IP - request blocked (fail closed)', {
+      requestId: req.requestId,
+      method: req.method,
+      path: req.originalUrl,
+      forwarded: typeof req.headers['x-forwarded-for'] === 'string'
+        ? req.headers['x-forwarded-for']
+        : undefined,
+    });
+
+    return blocked();
   }
 
   const geo = geoip.lookup(ip);
@@ -40,14 +84,13 @@ module.exports = function geoRestriction(req, res, next) {
     logger.warn('Blocked request from sanctioned country', {
       requestId: req.requestId,
       ip,
+      ipFromHeader,
       country,
       method: req.method,
       path: req.originalUrl,
     });
 
-    return res.status(451).json({
-      error: 'Service unavailable in your jurisdiction',
-    });
+    return blocked();
   }
 
   next();


### PR DESCRIPTION
## Overview

This PR closes the OFAC/UN sanctions geo-block bypass in the `geoRestriction` middleware. Previously, when `req.ip` was falsy the middleware fell back to the client-supplied `X-Forwarded-For` header without verifying Express `trust proxy` was configured, letting a user physically located in a blocked/sanctioned jurisdiction spoof a non-blocked-country IP (`X-Forwarded-For: 8.8.8.8`) and bypass the block entirely.

## Related Issue

Closes [#900](https://github.com/zeekman/Cross-Border-Payment-App-for-Africa/issues/900)

## Changes

### 🔒 Secure client IP resolution

-   **[MODIFY]** `backend/src/middleware/geoRestriction.js`
    -   `X-Forwarded-For` is only trusted when Express `trust proxy` is explicitly configured (`req.app.get('trust proxy')`), and the resolved address honors the configured proxy hop count via the `req.ips` chain.
    -   When `req.ip` cannot be reliably determined and no trusted proxy is configured, the middleware now **fails closed** (HTTP 451) instead of trusting a client-supplied header.
    -   Logs a distinct WARN when falling back to header-based IP resolution (with the `trustProxy` value) so operators can detect proxy misconfiguration.
    -   Audit log for sanctioned-country blocks now includes `ipFromHeader`.

### ✅ Tests

-   **[ADD]** `backend/src/__tests__/geoRestriction.test.js`
    -   Spoofed `X-Forwarded-For` from an untrusted source does not bypass the block when `trust proxy` is unset (geoip never queried with the spoofed IP).
    -   Legitimate `X-Forwarded-For` values are honored when `trust proxy` is correctly configured (both header parsing and the `req.ips` chain).
    -   Distinct warnings are asserted for header fallback and fail-closed paths.
    -   Prior fail-open (`next()`) behavior on unresolvable IPs replaced with fail-closed assertions.

## Verification Results

```
cd backend
npx jest src/__tests__/geoRestriction.test.js --runInBand
✅ 13/13 passed

Full backend suite: the only failing suites (stellar / ledger / memoRequired /
loyaltyMintJob integration) fail identically on untouched main — pre-existing
env/network issues, no regressions from this change.
```

Acceptance Criteria | Status
--- | ---
Only trust X-Forwarded-For when trust proxy is explicitly configured and the request came through a known proxy hop count | ✅ Header fallback gated on `req.app.get('trust proxy')`; proxy hop count honored via `req.ips`
When req.ip cannot be reliably determined and no trusted proxy is configured, fail closed (block or flag for manual review) | ✅ HTTP 451 block returned instead of fail-open `next()`
Test asserting a spoofed X-Forwarded-For header from an untrusted source does not bypass the block when trust proxy is unset | ✅ `does NOT trust a spoofed x-forwarded-for header when trust proxy is unset`
Test confirming legitimate X-Forwarded-For values are honored when trust proxy is correctly configured | ✅ `honors legitimate x-forwarded-for when trust proxy is configured` + `honors req.ips chain when trust proxy is configured`
Log a distinct warning when falling back to header-based IP resolution | ✅ `Geo-restriction: resolved client IP from X-Forwarded-For header - verify proxy configuration`